### PR TITLE
[rl] Add code contest script for both sync and async

### DIFF
--- a/hpc/skyrl_yaml/qwen3_8b_16x80GB_thinking_bs64_group8.yaml
+++ b/hpc/skyrl_yaml/qwen3_8b_16x80GB_thinking_bs64_group8.yaml
@@ -1,38 +1,29 @@
-# SkyRL Configuration: Qwen3 8B on 16x80GB GPUs (Binary Rewards, Async Training)
-# Optimized for 32k context agentic RL with ASYNCHRONOUS training
+# SkyRL Configuration: Qwen3 8B on 16x80GB GPUs (Interleaved Thinking)
+# Ablation: Enables interleaved thinking mode for Terminus-2 agent
 #
-# REWARD MODE: Binary (0/1) - original verifier reward without shaping
-# TRAINING MODE: Fully async - policy/ref/inference on dedicated GPU sets
+# AGENT: Terminus-2 with interleaved thinking enabled
+# Base config: qwen3_8b_16x80GB_binary.yaml
+#
+# INTERLEAVED THINKING:
+# - interleaved_thinking: true - includes reasoning content in chat history
+# - extra_body.chat_template_kwargs.enable_thinking: true - enables thinking in LLM
 #
 # Hardware: 16 GPUs with 80GB VRAM each (e.g., 2x8 H100/A100-80GB or 4x4)
 # Model: Qwen3 8B Base (~16GB bf16 weights)
-#
-# GPU ALLOCATION (colocate_all=false):
-#   - Policy model: 8 GPUs (2 nodes x 4 GPUs)
-#   - Reference model: 8 GPUs (2 nodes x 4 GPUs) - CPU offloaded, shares with policy
-#   - Inference engines: 8 GPUs (8 engines x TP=1)
-#
-# ASYNC TRAINING BENEFITS:
-#   - No waiting for slowest trajectory in batch
-#   - Continuous policy updates as trajectories complete
-#   - Better GPU utilization during generation
-#   - Reduced wall-clock time for same number of samples
 #
 # CONTEXT BUDGET (32k total model context):
 #   - max_generate_length: 8k tokens (agent responses)
 #   - vLLM enforces total context <= max_model_len (32k)
 #
-# Key Design Decisions:
-# - TP=1 for inference engines: 8 independent engines for maximum parallelism
-# - batched=false: Each async worker handles its own requests
-# - num_parallel_generation_workers=8: Matches inference engines
-# - n_samples_per_prompt=4: GRPO advantage estimation (unchanged from sync)
+# Note: Interleaved thinking may increase context usage due to reasoning tokens
+# being included in the chat history. Consider enabling summarization if
+# context limits become an issue.
 #
 # Usage:
 #   python -m hpc.launch \
 #       --job_type rl \
-#       --rl_config qwen3_8b_16x80GB_async_binary.yaml \
-#       --job_name qwen3_8b_agentic_async \
+#       --rl_config qwen3_8b_16x80GB_thinking.yaml \
+#       --job_name qwen3_8b_thinking \
 #       --train_data '["mlfoundations-dev/your-dataset"]' \
 #       --model_path Qwen/Qwen3-8B \
 #       --num_nodes 2
@@ -125,7 +116,7 @@ terminal_bench:
     # ==========================================================================
     # Orchestrator settings (QueueOrchestrator concurrency control)
     # ==========================================================================
-    n_concurrent_trials: 2048        # Number of parallel trial workers. num_parallel_generation_workers * n_samples_per_prompt
+    n_concurrent_trials: 256        # Number of parallel trial workers. train_batch_size * n_samples_per_prompt
 
     # ==========================================================================
     # Logging settings
@@ -163,10 +154,11 @@ trainer:
   epochs: 10
   update_epochs_per_batch: 1
 
-  # Batch sizes - async training requires train_batch_size == policy_mini_batch_size
-  # (no mini-batching in fully async mode)
+  # Batch sizes optimized for sync RL
+  # IMPORTANT: train_batch_size must be >= total GPUs (data parallel size)
+  # Override with --skyrl_override trainer.train_batch_size=N if needed
   train_batch_size: 64
-  policy_mini_batch_size: 64
+  policy_mini_batch_size: 64  # 1 gradient step per batch
   eval_batch_size: 32
 
   # Micro batch sizes - set to 1 for long context to avoid OOM
@@ -184,8 +176,6 @@ trainer:
   # Logging
   project_name: OpenThoughts-Agent
   log_level: INFO  # SkyRL logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-  # Commit to WandB after each step (for real-time monitoring in async training)
-  tracker_commit_each_step: true
 
   # Paths derived from experiments_dir/job_name if null
   run_name: null
@@ -202,52 +192,34 @@ trainer:
       max_grad_norm: 1.0
 
   # Reference model - CPU offload to save GPU memory
-  # With colocate_all=false, ref shares GPUs with policy but offloads weights
   ref:
     fsdp_config:
       cpu_offload: true
       reshard_after_forward: true
 
-  # ==========================================================================
-  # ASYNC TRAINING: Model placement (colocate_all=false)
-  # ==========================================================================
-  # Non-colocated placement for async RL:
-  # - Policy and ref get dedicated GPU sets (can overlap with CPU offload)
-  # - Inference engines run on separate GPUs
-  # - No memory swapping between rollout and training phases
+  # Model placement - derived from CLI args (--num_nodes, --gpus_per_node)
   placement:
-    colocate_all: false
-    policy_num_nodes: 2
-    ref_num_nodes: 2
-    policy_num_gpus_per_node: 4
-    ref_num_gpus_per_node: 4
-
-  # ==========================================================================
-  # ASYNC TRAINING: Fully async generation settings
-  # ==========================================================================
-  # Enable async RL training loop
-  fully_async:
-    # Number of parallel generation workers
-    # Constraint: mini_batch_size <= num_parallel_generation_workers <= mini_batch_size * (max_staleness_steps + 1)
-    # With mini_batch_size=16 and max_staleness_steps=4: 16 <= workers <= 80
-    max_staleness_steps: 4
-    num_parallel_generation_workers: 256
+    colocate_all: true
+    # Derived from CLI --num_nodes
+    policy_num_nodes: null
+    ref_num_nodes: null
+    # Derived from CLI --gpus_per_node (cluster-specific: 4 for ZIH, 8 for TACC H100s)
+    policy_num_gpus_per_node: null
+    ref_num_gpus_per_node: null
 
 # Generator (vLLM inference) configuration
 generator:
   backend: vllm
   model_dtype: bfloat16
 
-  # ==========================================================================
-  # ASYNC TRAINING: Inference engine configuration
-  # ==========================================================================
-  # TP=1 for maximum parallelism (8 independent engines)
-  # Each engine has full 80GB for 32k context with single sequences
-  inference_engine_tensor_parallel_size: 1
-  # 8 engines = 8 GPUs dedicated to inference
-  num_inference_engines: 8
+  # Tensor parallelism = 2 for 32k context with 8B model
+  # This gives us 8 engines (16 GPUs / TP=2)
+  # Each engine pair has 160GB effective memory for KV cache
+  inference_engine_tensor_parallel_size: 2
+  # Computed automatically: (num_nodes * gpus_per_node) / tensor_parallel_size
+  num_inference_engines: null
 
-  # GRPO samples per prompt - 4 is typical for advantage estimation
+  # GRPO typically uses 4-8 samples per prompt for advantage estimation
   n_samples_per_prompt: 8
   eval_n_samples_per_prompt: 4
 
@@ -255,18 +227,18 @@ generator:
   gpu_memory_utilization: 0.90
 
   # Sequence limits for 32k context (24k prompt + 8k gen)
-  # With TP=1, each engine handles fewer concurrent sequences
-  max_num_seqs: 32
+  # max_num_seqs: concurrent sequences per engine
+  # Lower value = more memory per sequence for long contexts
+  max_num_seqs: 64
   # max_num_batched_tokens: tokens processed per batch
+  # Should accommodate at least one full sequence (32k) with some headroom
   max_num_batched_tokens: 32768
 
   # Memory optimization for long contexts
   enable_prefix_caching: true
   enable_chunked_prefill: true
 
-  # ==========================================================================
-  # ASYNC TRAINING: Engine settings
-  # ==========================================================================
+  # Engine settings
   run_engines_locally: true
   weight_sync_backend: nccl
   async_engine: true

--- a/hpc/skyrl_yaml/qwen3_8b_16x80GB_thinking_bs64_group8_async.yaml
+++ b/hpc/skyrl_yaml/qwen3_8b_16x80GB_thinking_bs64_group8_async.yaml
@@ -1,29 +1,38 @@
-# SkyRL Configuration: Qwen3 8B on 16x80GB GPUs (Interleaved Thinking)
-# Ablation: Enables interleaved thinking mode for Terminus-2 agent
+# SkyRL Configuration: Qwen3 8B on 16x80GB GPUs (Binary Rewards, Async Training)
+# Optimized for 32k context agentic RL with ASYNCHRONOUS training
 #
-# AGENT: Terminus-2 with interleaved thinking enabled
-# Base config: qwen3_8b_16x80GB_binary.yaml
-#
-# INTERLEAVED THINKING:
-# - interleaved_thinking: true - includes reasoning content in chat history
-# - extra_body.chat_template_kwargs.enable_thinking: true - enables thinking in LLM
+# REWARD MODE: Binary (0/1) - original verifier reward without shaping
+# TRAINING MODE: Fully async - policy/ref/inference on dedicated GPU sets
 #
 # Hardware: 16 GPUs with 80GB VRAM each (e.g., 2x8 H100/A100-80GB or 4x4)
 # Model: Qwen3 8B Base (~16GB bf16 weights)
+#
+# GPU ALLOCATION (colocate_all=false):
+#   - Policy model: 8 GPUs (2 nodes x 4 GPUs)
+#   - Reference model: 8 GPUs (2 nodes x 4 GPUs) - CPU offloaded, shares with policy
+#   - Inference engines: 8 GPUs (8 engines x TP=1)
+#
+# ASYNC TRAINING BENEFITS:
+#   - No waiting for slowest trajectory in batch
+#   - Continuous policy updates as trajectories complete
+#   - Better GPU utilization during generation
+#   - Reduced wall-clock time for same number of samples
 #
 # CONTEXT BUDGET (32k total model context):
 #   - max_generate_length: 8k tokens (agent responses)
 #   - vLLM enforces total context <= max_model_len (32k)
 #
-# Note: Interleaved thinking may increase context usage due to reasoning tokens
-# being included in the chat history. Consider enabling summarization if
-# context limits become an issue.
+# Key Design Decisions:
+# - TP=1 for inference engines: 8 independent engines for maximum parallelism
+# - batched=false: Each async worker handles its own requests
+# - num_parallel_generation_workers=8: Matches inference engines
+# - n_samples_per_prompt=4: GRPO advantage estimation (unchanged from sync)
 #
 # Usage:
 #   python -m hpc.launch \
 #       --job_type rl \
-#       --rl_config qwen3_8b_16x80GB_thinking.yaml \
-#       --job_name qwen3_8b_thinking \
+#       --rl_config qwen3_8b_16x80GB_async_binary.yaml \
+#       --job_name qwen3_8b_agentic_async \
 #       --train_data '["mlfoundations-dev/your-dataset"]' \
 #       --model_path Qwen/Qwen3-8B \
 #       --num_nodes 2
@@ -116,7 +125,7 @@ terminal_bench:
     # ==========================================================================
     # Orchestrator settings (QueueOrchestrator concurrency control)
     # ==========================================================================
-    n_concurrent_trials: 512        # Number of parallel trial workers. train_batch_size * n_samples_per_prompt
+    n_concurrent_trials: 256        # Number of parallel trial workers. num_parallel_generation_workers * n_samples_per_prompt
 
     # ==========================================================================
     # Logging settings
@@ -154,11 +163,10 @@ trainer:
   epochs: 10
   update_epochs_per_batch: 1
 
-  # Batch sizes optimized for sync RL
-  # IMPORTANT: train_batch_size must be >= total GPUs (data parallel size)
-  # Override with --skyrl_override trainer.train_batch_size=N if needed
+  # Batch sizes - async training requires train_batch_size == policy_mini_batch_size
+  # (no mini-batching in fully async mode)
   train_batch_size: 64
-  policy_mini_batch_size: 64  # 1 gradient step per batch
+  policy_mini_batch_size: 64
   eval_batch_size: 32
 
   # Micro batch sizes - set to 1 for long context to avoid OOM
@@ -176,6 +184,8 @@ trainer:
   # Logging
   project_name: OpenThoughts-Agent
   log_level: INFO  # SkyRL logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+  # Commit to WandB after each step (for real-time monitoring in async training)
+  tracker_commit_each_step: true
 
   # Paths derived from experiments_dir/job_name if null
   run_name: null
@@ -192,34 +202,52 @@ trainer:
       max_grad_norm: 1.0
 
   # Reference model - CPU offload to save GPU memory
+  # With colocate_all=false, ref shares GPUs with policy but offloads weights
   ref:
     fsdp_config:
       cpu_offload: true
       reshard_after_forward: true
 
-  # Model placement - derived from CLI args (--num_nodes, --gpus_per_node)
+  # ==========================================================================
+  # ASYNC TRAINING: Model placement (colocate_all=false)
+  # ==========================================================================
+  # Non-colocated placement for async RL:
+  # - Policy and ref get dedicated GPU sets (can overlap with CPU offload)
+  # - Inference engines run on separate GPUs
+  # - No memory swapping between rollout and training phases
   placement:
-    colocate_all: true
-    # Derived from CLI --num_nodes
-    policy_num_nodes: null
-    ref_num_nodes: null
-    # Derived from CLI --gpus_per_node (cluster-specific: 4 for ZIH, 8 for TACC H100s)
-    policy_num_gpus_per_node: null
-    ref_num_gpus_per_node: null
+    colocate_all: false
+    policy_num_nodes: 2
+    ref_num_nodes: 2
+    policy_num_gpus_per_node: 4
+    ref_num_gpus_per_node: 4
+
+  # ==========================================================================
+  # ASYNC TRAINING: Fully async generation settings
+  # ==========================================================================
+  # Enable async RL training loop
+  fully_async:
+    # Number of parallel generation workers
+    # Constraint: mini_batch_size <= num_parallel_generation_workers <= mini_batch_size * (max_staleness_steps + 1)
+    # With mini_batch_size=16 and max_staleness_steps=4: 16 <= workers <= 80
+    max_staleness_steps: 4
+    num_parallel_generation_workers: 128
 
 # Generator (vLLM inference) configuration
 generator:
   backend: vllm
   model_dtype: bfloat16
 
-  # Tensor parallelism = 2 for 32k context with 8B model
-  # This gives us 8 engines (16 GPUs / TP=2)
-  # Each engine pair has 160GB effective memory for KV cache
-  inference_engine_tensor_parallel_size: 2
-  # Computed automatically: (num_nodes * gpus_per_node) / tensor_parallel_size
-  num_inference_engines: null
+  # ==========================================================================
+  # ASYNC TRAINING: Inference engine configuration
+  # ==========================================================================
+  # TP=1 for maximum parallelism (8 independent engines)
+  # Each engine has full 80GB for 32k context with single sequences
+  inference_engine_tensor_parallel_size: 1
+  # 8 engines = 8 GPUs dedicated to inference
+  num_inference_engines: 8
 
-  # GRPO typically uses 4-8 samples per prompt for advantage estimation
+  # GRPO samples per prompt - 4 is typical for advantage estimation
   n_samples_per_prompt: 8
   eval_n_samples_per_prompt: 4
 
@@ -227,18 +255,18 @@ generator:
   gpu_memory_utilization: 0.90
 
   # Sequence limits for 32k context (24k prompt + 8k gen)
-  # max_num_seqs: concurrent sequences per engine
-  # Lower value = more memory per sequence for long contexts
-  max_num_seqs: 64
+  # With TP=1, each engine handles fewer concurrent sequences
+  max_num_seqs: 32
   # max_num_batched_tokens: tokens processed per batch
-  # Should accommodate at least one full sequence (32k) with some headroom
   max_num_batched_tokens: 32768
 
   # Memory optimization for long contexts
   enable_prefix_caching: true
   enable_chunked_prefill: true
 
-  # Engine settings
+  # ==========================================================================
+  # ASYNC TRAINING: Engine settings
+  # ==========================================================================
   run_engines_locally: true
   weight_sync_backend: nccl
   async_engine: true


### PR DESCRIPTION
Sync script, changes compared to `hpc/skyrl_yaml/qwen3_8b_16x80GB_codeContest_thinking.yaml`:
- `n_concurrent_trials`: 16 -> 512
- `train_batch_size` and `policy_mini_batch_size` set to 64
- `lr`: 5.0e-7 -> 1e-6
- `n_samples_per_prompt`: 4 -> 8
- `batched`: true -> false (does not matter really)
- Removed `append_eos_token_after_stop_str_in_multi_turn` and `max_turns` (since they are only used in skyrl-gym-generator)

Async script, changes compared to `hpc/skyrl_yaml/qwen3_8b_16x80GB_thinking_async.yaml`:
- `n_concurrent_trials`: 16 -> 2048
- `train_batch_size` and `policy_mini_batch_size` set to 64
- `lr`: 5.0e-7 -> 1e-6
- `n_samples_per_prompt`: 4 -> 8
- `num_parallel_generation_workers`: 16 -> 256
- Specifically specified `max_staleness_steps: 4` (which is the default value)
- Removed `append_eos_token_after_stop_str_in_multi_turn` and `max_turns` (since they are only used in skyrl-gym-generator)