### PR TITLE
eval: cluster-diagnostic listener stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,8 @@ train/hpc/dotenv/secret.env
 # Claude
 CLAUDE.md
 development_progress.md
+
+# Eval listener — operator-local state (templates ship as .example / EXAMPLE.txt)
+eval/.local_notes/
+hpc/dotenv/jupiter_eval.env
+hpc/dotenv/jupiter_eval_data_org.env

--- a/database/unified_db/utils.py
+++ b/database/unified_db/utils.py
@@ -1953,10 +1953,27 @@ def get_sandbox_job_by_id(job_id: str) -> Optional[Dict[str, Any]]:
 
 
 def get_sandbox_job_by_name(job_name: str) -> Optional[Dict[str, Any]]:
-    """Retrieve a sandbox job from the database by name."""
+    """Retrieve a sandbox job from the database by name.
+
+    When v6 resume reuses a run_tag, multiple rows may share the same job_name
+    (the original Started/Finished row plus the new Pending row created by the
+    resume listener). Without explicit ordering, Postgres returns rows in
+    physical-insertion order, which means callers like
+    update_job_status_to_started() may see the stale Started row first and
+    short-circuit "already_started", leaving the actual Pending row never
+    flipped to Started. Order by submitted_at desc to always return the most
+    recent row.
+    """
     try:
         client = get_supabase_client()
-        response = client.table('sandbox_jobs').select('*').eq('job_name', job_name).execute()
+        response = (
+            client.table('sandbox_jobs')
+            .select('*')
+            .eq('job_name', job_name)
+            .order('submitted_at', desc=True)
+            .limit(1)
+            .execute()
+        )
 
         if not response.data:
             return None

--- a/eval/EVAL_GUIDE.md
+++ b/eval/EVAL_GUIDE.md
@@ -13,7 +13,8 @@ catalog in §7.
 5. [Yaml flip-restore workflow (Cat 4)](#5-yaml-flip-restore-workflow-cat-4)
 6. [Monitoring + result extraction](#6-monitoring--result-extraction)
 7. [Failure modes catalog](#7-failure-modes-catalog)
-8. [Recovery scripts](#8-recovery-scripts)
+8. [Resume after walltime](#8-resume-after-walltime)
+9. [Recovery scripts](#9-recovery-scripts)
 
 ---
 
@@ -441,7 +442,7 @@ mitigation.
    checksum does not match`. *Delete* the cache, refire.
 4. **24h SLURM wall before upload** — long jobs with many
    `AgentTimeoutError` trials burn walltime before Harbor's upload
-   step. *Use* `upload_overlong_jobs.py` (see §8).
+   step. *Use* `upload_overlong_jobs.py` (see §9).
 5. **Bearer token invalid / Daytona load-shedding** — sustained sandbox
    creation > ~10/s triggers fake 401s. *Drop* concurrent fires;
    stagger with `--stagger-delay 2 --chain-batch-size 2`. The
@@ -531,29 +532,171 @@ mitigation.
 
 ---
 
-## 8. Recovery scripts
+## 8. Resume after walltime
+
+When a SLURM job hits its wallclock cap before harbor finishes the dataset,
+the run dir is left at partial coverage with `finished_at=None`. Most
+clusters can recover the missing trials without re-running the whole job
+through the **resume tooling**:
+
+- `eval/check_resume_needed.py` — inspector. Reads disk + squeue, classifies
+  every run dir, prints a status table.
+- `eval/resume_chunked.py` — orchestrator. Fires N-at-a-time resume listener
+  invocations from a priority file.
+
+Both reuse internals from `eval/unified_eval_listener.py` so classification
+and infra-error definitions never drift.
+
+> **Read the bug catalogue first.** Out-of-the-box `harbor jobs resume`
+> re-runs the entire dataset due to a per-trial config mismatch (G12), and
+> can leave the DB row stuck at Pending (G13). Both fixes are committed in
+> this repo. The full cross-cluster catalogue + verification checklist
+> lives at [`eval/docs/RESUME_HANDOFF.md`](docs/RESUME_HANDOFF.md). Apply
+> the harbor-fix patches from `eval/envs/README.md` before relying on
+> resume — without them you'll waste compute or hit 9-10h tail retry loops.
+
+### Inspect first
+
+```bash
+python eval/check_resume_needed.py \
+  --jobs-dir $EVAL_JOBS_DIR \
+  --needs-resume-only
+```
+
+The output table classifies every run dir:
+
+| Status | Meaning | Resume? |
+|---|---|---|
+| `INCOMPLETE` | `n_completed < n_total`, `finished_at=None` | Yes — standard walltime case |
+| `DONE_WITH_ERRORS` | All trials done, infra errors > threshold | Yes |
+| `PARTIAL` | `n_completed < n_total`, `finished_at` set, infra > threshold | Yes |
+| `EARLY_KILL` | No `result.json`, `n_total=0` | Yes |
+| `DONE` | All trials done, infra ≤ threshold | No (by default — see override) |
+| `IN_FLIGHT` | Currently in squeue, or active map | No (wait) |
+| `AT_RESUME_LIMIT` | `n_fires ≥ --max-total-fires` | No — hand to upload (§9) |
+| `REJECTED` | `.no-resume` marker present | No (hidden by default) |
+
+Stuck-at-full runs — full coverage on disk but no `finished_at`, classify as
+`DONE` and get hidden by default. To resume them anyway, pass
+`--resume-error-threshold -1` to the orchestrator. This promotes
+`infra_errors=0` dirs from `DONE` to `DONE_WITH_ERRORS` so they become
+eligible.
+
+### Fire the resume
+
+```bash
+# Build a one-per-line priority file:
+cat > /tmp/resume.txt <<EOF
+<org>/<model_A>
+<org>/<model_B>
+EOF
+
+python eval/resume_chunked.py \
+  --priority-file /tmp/resume.txt \
+  --preset tb2 --org eval \
+  --jobs-dir $EVAL_JOBS_DIR \
+  --tag-prefix r_$(date -u +%H%M%S) \
+  --tp-size 2 --dp-size 2 --timeout-multiplier 16.0 \
+  --conda-env otagent-fix \
+  --chunk-size 6 --sleep-between 0
+# Add --resume-error-threshold -1 for stuck-at-full DONE dirs.
+```
+
+One listener invocation = one sizing config (one preset, one TP/DP combo,
+one conda env). Mixed sizes / presets → fire multiple invocations in
+parallel, one per (preset × size) combo.
+
+### Pre-walltime cancel
+
+Daytona sandboxes run remotely. When SLURM SIGTERM hits at walltime, harbor
+on the compute node dies but sandboxes keep writing back to the run dir on
+shared FS for 30-60 minutes. Observed: 267-task dir went 267 → 352 trial
+dirs after walltime; `n_completed` overshot `n_total`; the inspector
+silently skips dirs with `n_completed > n_total`.
+
+**Mitigation**: cancel before walltime hits.
+
+```bash
+# Cancel jobs at ≤15 min TIME_LEFT (~11h45m+ elapsed on a 12h cap):
+squeue -u $USER --format='%.10i %.10M %.10L' --noheader \
+  | awk '$3 ~ /^0:[0-3][0-9]:/ { print $1 }' | xargs -r scancel
+```
+
+Then wait ~60s and run the inspector. After a *walltime-killed* dir, wait
+~60min instead for zombies to settle.
+
+### Verify each resume
+
+For every new JID, confirm:
+
+```bash
+# RUNNING within 30s
+squeue -j <new_jid> --format='%.10i %.10T'
+
+# G12 check — per-trial sed patch ran
+grep "Patching api_base port in [0-9]+ per-trial" eval/logs/<log>_<new_jid>.out
+
+# G12 check — zero "skipping" warnings
+grep -c "not found in generated configs; skipping" eval/logs/<log>_<new_jid>.out
+# expect: 0
+
+# Harbor scheduled only the in-flight trials, not the whole dataset
+grep -c "^Starting trial" eval/logs/<log>_<new_jid>.out
+# expect: matches in_flight count from inspector pre-resume
+
+# G13 check — DB row flipped to Started
+python -c "from database.unified_db.utils import get_sandbox_job_by_name; \
+  print(get_sandbox_job_by_name('<run_tag>')['job_status'])"
+# expect: "Started"
+```
+
+If any check fails, see [`eval/docs/RESUME_HANDOFF.md`](docs/RESUME_HANDOFF.md)
+§Bug G12 / §Bug G13 for the root cause and the corresponding source patches.
+
+### Fire-cap
+
+Default `--max-total-fires=2` (one original + one resume). Beyond that the
+inspector marks the dir `AT_RESUME_LIMIT` — upload it as-is via §9 rather
+than firing again. Daytona auth tokens have a 24h validity window in most
+org configs, so a third fire usually starts failing in the auth-degradation
+window anyway.
+
+---
+
+## 9. Recovery scripts
+
+When resume isn't applicable (auto-upload failed, hit fire cap, or the run
+just needs to be pushed as-is), use one of the upload helpers.
 
 ### When to use which
 
 ```
                     +----------------------------------+
-                    | Did the SLURM job hit TIMEOUT    |
-                    | (24h walltime) before upload?    |
+                    | Has the run dir been resumed     |
+                    | to satisfactory coverage         |
+                    | (or is it AT_RESUME_LIMIT)?      |
                     +----------------+-----------------+
                                      |
                           yes        |       no
-                  +------------------+------------------+
-                  |                                     |
-         upload_overlong_jobs.py            Did Harbor's auto-upload
-         (scans jobs/, identifies            fail (e.g. numeric model_id,
-          overlong runs, batch                missing result.json)?
-          uploads partial results)                       |
-                                              yes       |       no
-                                       +----------------+--------+
-                                       |                         |
-                              manual_db_eval_push.py     no action — auto-upload
-                              --job-dir jobs/<run_tag>   succeeded; verify in
-                              --forced-update --verbose  Supabase
+                  +------------------+----------------+
+                  |                                   |
+        Did SLURM hit TIMEOUT                  Run §8 resume first
+        (24h walltime) before upload?
+                  |
+       yes        |       no
+       +----------+---------+
+       |                    |
+upload_overlong       Did Harbor's auto-upload
+_jobs.py              fail (numeric model_id,
+                      missing result.json)?
+                             |
+                  yes        |       no
+                  +----------+---------+
+                  |                    |
+        manual_db_eval_push.py    no action — verify
+        (single job)              in Supabase
+        batch_upload_eval.py
+        (multiple jobs)
 ```
 
 ### `manual_db_eval_push.py` — single-job recovery
@@ -595,12 +738,48 @@ Walks `$EVAL_JOBS_DIR`, picks runs whose latest `trial.log` mtime is
 older than the threshold (= TIMEOUT-killed), pushes their partial
 results to Supabase + HuggingFace as `status=overlong`.
 
+### `batch_upload_eval.py` — multi-job upload
+
+Cluster-agnostic batch helper for pushing many run dirs to Supabase + HF
+in one invocation. Reads `HF_TOKEN` / `SUPABASE_*` from the environment;
+no hardcoded paths — `--jobs-dir` defaults to `./jobs` and accepts any
+location. Useful when an in-flight batch of evals all complete and you
+want a single upload pass instead of N `manual_db_eval_push` calls.
+
+```bash
+source ~/.local/eval.env
+
+# Upload explicit run dirs
+python scripts/database/batch_upload_eval.py \
+  $EVAL_JOBS_DIR/<run_tag_A> \
+  $EVAL_JOBS_DIR/<run_tag_B>
+
+# Auto-detect overlong (TIMEOUT-killed) runs under a jobs dir
+python scripts/database/batch_upload_eval.py \
+  --auto-detect-overlong --jobs-dir $EVAL_JOBS_DIR
+
+# Parallel upload with N workers
+python scripts/database/batch_upload_eval.py -p 8 $EVAL_JOBS_DIR/swebench_*
+
+# Dry-run / DB-only / forced overwrite
+python scripts/database/batch_upload_eval.py --dry-run $EVAL_JOBS_DIR/<run_tag>
+python scripts/database/batch_upload_eval.py --skip-hf $EVAL_JOBS_DIR/<run_tag>
+python scripts/database/batch_upload_eval.py --force $EVAL_JOBS_DIR/<run_tag>
+```
+
+Same `model_id` numeric-id pitfall applies as for `manual_db_eval_push.py`
+— verify the model name in Supabase post-upload if the run used a vLLM
+endpoint.
+
 ---
 
 ## See also
 
 - `docs/PREFERRED_HARNESS_REPRODUCTION.md` — per-model recipe lookup
   with reproduction numbers.
+- `docs/RESUME_HANDOFF.md` — cross-cluster bug catalogue (G10/G12/G13 +
+  harbor #1617 + Bug #2) referenced from §8. Read before relying on
+  resume on a new cluster.
 - `clusters/example.yaml`, `hpc/dotenv/example.env` — populate these
   for your cluster before any fire.
 - `python eval/unified_eval_listener.py --help` — full CLI surface.

--- a/eval/EVAL_GUIDE.md
+++ b/eval/EVAL_GUIDE.md
@@ -325,9 +325,10 @@ only when the scaffold needs the JSON-after-think shape.
 ### Pattern A footgun: `--enforce-eager` × 32B + retries
 
 Eager mode adds ~5–14 min to vLLM startup. Default
-`MAX_RETRIES=10` × 60s = 10 min — sometimes the harness gives up
-before `Application startup complete`. For Pattern A 32B fires, pass
-`--vllm-max-retries 30` on the listener.
+`MAX_RETRIES=10` × 100 s = ~17 min — usually enough, but on a slow
+node the harness can still give up before `Application startup
+complete`. For Pattern A 32B fires, pass `--vllm-max-retries 30`
+(~50 min headroom) on the listener.
 
 ---
 
@@ -521,8 +522,9 @@ mitigation.
     Pending DB row with no result. *Refire* with `--force-reeval` only
     when silent-skipped (unconditional refire creates duplicates).
 29. **OpenSWE-32B paper sampling crashes terminus-2** — `rep_penalty
-    1.2` etc. in `override-generation-config` causes 75–77% STOE on
-    OOD. *Drop* the entire override block for OOD fires.
+    1.2` etc. in `override-generation-config` causes 75–77% STOE
+    (stuck-on-exception) on OOD. *Drop* the entire override block for
+    OOD fires.
 30. **Stuck tail trial** — last 1–2 trials hang for hours past job-end
     threshold. *Cancel* + push partial results via
     `manual_db_eval_push.py`.

--- a/eval/EVAL_GUIDE.md
+++ b/eval/EVAL_GUIDE.md
@@ -22,20 +22,67 @@ catalog in §7.
 ### Conda environments
 
 The listener picks an env per fire via `--conda-env`. Configure each
-mapping in your cluster config's `conda_envs:` block. Typical set:
+mapping in your cluster config's `conda_envs:` block. Two envs are
+load-bearing for evals:
 
 | Env | When |
 |---|---|
-| `otagent` | Default for terminus-2 reg eval, datagen, generic CLI |
-| `otagent-fix` | Has the harbor-fix branch — needed for OOD presets and most installed-agent reproductions |
-| `otagent2` | Axolotl-trained Qwen3 models (transformers ≥ 5.x) |
-| `otagent2-fix` | otagent2 + harbor-fix |
+| `otagent-fix` | Default. transformers 4.x line. Used by terminus-2 reg eval, OOD presets, and swe-agent / openhands text-tools / mini-swe-agent / aider installed-agent fires. |
+| `otagent2-fix` | transformers 5.x line. Used by axolotl-trained Qwen3 finetunes that crash to load on 4.x (`extra_special_tokens` list bug), Qwen3.5 family, and Pattern C scaffolds that need vLLM ≥ 0.17 for `--reasoning-parser-plugin` (Nemotron-Nano, Qwen3-Coder native). |
 
-The harbor-fix branch carries:
-- Daytona connection-pool fix (load-shedding instead of false 401s)
-- swerex `dirs_exist_ok=True` for swe-agent on dev_set_v2/tb2
-- vLLM `eos_token` reading from `tokenizer_config.json`
-- per-trial timeout handling and verifier deadlines
+Recreate both via the slim yaml recipes in [`envs/`](envs/):
+
+```bash
+conda env create -f eval/envs/otagent-fix.yml      # primary
+conda env create -f eval/envs/otagent2-fix.yml     # transformers 5.x line
+```
+
+Pinned versions (as of 2026-04-29):
+
+| Package | otagent-fix | otagent2-fix |
+|---|---|---|
+| python | 3.12 | 3.12 |
+| vllm | 0.13.0 | 0.17.1 |
+| torch | 2.9.0+cu128 | 2.10.0+cu128 |
+| transformers | 4.57.3 | 5.6.0.dev0 |
+| flashinfer-python | 0.5.3 | 0.6.4 |
+| huggingface-hub | 0.36.2 | 1.11.0 |
+| daytona | 0.164.0 | 0.164.0 |
+| harbor (editable) | from harbor-fix checkout | from harbor-fix checkout |
+
+See [`envs/README.md`](envs/README.md) for the verification one-liner
+and notes on when to retest after a version bump.
+
+### harbor-fix — pin the patch stack
+
+Harbor is installed *editable* from a checkout. The eval pipeline
+depends on patches that aren't yet in upstream `main`; pin to:
+
+```bash
+git clone https://github.com/harbor-framework/harbor.git ~/harbor-fix
+git -C ~/harbor-fix checkout penfever/temp-override
+git -C ~/harbor-fix checkout 9980f967     # tip used in the last validated fire
+pip install -e ~/harbor-fix               # inside each conda env
+```
+
+`9980f967` is the Daytona connection-pool fix (PR #1460); the rest of
+`penfever/temp-override` carries:
+
+- Loading-gate semaphore (cap = `n_concurrent * 2`)
+- Treat "Bearer token invalid" as transient
+- `assume_global_snapshot` flag for auto-snapshot pinning
+- Multiplier-aware `max_timeout_sec` ordering
+- Tmux dummy-session PTY + history-limit for swebench/tb2 task images
+- swerex `dirs_exist_ok=True` (mode 12 in §7)
+- ContextLengthExceeded → still run verifier
+- Summarization-timeout default raised (mode 6 in §7)
+- LiteLLM timeouts treated as env failures
+
+If you fire Cat 3 (preferred-harness reproductions), also apply the
+three uncommitted installed-agent patches documented in
+[`envs/README.md`](envs/README.md) (aider provider routing, mini-swe-agent
+api-key list, swe-agent venv PATH + set-u guard). Cat 1/2 fires don't
+need them.
 
 ### Secrets
 

--- a/eval/EVAL_GUIDE.md
+++ b/eval/EVAL_GUIDE.md
@@ -1,0 +1,557 @@
+# EVAL_GUIDE — cluster-diagnostic eval listener stack
+
+Operational guide for firing `(model × dataset × scaffold)` evaluations
+through `unified_eval_listener.py` and diagnosing failures with the
+catalog in §7.
+
+## Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Five firing categories](#2-five-firing-categories)
+3. [Pinggy management](#3-pinggy-management)
+4. [Pattern A/B/C/D — vLLM serving configs](#4-pattern-abcd--vllm-serving-configs)
+5. [Yaml flip-restore workflow (Cat 4)](#5-yaml-flip-restore-workflow-cat-4)
+6. [Monitoring + result extraction](#6-monitoring--result-extraction)
+7. [Failure modes catalog](#7-failure-modes-catalog)
+8. [Recovery scripts](#8-recovery-scripts)
+
+---
+
+## 1. Prerequisites
+
+### Conda environments
+
+The listener picks an env per fire via `--conda-env`. Configure each
+mapping in your cluster config's `conda_envs:` block. Typical set:
+
+| Env | When |
+|---|---|
+| `otagent` | Default for terminus-2 reg eval, datagen, generic CLI |
+| `otagent-fix` | Has the harbor-fix branch — needed for OOD presets and most installed-agent reproductions |
+| `otagent2` | Axolotl-trained Qwen3 models (transformers ≥ 5.x) |
+| `otagent2-fix` | otagent2 + harbor-fix |
+
+The harbor-fix branch carries:
+- Daytona connection-pool fix (load-shedding instead of false 401s)
+- swerex `dirs_exist_ok=True` for swe-agent on dev_set_v2/tb2
+- vLLM `eos_token` reading from `tokenizer_config.json`
+- per-trial timeout handling and verifier deadlines
+
+### Secrets
+
+Source a dotenv before any fire:
+
+```bash
+source ~/.local/eval.env       # or wherever your cluster's secrets live
+```
+
+Required: `HF_TOKEN`, `SUPABASE_URL`, `SUPABASE_ANON_KEY` (and
+`SUPABASE_KEY` aliased to it), `DAYTONA_API_KEY`. See
+`hpc/dotenv/example.env` for the full list.
+
+> **Two Daytona keys, two reliability tiers.** If you have a primary +
+> secondary key, the secondary often shows higher auth-error rates
+> under load. Route critical evals through the primary.
+
+### Pinggy
+
+Only Cat 3 (installed-agent reproductions) needs Pinggy — the agent
+CLI runs inside a Daytona sandbox and can't reach the SLURM node's
+localhost. Buy N pairs (one pair = one concurrent Cat 3 job) and load
+them via `source ~/pinggy_pairs.env`. See §3 for management.
+
+---
+
+## 2. Five firing categories
+
+All fires use the same launcher (`unified_eval_listener.py`); the
+category determines preset, harbor config, scaffold flags, and
+whether Pinggy is needed.
+
+### Cat 1 — Reg eval (terminus-2 on v2 / swebench / tb2)
+
+Default surface. Picks per-model serving config from
+`baseline_model_configs_minimal.yaml`, runs against
+`dcagent_eval_config.yaml`.
+
+```bash
+echo "Qwen/Qwen3-32B" > /tmp/list.txt
+for preset in v2 swebench tb2; do
+  python eval/unified_eval_listener.py \
+    --cluster-config ~/.local/eval-cluster.yaml \
+    --preset $preset \
+    --priority-file /tmp/list.txt \
+    --baseline-model-config eval/configs/baseline_model_configs_minimal.yaml \
+    --conda-env otagent-fix \
+    --enable-thinking --tp-size 2 --dp-size 2 --timeout-multiplier 2.0 \
+    --slurm-partition <PARTITION> --slurm-time 24:00:00 \
+    --max-jobs-submitted 32 --n-concurrent 32 \
+    --no-disk-resume --auto-snapshot \
+    --stagger-delay 2 --chain-batch-size 2 --once
+done
+```
+
+### Cat 2 — OOD presets (aider / bfcl / medagentbench / gaia / financeagent / swebench_full)
+
+OOD = "out-of-distribution" relative to terminus-2 training. Each
+preset pins a different dataset + harbor config but runs the same
+terminus-2 agent.
+
+```bash
+python eval/unified_eval_listener.py \
+  --cluster-config ~/.local/eval-cluster.yaml \
+  --preset bfcl \
+  --priority-file /tmp/list.txt \
+  --baseline-model-config eval/configs/baseline_model_configs_minimal.yaml \
+  --conda-env otagent-fix \
+  --enable-thinking --tp-size 2 --dp-size 2 --timeout-multiplier 2.0 \
+  --slurm-partition <PARTITION> --slurm-time 24:00:00 \
+  --max-jobs-submitted 32 --n-concurrent 32 \
+  --no-disk-resume --auto-snapshot \
+  --stagger-delay 2 --chain-batch-size 2 --once
+```
+
+Per-preset nuances:
+- **financeagent**: SEC EDGAR caps at 10 req/s. Preset bumps
+  `n_concurrent` to 16 (empirical p95 ~6.8 req/s aggregate, safe
+  margin); don't override below.
+- **swebench_full**: 500 trials, ~36–48h walltime. Bump
+  `--slurm-time 48:00:00` and pre-download the dataset on a no-internet
+  cluster.
+- **aider / bfcl / medagentbench / gaia**: each pins
+  `dcagent_eval_config_no_override.yaml` (force_build=true,
+  n_concurrent_trials=4) to side-step the swe-agent `/workdir` bug
+  on dev_set_v2/tb2-shaped datasets.
+
+### Cat 3 — Preferred-harness reproduction
+
+Paper-author scaffold + installed-agent CLI in a Daytona sandbox,
+talking back to the served model via Pinggy. See
+[`docs/PREFERRED_HARNESS_REPRODUCTION.md`](docs/PREFERRED_HARNESS_REPRODUCTION.md)
+for the per-model recipes.
+
+```bash
+source ~/pinggy_pairs.env
+python eval/unified_eval_listener.py \
+  --cluster-config ~/.local/eval-cluster.yaml \
+  --preset swebench \
+  --priority-file /tmp/list.txt \
+  --baseline-model-config eval/configs/baseline_model_configs_minimal.yaml \
+  --conda-env otagent-fix \
+  --config-yaml dcagent_eval_config_swe_agent.yaml \
+  --agent-parser "" \
+  --enable-thinking --tp-size 2 --dp-size 2 --timeout-multiplier 2.0 \
+  --slurm-partition <PARTITION> --slurm-time 24:00:00 \
+  --max-jobs-submitted 1 --n-concurrent 32 \
+  --no-disk-resume --no-auto-snapshot \
+  --pinggy-url "$PINGGY_URL_1" --pinggy-token "$PINGGY_TOKEN_1" \
+  --stagger-delay 2 --chain-batch-size 2 --once --force-reeval
+```
+
+Swap `--config-yaml` per scaffold:
+
+| Scaffold | `--config-yaml` |
+|---|---|
+| swe-agent regular / SERA-e2e | `dcagent_eval_config_swe_agent.yaml` |
+| openhands native (text tools) | `dcagent_eval_config_openhands.yaml` |
+| openhands Qwen3-Coder native | `dcagent_eval_config_openhands_qwen3_coder.yaml` |
+| openhands Nemotron-Nano native | `dcagent_eval_config_openhands_toolcall.yaml` |
+| mini-swe-agent | `dcagent_eval_config_mini_swe_agent.yaml` |
+| aider (no thinking) | `dcagent_eval_config_aider_agent_nothink.yaml` |
+
+For SERA-e2e, also export
+`SWEAGENT_CONFIG=https://huggingface.co/datasets/DCAgent2/swe-agent-configs/resolve/main/sera_e2e.yaml`
+before fire (the listener forwards it).
+
+### Cat 4 — Yaml flip-restore
+
+A model whose baseline-yaml entry uses Pattern B/C (parsers tuned for
+its native installed-agent harness) gives **0% on terminus-2** because
+the parser hijacks JSON the agent expects to consume directly. To
+fire terminus-2 on such a model:
+
+1. Edit its yaml entry — strip `tool_call_parser` and
+   `reasoning_parser`. Keep tp/dp, swap_space, trust_remote_code,
+   chat_template, extra_args. Add a header comment `# TEMP FLIP <date>`.
+2. Fire the Cat 1 command.
+3. Wait for batch completion (the listener bakes env vars at submit
+   time, so restore is safe once all jobs are queued).
+4. Restore the yaml. The repo's last-write rule is **the file ends in
+   the most-common state** so future sessions see the right config.
+
+See §5 for a worked example.
+
+### Cat 5 — Per-model serving config
+
+Lives entirely in `configs/baseline_model_configs_minimal.yaml`. No
+fire change. Add an entry, choose Pattern A/B/C/D from §4, sanity-check
+with a one-model dry-run, then fold into a Cat 1/2/3 batch.
+
+---
+
+## 3. Pinggy management
+
+### What Pinggy is
+
+A persistent reverse-tunnel service. Each pair (`url`, `token`) maps
+to a stable `https://<...>.a.pinggy.link/v1` endpoint. The sbatch
+opens an SSH reverse tunnel from the SLURM node so the served vLLM is
+reachable from inside Daytona sandboxes (which can't reach SLURM
+node localhost).
+
+### Allocation
+
+One pair per concurrent Cat 3 job. SSH reverse binding is exclusive —
+the second tunnel to the same pair is rejected. Buy as many pairs as
+you want concurrent installed-agent fires. Store as:
+
+```bash
+# ~/pinggy_pairs.env  (chmod 600)
+export PINGGY_URL_1="abcd1234.a.pinggy.link"
+export PINGGY_TOKEN_1="..."
+export PINGGY_URL_2="..."
+# ...etc
+```
+
+### Occupancy check (which pairs are in use right now)
+
+```bash
+for jid in $(squeue -u $USER --format='%.10i' --noheader); do
+  url=$(grep -oE "[a-z0-9]+\.a\.pinggy\.link" eval/logs/data_${jid}.out 2>/dev/null | head -1)
+  [ -n "$url" ] && echo "$jid -> $url"
+done
+```
+
+### Cross-cluster collision check (before fire)
+
+If pairs are shared with another cluster (e.g. you also use Jupiter
+with the same account), the SSH binding races. The pair appears
+healthy from your side but routes to the *other cluster's* model.
+Detect by querying the served-model id and comparing root path:
+
+```bash
+URL=<pair-url>
+curl -s --max-time 8 https://$URL/v1/models \
+  | python3 -c "import sys, json; d=json.load(sys.stdin); m=d.get('data',[{}])[0]; print(f\"served={m.get('id')} root={m.get('root','')[:80]}\")"
+```
+
+If `root=` doesn't point inside *your* `paths.hf_cache`, the pair is
+contaminated — cancel the job, fire on a different pair.
+
+### Rules of thumb
+
+- Cat 1/2 fires never need Pinggy (terminus-2 talks to vLLM directly
+  on the SLURM node).
+- Cat 3 fires always need Pinggy *unless* the scaffold ships a
+  Daytona-internal endpoint (rare).
+- A failed Cat 3 fire that left a hung tunnel: cancel the SLURM job;
+  the SSH tunnel dies with it.
+
+---
+
+## 4. Pattern A/B/C/D — vLLM serving configs
+
+The shape of `extra_args` + parsers in
+`baseline_model_configs_minimal.yaml` falls into four patterns. Pick
+based on (a) what scaffold the model was trained for, (b) whether the
+model emits `<think>`, (c) tool-call format.
+
+| Pattern | Scaffold | tool_call_parser | reasoning_parser | extra_args highlights |
+|---|---|---|---|---|
+| **A** | swe-agent SERA-e2e | `hermes` | _(none)_ | `--enforce-eager --disable-cascade-attn --seed 42`; no prefix-caching |
+| **B** | swe-agent regular / openhands native | `hermes` | `qwen3` (when model emits `<think>`) | `--enable-prefix-caching` |
+| **C** | openhands Qwen3-Coder / Nemotron-Nano native | `qwen3_coder` | `nano_v3` (Nemotron) | `--reasoning-parser-plugin ${DCFT}/eval/configs/nano_v3_reasoning_parser.py --chat-template ${DCFT}/eval/configs/nemotron_chat_template.jinja --override-generation-config '{"temperature":0.6,"top_p":0.95}' --enable-prefix-caching` |
+| **D** | terminus-2 / openhands text-tools | _(none)_ | _(none)_ | `--enable-prefix-caching` (optional) |
+
+### Why no parser for Pattern D
+
+Terminus-2 and openhands text-tools both do their own JSON extraction
+client-side. A vLLM-side `tool_call_parser` mangles the response —
+silent 0%.
+
+### Why `reasoning_parser: qwen3` only when needed
+
+Adding it strips `<think>` blocks cross-turn. Models trained to keep
+those (SA-SWE, some axolotl variants) regress hard. Default off; add
+only when the scaffold needs the JSON-after-think shape.
+
+### Pattern A footgun: `--enforce-eager` × 32B + retries
+
+Eager mode adds ~5–14 min to vLLM startup. Default
+`MAX_RETRIES=10` × 60s = 10 min — sometimes the harness gives up
+before `Application startup complete`. For Pattern A 32B fires, pass
+`--vllm-max-retries 30` on the listener.
+
+---
+
+## 5. Yaml flip-restore workflow (Cat 4)
+
+Worked example: fire terminus-2 on `Qwen/Qwen3-32B`, which is
+configured Pattern B in baseline yaml.
+
+**Before** (Pattern B — installed-agent):
+
+```yaml
+"Qwen/Qwen3-32B":
+  tensor_parallel_size: 2
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: hermes
+  reasoning_parser: qwen3
+  extra_args: "--enable-prefix-caching"
+```
+
+**During fire** (Pattern D — terminus-2):
+
+```yaml
+"Qwen/Qwen3-32B":
+  tensor_parallel_size: 2
+  swap_space: 32
+  trust_remote_code: true
+  # TEMP FLIP <YYYY-MM-DD> — parsers stripped for terminus-2
+  extra_args: "--enable-prefix-caching"
+```
+
+Fire the Cat 1 command, wait for `--max-jobs-submitted N` jobs to
+queue, then restore.
+
+**Restore rule**: the file's last-write state is what every future
+fire — and every other contributor — sees. Restore *immediately* after
+the batch is queued, not after the batch completes. The listener's
+env-baking happens at submit time; the on-disk yaml doesn't matter
+once jobs are queued.
+
+---
+
+## 6. Monitoring + result extraction
+
+### Live progress
+
+```bash
+python eval/check_progress.py            # text summary
+python eval/check_progress.py --live     # rich dashboard
+```
+
+### Per-trial result extraction
+
+```python
+import json, glob, os
+from collections import Counter
+
+run_dir = "jobs/<run_tag>"
+results = glob.glob(os.path.join(run_dir, "*__*/result.json"))
+total = len(results)
+rewards, exceptions = [], Counter()
+for r in results:
+    d = json.load(open(r))
+    rw = ((d.get("verifier_result") or {}).get("rewards") or {}).get("reward")
+    if rw is not None:
+        rewards.append(rw)
+    exc = (d.get("exception_info") or {}).get("exception_type")
+    if exc:
+        exceptions[exc] += 1
+errors = sum(exceptions.values())
+scored = total - errors
+correct = sum(1 for r in rewards if r == 1.0)
+acc = correct / scored * 100 if scored else 0
+print(f"trials={total} errors={errors} correct={correct} acc={acc:.1f}%")
+for e, c in exceptions.most_common():
+    print(f"  {e}: {c}")
+```
+
+### Trust threshold
+
+**Make recipe decisions only when n ≥ 150 trials are scored.** Sub-150
+reads can drift ±5–10 percentage points as more trials land — several
+preferred-harness reads moved 5–8 pp in the pessimistic direction
+between n=50 and n=150 in earlier work. If the dataset has fewer than
+150 tasks total, run multiple seeds and aggregate.
+
+### Health-check thresholds (running jobs)
+
+| Symptom | Likely cause |
+|---|---|
+| No new `result.json` for 60+ min, job RUNNING | Harbor stall (all trials timing out simultaneously, or hung) |
+| vLLM `Running: 0` for 10+ min | Agents not generating: env-build stall, auth degradation, drain |
+| All trials done but job RUNNING | Zombie — Harbor process didn't exit. Cancel + manual upload |
+| Repeated `Bearer token is invalid` in slurm log | Daytona auth degradation under load (see #5 in §7) |
+
+---
+
+## 7. Failure modes catalog
+
+The cluster-diagnostic spine. Each entry: short symptom, root cause,
+mitigation.
+
+1. **vLLM health-check timeout on 32B cold start** — sbatch retried
+   10× × 60s, model needs 12–15 min. *Refire.* If chronic, raise
+   `--vllm-max-retries 20`.
+2. **NCCL ALLREDUCE timeout during flashinfer autotune** — usually a
+   bad node. *Clear* `~/.cache/vllm/torch_compile_cache`, refire on a
+   different node.
+3. **Torch-compile cache corrupted** — `Bytes object is corrupted,
+   checksum does not match`. *Delete* the cache, refire.
+4. **24h SLURM wall before upload** — long jobs with many
+   `AgentTimeoutError` trials burn walltime before Harbor's upload
+   step. *Use* `upload_overlong_jobs.py` (see §8).
+5. **Bearer token invalid / Daytona load-shedding** — sustained sandbox
+   creation > ~10/s triggers fake 401s. *Drop* concurrent fires;
+   stagger with `--stagger-delay 2 --chain-batch-size 2`. The
+   harbor-fix branch widens the connection pool.
+6. **`SummarizationTimeoutError` dominates** — default 300s too short
+   for 32B on long context. *Use* a harbor config with
+   `summarization_timeout: 1800`.
+7. **Daytona "Dockerfile cannot be empty"** — transient build flake at
+   high concurrency. *Harbor* retries; usually clears. If >50% of
+   trials hit it, cancel and back off.
+8. **Cross-cluster Pinggy contamination** — pair shared with another
+   cluster, SSH races. *Run* the §3 collision check before each Cat 3
+   fire.
+9. **vLLM port collision via DP workers** — DP=2 binds 3 contiguous
+   ports; SLURM JIDs differing by ≤2 on the same node collide. *Cancel
+   one, refire* (gets a new JID → new port range).
+10. **Pattern A `--enforce-eager` × 32B startup race** — see §4.
+    *Pass* `--vllm-max-retries 30`.
+11. **HF Hub 429 (org-level rate limit)** — pre-download HEAD calls
+    across many shards × many jobs blow the 12 k / 5 min quota.
+    *Stagger* fires (≥60s apart); set `HF_HUB_OFFLINE=1` for
+    fully-cached models.
+12. **swe-agent `/workdir already exists`** — task containers on
+    dev_set_v2 / tb2 pre-create `/workdir`; swe-agent's setup uses
+    `copytree(exist_ok=False)`. *Use* openhands instead, or pin the
+    swerex patch (`dirs_exist_ok=True`).
+13. **Tool-call parser hijacks terminus-2 JSON** — `hermes` /
+    `qwen3_coder` parser on a terminus-2 fire = silent 0%. *Pattern D
+    has no parser*; flip baseline yaml (Cat 4) before fire.
+14. **`reasoning_parser: qwen3` strips `<think>` cross-turn** — breaks
+    models trained to keep them. *Add only when the scaffold needs the
+    post-think JSON shape.*
+15. **Engine-direct scaffolds aren't portable** — SkyRL's
+    `OHCodeActAgent` bypasses the OpenAI API, custom chat templates
+    aren't reproducible via Harbor. *Documented as structurally
+    unreproducible (SA-SWE, OpenSWE).*
+16. **Custom chat templates accumulate state at 32k** — a template
+    that re-emits earlier `<think>` fills the context window;
+    condenser fires, drops observations, agent gets stuck. *Don't add
+    unless context budget can grow to 64k+.*
+17. **v4-axolotl tokenizer crash** — the older transformers 4.x
+    crashes on `extra_special_tokens: list`. *Use* `otagent2-fix`.
+18. **HF 429 on fresh-upload batch** — cluster of jobs fails on the
+    same safetensors shard before the model is fully on disk.
+    *Refire* survivors individually.
+19. **Pinggy pair user-collision** — another user holds the pair.
+    *Refire* on a different pair.
+20. **`--config-yaml <path>` path-doubling** — sbatch auto-prepends
+    `${DCFT}/eval/configs/`. Passing an absolute path → `Harbor config
+    not found`, crashes after vLLM warmup. *Pass bare filename.*
+21. **Numeric model-id in DB after upload** — Harbor reads the served
+    model name from `agent_info.model_info.name`, which for vLLM is a
+    numeric serving id. *Pass* `--model-name laion/<real-name>` to
+    `manual_db_eval_push.py`, or fix the model_id post-upload.
+22. **Small-n accuracy reads overstate** — see §6 trust threshold.
+    Decisions with n<150 are unreliable.
+23. **Numeric subagent-cited paper IDs** — verify chat-template format
+    against `tokenizer_config.json` directly, not against subagent
+    summaries.
+24. **Qwen3-Coder-tuned models with broken tool-call format** —
+    axolotl SFT'd against hermes, deployed against openhands
+    CodeActAgent → format mismatch. *Sample* a `trajectory.json` for
+    `<parameter=...>` without surrounding `<function=...>` markers
+    before declaring a recipe.
+25. **Harness × model fit dominates accuracy** — same model on
+    swe-agent regular vs openhands text-tools can swing 30 pp.
+    *Confirm* the harness matches the SFT training before declaring
+    "model is broken".
+26. **Secondary Daytona key has worse capacity** — when two keys are
+    available, the secondary often shows ~40% auth-error rate under
+    load. *Route critical evals through the primary.*
+27. **vLLM `auto-snapshot` cached image** — `--auto-snapshot` reuses a
+    cached `action_execution_server` build that's broken for some
+    openhands fires (silent 0%). *Drop* the flag for fresh builds, or
+    rely on the preset's authoritative `auto_snapshot` field. Don't
+    pass it on the CLI — let the preset decide.
+28. **bfcl false-skip on listener restart** — silent skip leaves a
+    Pending DB row with no result. *Refire* with `--force-reeval` only
+    when silent-skipped (unconditional refire creates duplicates).
+29. **OpenSWE-32B paper sampling crashes terminus-2** — `rep_penalty
+    1.2` etc. in `override-generation-config` causes 75–77% STOE on
+    OOD. *Drop* the entire override block for OOD fires.
+30. **Stuck tail trial** — last 1–2 trials hang for hours past job-end
+    threshold. *Cancel* + push partial results via
+    `manual_db_eval_push.py`.
+
+---
+
+## 8. Recovery scripts
+
+### When to use which
+
+```
+                    +----------------------------------+
+                    | Did the SLURM job hit TIMEOUT    |
+                    | (24h walltime) before upload?    |
+                    +----------------+-----------------+
+                                     |
+                          yes        |       no
+                  +------------------+------------------+
+                  |                                     |
+         upload_overlong_jobs.py            Did Harbor's auto-upload
+         (scans jobs/, identifies            fail (e.g. numeric model_id,
+          overlong runs, batch                missing result.json)?
+          uploads partial results)                       |
+                                              yes       |       no
+                                       +----------------+--------+
+                                       |                         |
+                              manual_db_eval_push.py     no action — auto-upload
+                              --job-dir jobs/<run_tag>   succeeded; verify in
+                              --forced-update --verbose  Supabase
+```
+
+### `manual_db_eval_push.py` — single-job recovery
+
+```bash
+source ~/.local/eval.env
+python scripts/database/manual_db_eval_push.py \
+  --job-dir jobs/<run_tag> \
+  --verbose
+```
+
+**Common flags**:
+- `--forced-update` — overwrite existing DB rows (default: skip if row
+  exists).
+- `--skip-hf` — DB-only (skip the HuggingFace traces upload).
+- `--hf-repo DCAgent2/<run_tag>-traces` — explicit override.
+
+**Watch out**: `agent_info.model_info.name` in `result.json` is the
+vLLM-served numeric id (e.g. `1774950145766573`), not the HF model
+name. The script may register a bogus model row. After upload, verify
+the model name in Supabase and fix it if needed:
+
+```bash
+python -c "
+import json
+d = json.load(open('experiments/<run_tag>/configs/<run_tag>_eval_config.json'))
+print(d['model_hf_name'])
+"
+```
+
+### `upload_overlong_jobs.py` — batch TIMEOUT recovery
+
+```bash
+source ~/.local/eval.env
+python scripts/database/upload_overlong_jobs.py --upload --force --parallel 8
+```
+
+Walks `$EVAL_JOBS_DIR`, picks runs whose latest `trial.log` mtime is
+older than the threshold (= TIMEOUT-killed), pushes their partial
+results to Supabase + HuggingFace as `status=overlong`.
+
+---
+
+## See also
+
+- `docs/PREFERRED_HARNESS_REPRODUCTION.md` — per-model recipe lookup
+  with reproduction numbers.
+- `clusters/example.yaml`, `hpc/dotenv/example.env` — populate these
+  for your cluster before any fire.
+- `python eval/unified_eval_listener.py --help` — full CLI surface.

--- a/eval/EVAL_GUIDE.md
+++ b/eval/EVAL_GUIDE.md
@@ -712,7 +712,16 @@ python scripts/database/manual_db_eval_push.py \
 - `--forced-update` — overwrite existing DB rows (default: skip if row
   exists).
 - `--skip-hf` — DB-only (skip the HuggingFace traces upload).
-- `--hf-repo DCAgent2/<run_tag>-traces` — explicit override.
+- `--hf-repo DCAgent3/<run_tag>-traces` — explicit override.
+
+> **HF trace upload destination is `DCAgent3`.** `DCAgent` and `DCAgent2` are
+> the previous orgs — both have hit their public-storage cap (HF returns 403
+> on new uploads), so new traces go to `DCAgent3`. The two older orgs still
+> host source benchmark datasets (e.g. `DCAgent2/terminal_bench_2`,
+> `DCAgent/dev_set_v2`) — those are read-only and unchanged. If you see a
+> sbatch fail at upload with `403 Forbidden` on a `DCAgent2/` path, the run
+> was launched from a pre-migration sbatch checkout; re-upload via
+> `batch_upload_eval.py` to land on `DCAgent3`.
 
 **Watch out**: `agent_info.model_info.name` in `result.json` is the
 vLLM-served numeric id (e.g. `1774950145766573`), not the HF model

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,71 @@
+# eval/
+
+Listener-driven evaluation pipeline for OpenThoughts-Agent. The core
+loop: pick (model × dataset × scaffold), serve the model with vLLM
+inside SLURM, run trials through Harbor + Daytona, upload results to
+Supabase + HuggingFace.
+
+## Quickstart
+
+1. Pick or create a cluster config:
+
+   ```bash
+   cp eval/clusters/example.yaml ~/.local/eval-cluster.yaml
+   $EDITOR ~/.local/eval-cluster.yaml          # fill in placeholders
+   cp hpc/dotenv/example.env ~/.local/eval.env
+   $EDITOR ~/.local/eval.env                   # fill in TODO secrets
+   source ~/.local/eval.env
+   ```
+
+2. Fire a single-model dry-run to confirm the surface is wired up:
+
+   ```bash
+   echo "Qwen/Qwen3-32B" > /tmp/dry.txt
+   python eval/unified_eval_listener.py \
+     --cluster-config ~/.local/eval-cluster.yaml \
+     --preset v2 --priority-file /tmp/dry.txt \
+     --baseline-model-config eval/configs/baseline_model_configs_minimal.yaml \
+     --once --dry-run
+   ```
+
+3. Read [`EVAL_GUIDE.md`](EVAL_GUIDE.md) for full fire templates,
+   the failure-modes catalog, and recovery procedures.
+
+## Five firing categories
+
+- **Cat 1 — Reg eval**: terminus-2 on `v2 / swebench / tb2`. Default
+  preset, default harbor config, default agent.
+- **Cat 2 — OOD presets**: `aider / bfcl / medagentbench / gaia /
+  financeagent / swebench_full`. Same listener, different presets,
+  `dcagent_eval_config_no_override.yaml`.
+- **Cat 3 — Preferred-harness reproduction**: paper-author scaffolds
+  (swe-agent / openhands / mini-swe-agent / aider) with installed-agent
+  CLIs talking to the served model via Pinggy SSH tunnels. See
+  [`docs/PREFERRED_HARNESS_REPRODUCTION.md`](docs/PREFERRED_HARNESS_REPRODUCTION.md).
+- **Cat 4 — Yaml flip-restore**: temporarily strip Pattern A/B/C
+  parsers from a model's baseline-yaml entry to fire it on terminus-2
+  (Pattern D), then restore.
+- **Cat 5 — Per-model serving config**: edit
+  `configs/baseline_model_configs_minimal.yaml` to add a new tp/dp,
+  parser, chat-template, or extra_args entry for a model.
+
+## Layout
+
+```
+eval/
+├── unified_eval_listener.py    # daemon / one-shot SLURM submitter
+├── unified_eval_harbor.sbatch  # vLLM serve + harbor run + DB upload
+├── build_vllm_cmd.sh           # consumes EVAL_VLLM_* env from listener
+├── check_progress.py           # progress + result dashboard
+├── snapshot_download.py        # pre-download HF caches
+├── configs/                    # baseline + scaffold harbor yamls
+├── clusters/                   # one yaml per SLURM cluster
+├── lists/                      # priority files (one HF model per line)
+└── docs/PREFERRED_HARNESS_REPRODUCTION.md
+```
+
+## Help
+
+```bash
+python eval/unified_eval_listener.py --help
+```

--- a/eval/build_vllm_cmd.sh
+++ b/eval/build_vllm_cmd.sh
@@ -15,12 +15,13 @@
 # Env vars consumed (all optional, set by listener):
 #   EVAL_VLLM_TENSOR_PARALLEL_SIZE  (default: 4)
 #   EVAL_VLLM_MAX_MODEL_LEN         (default: unset = model native)
-#   EVAL_VLLM_SWAP_SPACE            (default: 4)
+#   EVAL_VLLM_SWAP_SPACE            (default: 32)
 #   EVAL_VLLM_TRUST_REMOTE_CODE     (default: unset; set to "1" to enable)
 #   EVAL_VLLM_TOOL_CALL_PARSER      (default: unset)
 #   EVAL_VLLM_REASONING_PARSER      (default: unset)
 #   EVAL_VLLM_DATA_PARALLEL_SIZE    (default: unset; vLLM v0.8+ only)
 #   EVAL_VLLM_EXTRA_ARGS            (default: unset; space-separated string)
+#   EVAL_VLLM_HF_OVERRIDES          (default: unset; JSON string for --hf-overrides)
 # ==============================================================================
 
 build_vllm_cmd() {
@@ -31,18 +32,19 @@ build_vllm_cmd() {
     # Read overrides from env (set by listener via sbatch --export)
     local tp="${EVAL_VLLM_TENSOR_PARALLEL_SIZE:-4}"
     local dp="${EVAL_VLLM_DATA_PARALLEL_SIZE:-}"
-    local max_model_len="${EVAL_VLLM_MAX_MODEL_LEN:-}"
-    local swap_space="${EVAL_VLLM_SWAP_SPACE:-4}"
+    local max_model_len="${EVAL_VLLM_MAX_MODEL_LEN:-32768}"
+    local swap_space="${EVAL_VLLM_SWAP_SPACE:-32}"
     local trust_remote_code="${EVAL_VLLM_TRUST_REMOTE_CODE:-}"
     local tool_call_parser="${EVAL_VLLM_TOOL_CALL_PARSER:-}"
     local reasoning_parser="${EVAL_VLLM_REASONING_PARSER:-}"
     local extra_args="${EVAL_VLLM_EXTRA_ARGS:-}"
+    local hf_overrides="${EVAL_VLLM_HF_OVERRIDES:-}"
 
     # Build command array
     VLLM_CMD=(
         "$python_bin" -m vllm.entrypoints.openai.api_server
         --model "$model"
-        --host 0.0.0.0 --port 8000
+        --host 0.0.0.0 --port "${VLLM_PORT:-8000}"
         --served-model-name "$model"
         --tensor-parallel-size "$tp"
         --gpu-memory-utilization "$gpu_mem_util"
@@ -68,6 +70,11 @@ build_vllm_cmd() {
 
     if [ -n "$reasoning_parser" ]; then
         VLLM_CMD+=(--reasoning-parser "$reasoning_parser")
+    fi
+
+    # HF model config overrides (JSON string, properly quoted)
+    if [ -n "$hf_overrides" ]; then
+        VLLM_CMD+=(--hf-overrides "$hf_overrides")
     fi
 
     # Append extra args (space-separated string)

--- a/eval/check_progress.py
+++ b/eval/check_progress.py
@@ -318,6 +318,33 @@ def collect_job_data(jobs_dir):
     # Resolve log dirs once — stat-checking EXTRA_LOG_DIRS per-job wastes syscalls.
     all_log_dirs = [LOGS_DIR] + [d for d in EXTRA_LOG_DIRS if d.exists()]
 
+    # Build run_tag → [JIDs] index across all slurm log dirs once. Used to
+    # surface the prior fire's JID for resume jobs (so the user can see what
+    # this resume continues from). A run dir gets one log per fire (original +
+    # each resume); we sort numerically so the highest JID < current is the
+    # immediate predecessor.
+    fire_index: dict[str, list[str]] = {}
+    for log_dir in all_log_dirs:
+        if not log_dir.is_dir():
+            continue
+        for f in log_dir.glob("data_*.out"):
+            try:
+                fjid = f.stem.split("_", 1)[1]
+            except IndexError:
+                continue
+            try:
+                with open(f, "r", errors="replace") as fh:
+                    for i, line in enumerate(fh):
+                        if i > 200:
+                            break
+                        if line.startswith("Run tag: "):
+                            rt = line[len("Run tag: "):].strip()
+                            if rt:
+                                fire_index.setdefault(rt, []).append(fjid)
+                            break
+            except (OSError, IOError):
+                continue
+
     def process_one(job):
         jid, name, state, start_time = job
         model, bench, run_tag, num_shards, n_concurrent, timeout_mult, is_resume_log = parse_eval_log(jid, name, all_log_dirs)
@@ -341,9 +368,24 @@ def collect_job_data(jobs_dir):
         #      path regardless of job name. The orchestrator submits with the
         #      default --job-name "data", so name-based detection alone misses it.
         is_resume = name.startswith("res_") or is_resume_log
+        prior_jid = None
+        if is_resume and run_tag:
+            # Find the most-recent prior fire for this run_tag (highest JID
+            # numerically less than the current one). Falls back gracefully if
+            # the prior fire's slurm log was rotated/deleted (rmlogs).
+            try:
+                cur_int = int(jid)
+                priors = sorted(
+                    (int(j) for j in fire_index.get(run_tag, []) if j.isdigit() and int(j) < cur_int),
+                    reverse=True,
+                )
+                if priors:
+                    prior_jid = str(priors[0])
+            except (ValueError, TypeError):
+                pass
         tags = []
         if is_resume:
-            tags.append("RES")
+            tags.append(f"RES <- {prior_jid}" if prior_jid else "RES")
         if num_shards > 1:
             tags.append(f"{num_shards}x DP")
 

--- a/eval/check_progress.py
+++ b/eval/check_progress.py
@@ -22,12 +22,7 @@ from pathlib import Path
 
 REPO_DIR = Path(__file__).resolve().parent.parent
 LOGS_DIR = REPO_DIR / "eval" / "logs"
-EXTRA_LOG_DIRS = [
-    REPO_DIR / "eval" / "local" / "logs",        # legacy v6 default
-    REPO_DIR / "eval" / "MBZ" / "logs",           # legacy MBZ v4
-    REPO_DIR / "eval" / "local" / "mbz" / "logs", # legacy MBZ v6
-    REPO_DIR / "eval" / "local" / "m2" / "logs",  # legacy M2
-]
+EXTRA_LOG_DIRS: list[Path] = []
 DEFAULT_JOBS_DIR = REPO_DIR / "jobs"
 
 # Benchmark ordering for display. Core benchmarks render first in the listed

--- a/eval/check_progress.py
+++ b/eval/check_progress.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+"""Check progress of all running eval jobs on Jupiter.
+
+Usage:
+    python check_progress.py              # grouped text output (default)
+    python check_progress.py --live       # rich live dashboard
+    python check_progress.py --live -i 3  # live with 3s refresh
+    python check_progress.py --sort elapsed
+    python check_progress.py --jobs-dir /path/to/other/jobs  # override jobs dir
+"""
+
+import argparse
+import concurrent.futures
+import subprocess
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+LOGS_DIR = REPO_DIR / "eval" / "logs"
+EXTRA_LOG_DIRS = [
+    REPO_DIR / "eval" / "local" / "logs",        # legacy v6 default
+    REPO_DIR / "eval" / "MBZ" / "logs",           # legacy MBZ v4
+    REPO_DIR / "eval" / "local" / "mbz" / "logs", # legacy MBZ v6
+    REPO_DIR / "eval" / "local" / "m2" / "logs",  # legacy M2
+]
+DEFAULT_JOBS_DIR = REPO_DIR / "jobs"
+
+# Benchmark ordering for display. Core benchmarks render first in the listed
+# order, then OOD benchmarks in the listed order, then anything else
+# alphabetically. Names are matched against the short benchmark name
+# (the last path segment of the Dataset: header).
+CORE_BENCHMARKS = [
+    "dev_set_v2",
+    "swebench-verified-random-100-folders",
+    "terminal_bench_2",
+]
+OOD_BENCHMARKS = [
+    "aider_polyglot",
+    "bfcl-parity",
+    "medagentbench",
+    "swebench-verified",
+    "gaia_127",
+    "financeagent_terminal",
+]
+CATEGORY_LABELS = {
+    "core": "CORE BENCHMARKS",
+    "ood": "OOD BENCHMARKS",
+    "other": "OTHER",
+}
+
+
+# ---------------------------------------------------------------------------
+# Data collection helpers (unchanged logic, refactored for reuse)
+# ---------------------------------------------------------------------------
+
+def get_running_jobs():
+    result = subprocess.run(
+        ["squeue", "-u", os.environ["USER"], "--format=%.10i %.15j %.8T %.20S", "--noheader"],
+        capture_output=True, text=True,
+    )
+    jobs = []
+    for line in result.stdout.strip().split("\n"):
+        parts = line.split()
+        if len(parts) >= 4:
+            jobs.append((parts[0].strip(), parts[1].strip(), parts[2].strip(), parts[3].strip()))
+    return jobs
+
+
+def parse_eval_log(jid, job_name, all_log_dirs=None, max_lines=2000):
+    """Try multiple log naming patterns. SLURM %x is captured at submit time,
+    so renamed jobs (eval_dp -> eval_dp_v2) need fallback to original name.
+
+    Headers are written near the top of the log. We read at most max_lines
+    and early-exit once all fields are found, instead of scanning multi-GB
+    stdout files end-to-end.
+    """
+    if all_log_dirs is None:
+        all_log_dirs = [LOGS_DIR] + [d for d in EXTRA_LOG_DIRS if d.exists()]
+    candidates = []
+    for log_dir in all_log_dirs:
+        candidates.append(log_dir / f"{job_name}_{jid}.out")
+    if job_name.startswith("eval_dp_"):
+        for log_dir in all_log_dirs:
+            candidates.append(log_dir / f"eval_dp_{jid}.out")
+    elif job_name.startswith("eval_"):
+        for log_dir in all_log_dirs:
+            candidates.append(log_dir / f"eval_{jid}.out")
+    if job_name.startswith("res_dp_"):
+        for log_dir in all_log_dirs:
+            candidates.append(log_dir / f"res_dp_{jid}.out")
+    elif job_name.startswith("res_"):
+        for log_dir in all_log_dirs:
+            candidates.append(log_dir / f"res_{jid}.out")
+
+    is_dp = job_name.startswith("eval_dp_") or job_name.startswith("res_dp_")
+    model = bench = run_tag = None
+    num_shards = 0
+    for log in candidates:
+        if not log.exists():
+            continue
+        with open(log) as f:
+            for i, line in enumerate(f):
+                if i >= max_lines:
+                    break
+                if line.startswith("Model: "):
+                    model = line.strip()[7:]
+                elif line.startswith("Dataset: "):
+                    bench = line.strip()[9:]
+                elif line.startswith("Run tag: "):
+                    run_tag = line.strip()[9:]
+                elif "total shards)" in line:
+                    try:
+                        num_shards = int(line.split("total shards")[0].split(",")[-1].strip())
+                    except (ValueError, IndexError):
+                        pass
+                # Early exit once every expected field is found.
+                # Non-DP jobs never emit "total shards", so don't wait on num_shards.
+                if model and bench and run_tag and (num_shards > 0 or not is_dp):
+                    break
+        break
+    return model, bench, run_tag, num_shards
+
+
+VALID_ERROR_TYPES = {
+    "AgentTimeoutError", "ContextLengthExceededError",
+    "SummarizationTimeout", "SummarizationTimeoutError", "BadRequestError",
+}
+
+
+def get_progress_single(run_tag, jobs_dir):
+    """Get progress from a single (non-DP) job dir."""
+    if not run_tag:
+        return None, None, None, None, None, None, None
+    job_dir = jobs_dir / run_tag
+    rf = job_dir / "result.json"
+    if not rf.exists():
+        return None, None, None, None, None, None, None
+    try:
+        with open(rf) as f:
+            d = json.load(f)
+        completed = d.get("stats", {}).get("n_trials", None)
+        total = d.get("n_total_trials", None)
+        finished = d.get("finished_at") is not None
+        invalid_trials = set()
+        evals = d.get("stats", {}).get("evals", {})
+        # Extract accuracy from metrics + agent name from eval key prefix
+        accuracy = None
+        agent = None
+        for eval_key, eval_data in evals.items():
+            if agent is None and "__" in eval_key:
+                agent = eval_key.split("__", 1)[0]
+            for error_type, trial_names in eval_data.get("exception_stats", {}).items():
+                if error_type not in VALID_ERROR_TYPES and isinstance(trial_names, list):
+                    invalid_trials.update(trial_names)
+            metrics = eval_data.get("metrics", [])
+            if metrics and isinstance(metrics, list):
+                mr = metrics[0].get("mean_reward")
+                if mr is not None:
+                    accuracy = mr
+        # Use reward_stats to count completed trials (avoids expensive dir scan)
+        n_on_disk = None
+        for eval_data in evals.values():
+            rs = eval_data.get("reward_stats", {}).get("reward", {})
+            if rs:
+                n_on_disk = sum(len(v) for v in rs.values() if isinstance(v, list))
+                break
+        if n_on_disk is None:
+            # Fallback: count from stats
+            n_on_disk = completed
+        return completed, total, len(invalid_trials), finished, n_on_disk, accuracy, agent
+    except Exception:
+        return None, None, None, None, None, None, None
+
+
+def get_progress(run_tag, num_shards, jobs_dir):
+    """Get progress, aggregating across shards for DP jobs."""
+    if not run_tag:
+        return None, None, None, None, None, None, None
+    if num_shards > 1:
+        total_completed = 0
+        total_total = 0
+        total_errors = 0
+        total_on_disk = 0
+        all_finished = True
+        found_any = False
+        all_accuracies = []
+        agent = None
+        for shard_idx in range(num_shards):
+            shard_tag = f"{run_tag}_shard{shard_idx}"
+            c, t, e, fin, od, acc, ag = get_progress_single(shard_tag, jobs_dir)
+            if c is not None:
+                found_any = True
+                total_completed += c
+                total_total += (t or 0)
+                total_errors += (e or 0)
+                total_on_disk += (od or 0)
+                if acc is not None:
+                    all_accuracies.append(acc)
+                if not fin:
+                    all_finished = False
+                if agent is None and ag:
+                    agent = ag
+        if found_any:
+            avg_acc = (sum(all_accuracies) / len(all_accuracies)) if all_accuracies else None
+            return total_completed, total_total, total_errors, all_finished, total_on_disk, avg_acc, agent
+        return None, None, None, None, None, None, None
+    else:
+        return get_progress_single(run_tag, jobs_dir)
+
+
+def format_elapsed(start_str):
+    try:
+        if start_str == "N/A":
+            return "-", 0
+        st = datetime.fromisoformat(start_str.replace("T", " "))
+        delta = datetime.now() - st
+        secs = int(delta.total_seconds())
+        hours, rem = divmod(secs, 3600)
+        mins, _ = divmod(rem, 60)
+        return f"{hours}h{mins:02d}m", secs
+    except Exception:
+        return "?", 0
+
+
+# ---------------------------------------------------------------------------
+# Unified data collection
+# ---------------------------------------------------------------------------
+
+def collect_job_data(jobs_dir):
+    """Collect all job data into structured dicts.
+
+    Returns (running_data: list[dict], pending_jobs: list[tuple]).
+
+    Per-job work (log header parse + result.json reads) is pure I/O and
+    runs in a thread pool. With N running jobs this reduces wall time
+    from N * per_job_latency to roughly per_job_latency.
+    """
+    all_jobs = get_running_jobs()
+    if not all_jobs:
+        return [], []
+
+    running_raw = [(jid, name, state, start) for jid, name, state, start in all_jobs if state == "RUNNING"]
+    pending = [(jid, name, state, start) for jid, name, state, start in all_jobs if state == "PENDING"]
+
+    if not running_raw:
+        return [], pending
+
+    # Resolve log dirs once — stat-checking EXTRA_LOG_DIRS per-job wastes syscalls.
+    all_log_dirs = [LOGS_DIR] + [d for d in EXTRA_LOG_DIRS if d.exists()]
+
+    def process_one(job):
+        jid, name, state, start_time = job
+        model, bench, run_tag, num_shards = parse_eval_log(jid, name, all_log_dirs)
+        completed, total, invalid_errors, finished, n_on_disk, accuracy, agent = get_progress(run_tag, num_shards, jobs_dir)
+
+        if finished:
+            status = "done"
+        elif completed is not None and total and completed >= total:
+            status = "retry"
+        else:
+            status = "active"
+
+        elapsed, elapsed_secs = format_elapsed(start_time)
+        m_short = model.split("/")[-1] if model and "/" in model else (model or "?")
+        b_short = bench.split("/")[-1] if bench and "/" in bench else (bench or "?")
+
+        is_resume = name.startswith("res_")
+        tags = []
+        if is_resume:
+            tags.append("RES")
+        if num_shards > 1:
+            tags.append(f"{num_shards}x DP")
+
+        # Progress percentage (based on disk for ground truth)
+        if n_on_disk is not None and total and total > 0:
+            progress_pct = n_on_disk / total
+        elif completed is not None and total and total > 0:
+            progress_pct = completed / total
+        else:
+            progress_pct = 0.0
+
+        return {
+            "jid": jid,
+            "job_name": name,
+            "model": m_short,
+            "model_full": model or "?",
+            "bench": b_short,
+            "bench_full": bench or "?",
+            "agent": agent or "?",
+            "run_tag": run_tag,
+            "num_shards": num_shards,
+            "completed": completed,
+            "total": total,
+            "n_on_disk": n_on_disk,
+            "n_invalid_errors": invalid_errors,
+            "accuracy": accuracy,
+            "finished": finished,
+            "elapsed": elapsed,
+            "elapsed_secs": elapsed_secs,
+            "status": status,
+            "tags": tags,
+            "progress_pct": progress_pct,
+            "is_resume": is_resume,
+        }
+
+    max_workers = min(32, max(4, len(running_raw)))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        running_data = list(executor.map(process_one, running_raw))
+
+    return running_data, pending
+
+
+def group_by_benchmark(jobs, sort_key="progress"):
+    """Group jobs by benchmark. Returns an ordered list of
+    (category, bench_name, jobs) tuples.
+
+    Ordering: CORE_BENCHMARKS (in declared order), then OOD_BENCHMARKS
+    (in declared order), then unknown benchmarks alphabetically.
+
+    sort_key (applied within each group): 'progress' (default), 'elapsed',
+    'model', 'errors'.
+    """
+    groups = defaultdict(list)
+    for job in jobs:
+        groups[job["bench"]].append(job)
+
+    # Sort within each group
+    for bench in groups:
+        if sort_key == "elapsed":
+            groups[bench].sort(key=lambda j: j["elapsed_secs"], reverse=True)
+        elif sort_key == "model":
+            groups[bench].sort(key=lambda j: j["model"].lower())
+        elif sort_key == "errors":
+            groups[bench].sort(key=lambda j: (j["n_invalid_errors"] or 0), reverse=True)
+        else:  # progress (default)
+            groups[bench].sort(key=lambda j: j["progress_pct"], reverse=True)
+
+    ordered = []
+    for b in CORE_BENCHMARKS:
+        if b in groups:
+            ordered.append(("core", b, groups[b]))
+    for b in OOD_BENCHMARKS:
+        if b in groups:
+            ordered.append(("ood", b, groups[b]))
+    known = set(CORE_BENCHMARKS) | set(OOD_BENCHMARKS)
+    for b in sorted(groups.keys()):
+        if b not in known:
+            ordered.append(("other", b, groups[b]))
+    return ordered
+
+
+def get_pending_reasons():
+    """Get pending job reasons from squeue."""
+    result = subprocess.run(
+        ["squeue", "-u", os.environ["USER"], "--format=%.10i %.8T %R", "--noheader"],
+        capture_output=True, text=True,
+    )
+    reasons = {}
+    for line in result.stdout.strip().split("\n"):
+        parts = line.split(None, 2)
+        if len(parts) >= 3 and parts[1].strip() == "PENDING":
+            reasons[parts[0].strip()] = parts[2].strip()
+    return reasons
+
+
+# ---------------------------------------------------------------------------
+# Default text mode (enhanced with grouping)
+# ---------------------------------------------------------------------------
+
+def print_default(running_data, pending, sort_key="progress"):
+    if not running_data and not pending:
+        print("No jobs in queue.")
+        return
+
+    if running_data:
+        groups = group_by_benchmark(running_data, sort_key)
+
+        # Count statuses
+        status_counts = defaultdict(int)
+        for j in running_data:
+            status_counts[j["status"]] += 1
+
+        print(f"\nRUNNING ({len(running_data)}):")
+
+        header = f"  {'JID':>8s}  {'Progress':>10s}  {'On Disk':>8s}  {'Acc':>6s}  {'Errors':>6s}  {'Status':>6s}  {'Elapsed':>8s}  {'Agent':<14s}  Model"
+        sep = "  " + "-" * (len(header) - 2)
+
+        current_category = None
+        for category, bench_name, jobs in groups:
+            if category != current_category:
+                label = CATEGORY_LABELS.get(category, category.upper())
+                bar = "=" * 80
+                print(f"\n  {bar}")
+                print(f"  {label}")
+                print(f"  {bar}")
+                current_category = category
+
+            # Per-benchmark summary
+            n_active = sum(1 for j in jobs if j["status"] == "active")
+            n_retry = sum(1 for j in jobs if j["status"] == "retry")
+            n_done = sum(1 for j in jobs if j["status"] == "done")
+            parts = []
+            if n_active:
+                parts.append(f"{n_active} active")
+            if n_retry:
+                parts.append(f"{n_retry} retry")
+            if n_done:
+                parts.append(f"{n_done} done")
+            status_str = ", ".join(parts) if parts else "0 jobs"
+
+            print(f"\n  === {bench_name} ({len(jobs)} jobs: {status_str}) ===")
+            print(header)
+            print(sep)
+
+            for j in jobs:
+                progress = f"{j['completed']}/{j['total']}" if j["completed"] is not None else "-"
+                on_disk = f"{j['n_on_disk']}/{j['total']}" if j["n_on_disk"] is not None and j["total"] else "-"
+                acc = f"{j['accuracy']:.1%}" if j["accuracy"] is not None else "-"
+                errors = str(j["n_invalid_errors"]) if j["n_invalid_errors"] is not None else "-"
+                tag_str = f" [{', '.join(j['tags'])}]" if j["tags"] else ""
+                print(f"  {j['jid']:>8s}  {progress:>10s}  {on_disk:>8s}  {acc:>6s}  {errors:>6s}  {j['status']:>6s}  {j['elapsed']:>8s}  {j['agent']:<14s}  {j['model']}{tag_str}")
+
+    if pending:
+        reasons = get_pending_reasons()
+        print(f"\n  PENDING ({len(pending)}):")
+        print(f"  {'JID':>8s}  Reason")
+        print("  " + "-" * 38)
+        for jid, name, state, start in pending:
+            reason = reasons.get(jid, "?")
+            print(f"  {jid:>8s}  {reason}")
+
+    # Summary line
+    status_counts = defaultdict(int)
+    for j in running_data:
+        status_counts[j["status"]] += 1
+    parts = []
+    for s in ["active", "retry", "done"]:
+        if status_counts[s]:
+            parts.append(f"{status_counts[s]} {s}")
+    status_detail = f" ({', '.join(parts)})" if parts else ""
+    print(f"\n  Total: {len(running_data)} running{status_detail}, {len(pending)} pending\n")
+
+
+# ---------------------------------------------------------------------------
+# Rich Live dashboard
+# ---------------------------------------------------------------------------
+
+def run_live_dashboard(jobs_dir, interval, sort_key="progress", compact=False,
+                       benchmark_filter=None, page_mode=False):
+    from rich.console import Console, Group
+    from rich.table import Table
+    from rich.live import Live
+    from rich.text import Text
+    from rich.panel import Panel
+    from rich.progress_bar import ProgressBar
+
+    console = Console()
+    page_idx = [0]  # mutable for closure
+
+    STATUS_STYLES = {
+        "active": "green",
+        "active_res": "purple",
+        "retry": "yellow",
+        "done": "dim",
+    }
+
+    def _job_style(j):
+        """Get style key for a job: distinguish resume (cyan) from fresh (green) for active jobs."""
+        if j["status"] == "active" and j["is_resume"]:
+            return "active_res"
+        return j["status"]
+
+    def make_progress_bar(pct, style_key):
+        """Create a colored progress bar."""
+        color = STATUS_STYLES.get(style_key, "white")
+        bar = ProgressBar(total=100, completed=int(pct * 100), width=10,
+                          complete_style=color, finished_style=color)
+        return bar
+
+    def render():
+        running_data, pending = collect_job_data(jobs_dir)
+        now = datetime.now().strftime("%H:%M:%S")
+
+        renderables = []
+
+        # Header
+        n_fresh = sum(1 for j in running_data if j["status"] == "active" and not j["is_resume"])
+        n_resume = sum(1 for j in running_data if j["status"] == "active" and j["is_resume"])
+        n_retry = sum(1 for j in running_data if j["status"] == "retry")
+        n_done = sum(1 for j in running_data if j["status"] == "done")
+        header_parts = [
+            f"[bold]EVAL DASHBOARD[/bold]",
+            f"[green]{n_fresh} fresh[/green]" if n_fresh else None,
+            f"[purple]{n_resume} resume[/purple]" if n_resume else None,
+            f"[yellow]{n_retry} retry[/yellow]" if n_retry else None,
+            f"[dim]{n_done} done[/dim]" if n_done else None,
+            f"{len(pending)} pending" if pending else None,
+            f"[dim]Updated {now}[/dim]",
+        ]
+        header_text = "  |  ".join(p for p in header_parts if p)
+        renderables.append(Text.from_markup(header_text))
+        renderables.append(Text(""))
+
+        if not running_data and not pending:
+            renderables.append(Text("No jobs in queue.", style="dim"))
+            return Group(*renderables)
+
+        # Group by benchmark (returns ordered list of (category, bench, jobs))
+        groups = group_by_benchmark(running_data, sort_key)
+
+        # Apply benchmark filter
+        if benchmark_filter:
+            groups = [(c, b, jobs) for c, b, jobs in groups
+                      if benchmark_filter.lower() in b.lower()]
+
+        # Page mode: show one benchmark at a time, rotating each refresh
+        if page_mode and groups:
+            total_pages = len(groups)
+            idx = page_idx[0] % total_pages
+            groups = [groups[idx]]
+            page_idx[0] += 1
+            renderables.append(Text.from_markup(
+                f"[dim]Page {idx + 1}/{total_pages}[/dim]"))
+            renderables.append(Text(""))
+
+        current_category = None
+        for category, bench_name, jobs in groups:
+            if category != current_category:
+                label = CATEGORY_LABELS.get(category, category.upper())
+                style = {"core": "bold magenta", "ood": "bold blue",
+                         "other": "bold white"}.get(category, "bold")
+                renderables.append(Text.from_markup(
+                    f"[{style}]━━━ {label} ━━━[/{style}]"))
+                renderables.append(Text(""))
+                current_category = category
+            # Per-benchmark stats
+            b_fresh = sum(1 for j in jobs if j["status"] == "active" and not j["is_resume"])
+            b_resume = sum(1 for j in jobs if j["status"] == "active" and j["is_resume"])
+            b_retry = sum(1 for j in jobs if j["status"] == "retry")
+            b_done = sum(1 for j in jobs if j["status"] == "done")
+            b_errors = sum(j["n_invalid_errors"] or 0 for j in jobs)
+            avg_pct = sum(j["progress_pct"] for j in jobs) / len(jobs) if jobs else 0
+
+            status_parts = []
+            if b_fresh:
+                status_parts.append(f"[green]{b_fresh} fresh[/green]")
+            if b_resume:
+                status_parts.append(f"[purple]{b_resume} resume[/purple]")
+            if b_retry:
+                status_parts.append(f"[yellow]{b_retry} retry[/yellow]")
+            if b_done:
+                status_parts.append(f"[dim]{b_done} done[/dim]")
+            error_str = f"  [red]{b_errors} err[/red]" if b_errors > 10 else (f"  {b_errors} err" if b_errors else "")
+
+            title = (f"[bold cyan]{bench_name}[/bold cyan]  "
+                     f"{len(jobs)} jobs | {' | '.join(status_parts)}{error_str} | "
+                     f"avg {avg_pct:.0%}")
+
+            # In compact mode, only show active jobs in the table
+            display_jobs = [j for j in jobs if j["status"] == "active"] if compact else jobs
+            n_hidden = len(jobs) - len(display_jobs)
+
+            table = Table(
+                show_header=True, header_style="bold", box=None,
+                padding=(0, 1), expand=True,
+            )
+            table.add_column("JID", style="dim", width=7, justify="right")
+            table.add_column("Progress", width=8, justify="right")
+            if not compact:
+                table.add_column("Bar", width=12)
+            table.add_column("Disk", width=8, justify="right")
+            table.add_column("Acc", width=6, justify="right")
+            table.add_column("Err", width=4, justify="right")
+            table.add_column("Status", width=6, justify="right")
+            table.add_column("Elapsed", width=6, justify="right")
+            table.add_column("Agent", width=14, no_wrap=True)
+            table.add_column("Model", no_wrap=False, ratio=1)
+
+            for j in display_jobs:
+                skey = _job_style(j)
+                style = STATUS_STYLES.get(skey, "")
+                progress = f"{j['completed']}/{j['total']}" if j["completed"] is not None else "-"
+                on_disk = f"{j['n_on_disk']}/{j['total']}" if j["n_on_disk"] is not None and j["total"] else "-"
+                acc = f"{j['accuracy']:.1%}" if j["accuracy"] is not None else "-"
+                errors = str(j["n_invalid_errors"]) if j["n_invalid_errors"] is not None else "-"
+                error_style = "red bold" if (j["n_invalid_errors"] or 0) > 10 else ""
+                tag_str = f" [{', '.join(j['tags'])}]" if j["tags"] else ""
+                model_display = j["model_full"]
+
+                row = [
+                    j["jid"],
+                    Text(progress, style=style),
+                ]
+                if not compact:
+                    row.append(make_progress_bar(j["progress_pct"], skey))
+                row.extend([
+                    Text(on_disk, style=style),
+                    Text(acc, style="cyan" if j["accuracy"] is not None else style),
+                    Text(errors, style=error_style or style),
+                    Text("resume" if skey == "active_res" else j["status"], style=style),
+                    Text(j["elapsed"], style=style),
+                    Text(j["agent"], style=style),
+                    Text(f"{model_display}{tag_str}", style=style),
+                ])
+                table.add_row(*row)
+
+            renderables.append(Text.from_markup(title))
+            if display_jobs:
+                renderables.append(table)
+            if n_hidden:
+                renderables.append(Text.from_markup(
+                    f"  [dim]... {n_hidden} done/retry job(s) hidden (use without --compact to show)[/dim]"))
+            renderables.append(Text(""))
+
+        # Pending section
+        if pending:
+            reasons = get_pending_reasons()
+            pending_lines = []
+            for jid, name, state, start in pending:
+                reason = reasons.get(jid, "?")
+                pending_lines.append(f"  {jid}  {reason}")
+            pending_text = "\n".join(pending_lines[:10])
+            if len(pending) > 10:
+                pending_text += f"\n  ... and {len(pending) - 10} more"
+            renderables.append(Panel(
+                pending_text,
+                title=f"[dim]PENDING ({len(pending)})[/dim]",
+                border_style="dim",
+                expand=False,
+            ))
+
+        # Footer
+        tags = []
+        if compact:
+            tags.append("compact")
+        if page_mode:
+            tags.append("paging")
+        if benchmark_filter:
+            tags.append(f"filter: {benchmark_filter}")
+        extra = f"  |  {', '.join(tags)}" if tags else ""
+        renderables.append(Text.from_markup(
+            f"[dim]Ctrl+C to exit  |  Refreshing every {interval}s  |  "
+            f"Sort: {sort_key}{extra}[/dim]"
+        ))
+
+        return Group(*renderables)
+
+    try:
+        with Live(render(), console=console, refresh_per_second=1,
+                  vertical_overflow="ellipsis") as live:
+            while True:
+                time.sleep(interval)
+                live.update(render())
+    except KeyboardInterrupt:
+        console.print("\n[dim]Dashboard stopped.[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Check progress of running eval jobs on Jupiter.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+examples:
+  %(prog)s                        # grouped text output
+  %(prog)s --live                 # rich live dashboard
+  %(prog)s --live -i 3            # 3s refresh interval
+  %(prog)s --sort elapsed         # sort by elapsed time
+  %(prog)s --sort errors          # sort by error count
+  %(prog)s --live --compact       # live, hide done/retry + no bar (fits more)
+  %(prog)s --live -b tb2          # live, only terminal_bench_2
+  %(prog)s --live --page          # live, rotate one benchmark per refresh
+""",
+    )
+    parser.add_argument(
+        "--live", "-w", action="store_true",
+        help="Launch Rich live dashboard (auto-refreshing)",
+    )
+    parser.add_argument(
+        "--interval", "-i", type=int, default=5,
+        help="Refresh interval in seconds for --live mode (default: 5, min: 3)",
+    )
+    parser.add_argument(
+        "--sort", "-s", choices=["progress", "elapsed", "model", "errors"],
+        default="progress",
+        help="Sort order within benchmark groups (default: progress)",
+    )
+    parser.add_argument(
+        "--compact", "-c", action="store_true",
+        help="In --live mode, hide done/retry jobs and progress bar (fits more rows)",
+    )
+    parser.add_argument(
+        "--benchmark", "-b", type=str, default=None,
+        help="Filter to benchmarks matching this substring (e.g. 'tb2', 'dev_set')",
+    )
+    parser.add_argument(
+        "--page", "-p", action="store_true",
+        help="In --live mode, show one benchmark per page, rotating each refresh",
+    )
+    parser.add_argument(
+        "--jobs-dir", type=Path, default=DEFAULT_JOBS_DIR,
+        help=f"Path to eval jobs directory (default: {DEFAULT_JOBS_DIR})",
+    )
+    parser.add_argument(
+        "--logs-dir", type=Path, default=LOGS_DIR,
+        help=f"Path to eval logs directory (default: {LOGS_DIR})",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    global LOGS_DIR
+    LOGS_DIR = args.logs_dir
+
+    if args.live:
+        interval = max(3, args.interval)
+        run_live_dashboard(args.jobs_dir, interval, sort_key=args.sort,
+                           compact=args.compact, benchmark_filter=args.benchmark,
+                           page_mode=args.page)
+    else:
+        running_data, pending = collect_job_data(args.jobs_dir)
+        if args.benchmark:
+            running_data = [j for j in running_data
+                           if args.benchmark.lower() in j["bench"].lower()]
+        print_default(running_data, pending, sort_key=args.sort)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/check_progress.py
+++ b/eval/check_progress.py
@@ -24,6 +24,51 @@ REPO_DIR = Path(__file__).resolve().parent.parent
 LOGS_DIR = REPO_DIR / "eval" / "logs"
 EXTRA_LOG_DIRS: list[Path] = []
 DEFAULT_JOBS_DIR = REPO_DIR / "jobs"
+CLUSTERS_DIR = REPO_DIR / "eval" / "clusters"
+
+
+def _read_cluster_jobs_dir(yaml_path: Path) -> Path | None:
+    """Pull paths.eval_jobs_dir from a cluster YAML, expanding $VARS and ~."""
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        with open(yaml_path) as f:
+            cfg = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+    raw = (cfg.get("paths") or {}).get("eval_jobs_dir")
+    if not isinstance(raw, str):
+        return None
+    return Path(os.path.expandvars(os.path.expanduser(raw)))
+
+
+def resolve_jobs_dir(cli_jobs_dir: Path | None,
+                     cluster_config: Path | None) -> Path:
+    """Resolve the eval jobs dir. Precedence:
+
+      1. --jobs-dir CLI flag (explicit override)
+      2. $EVAL_JOBS_DIR env var
+      3. --cluster-config YAML's paths.eval_jobs_dir
+      4. Auto-scan eval/clusters/*.yaml; pick first whose eval_jobs_dir exists
+      5. DEFAULT_JOBS_DIR (legacy fallback)
+    """
+    if cli_jobs_dir is not None:
+        return cli_jobs_dir
+    env_dir = os.environ.get("EVAL_JOBS_DIR")
+    if env_dir:
+        return Path(env_dir)
+    if cluster_config is not None:
+        p = _read_cluster_jobs_dir(cluster_config)
+        if p is not None:
+            return p
+    if CLUSTERS_DIR.is_dir():
+        for yml in sorted(CLUSTERS_DIR.glob("*.yaml")):
+            p = _read_cluster_jobs_dir(yml)
+            if p is not None and p.is_dir():
+                return p
+    return DEFAULT_JOBS_DIR
 
 # Benchmark ordering for display. Core benchmarks render first in the listed
 # order, then OOD benchmarks in the listed order, then anything else
@@ -95,6 +140,9 @@ def parse_eval_log(jid, job_name, all_log_dirs=None, max_lines=2000):
     is_dp = job_name.startswith("eval_dp_") or job_name.startswith("res_dp_")
     model = bench = run_tag = None
     num_shards = 0
+    n_concurrent = None
+    timeout_mult = None
+    is_resume_log = False  # True if sbatch entered resume code path (line ~829)
     for log in candidates:
         if not log.exists():
             continue
@@ -108,17 +156,39 @@ def parse_eval_log(jid, job_name, all_log_dirs=None, max_lines=2000):
                     bench = line.strip()[9:]
                 elif line.startswith("Run tag: "):
                     run_tag = line.strip()[9:]
+                elif line.startswith("N concurrent: "):
+                    try:
+                        n_concurrent = int(line.strip()[14:])
+                    except ValueError:
+                        pass
+                elif line.startswith("Timeout multiplier: "):
+                    try:
+                        timeout_mult = float(line.strip()[20:])
+                    except ValueError:
+                        pass
                 elif "total shards)" in line:
                     try:
                         num_shards = int(line.split("total shards")[0].split(",")[-1].strip())
                     except (ValueError, IndexError):
                         pass
+                # Resume detection: sbatch prints both lines together (sbatch:829-836)
+                # when entering resume mode. Either line is a sufficient signal.
+                # Job-name-based detection (`res_` prefix) misses jobs submitted
+                # via the orchestrator, which uses sbatch's default --job-name "data".
+                elif (line.startswith("Found existing job dir, resuming:")
+                      or line.startswith("Patching api_base port in config.json")):
+                    is_resume_log = True
                 # Early exit once every expected field is found.
                 # Non-DP jobs never emit "total shards", so don't wait on num_shards.
-                if model and bench and run_tag and (num_shards > 0 or not is_dp):
+                # Don't early-exit on is_resume_log — resume signal appears later
+                # in the log (after dataset locate phase) than the header fields.
+                if (model and bench and run_tag
+                        and n_concurrent is not None and timeout_mult is not None
+                        and (num_shards > 0 or not is_dp)
+                        and is_resume_log):
                     break
         break
-    return model, bench, run_tag, num_shards
+    return model, bench, run_tag, num_shards, n_concurrent, timeout_mult, is_resume_log
 
 
 VALID_ERROR_TYPES = {
@@ -250,7 +320,7 @@ def collect_job_data(jobs_dir):
 
     def process_one(job):
         jid, name, state, start_time = job
-        model, bench, run_tag, num_shards = parse_eval_log(jid, name, all_log_dirs)
+        model, bench, run_tag, num_shards, n_concurrent, timeout_mult, is_resume_log = parse_eval_log(jid, name, all_log_dirs)
         completed, total, invalid_errors, finished, n_on_disk, accuracy, agent = get_progress(run_tag, num_shards, jobs_dir)
 
         if finished:
@@ -264,7 +334,13 @@ def collect_job_data(jobs_dir):
         m_short = model.split("/")[-1] if model and "/" in model else (model or "?")
         b_short = bench.split("/")[-1] if bench and "/" in bench else (bench or "?")
 
-        is_resume = name.startswith("res_")
+        # Resume detection covers two paths:
+        #   1) Job-name prefix `res_` — set when listener creates a sbatch with
+        #      explicit --job-name (older flow).
+        #   2) Slurm-log content match — set when sbatch enters its resume code
+        #      path regardless of job name. The orchestrator submits with the
+        #      default --job-name "data", so name-based detection alone misses it.
+        is_resume = name.startswith("res_") or is_resume_log
         tags = []
         if is_resume:
             tags.append("RES")
@@ -301,6 +377,8 @@ def collect_job_data(jobs_dir):
             "tags": tags,
             "progress_pct": progress_pct,
             "is_resume": is_resume,
+            "n_concurrent": n_concurrent,
+            "timeout_mult": timeout_mult,
         }
 
     max_workers = min(32, max(4, len(running_raw)))
@@ -382,7 +460,7 @@ def print_default(running_data, pending, sort_key="progress"):
 
         print(f"\nRUNNING ({len(running_data)}):")
 
-        header = f"  {'JID':>8s}  {'Progress':>10s}  {'On Disk':>8s}  {'Acc':>6s}  {'Errors':>6s}  {'Status':>6s}  {'Elapsed':>8s}  {'Agent':<14s}  Model"
+        header = f"  {'JID':>8s}  {'Progress':>10s}  {'On Disk':>8s}  {'Acc':>6s}  {'Errors':>6s}  {'Conc':>4s}  {'Tmout':>5s}  {'Status':>6s}  {'Elapsed':>8s}  {'Agent':<14s}  Model"
         sep = "  " + "-" * (len(header) - 2)
 
         current_category = None
@@ -417,8 +495,10 @@ def print_default(running_data, pending, sort_key="progress"):
                 on_disk = f"{j['n_on_disk']}/{j['total']}" if j["n_on_disk"] is not None and j["total"] else "-"
                 acc = f"{j['accuracy']:.1%}" if j["accuracy"] is not None else "-"
                 errors = str(j["n_invalid_errors"]) if j["n_invalid_errors"] is not None else "-"
+                conc = str(j["n_concurrent"]) if j["n_concurrent"] is not None else "-"
+                tmout = f"{j['timeout_mult']:g}x" if j["timeout_mult"] is not None else "-"
                 tag_str = f" [{', '.join(j['tags'])}]" if j["tags"] else ""
-                print(f"  {j['jid']:>8s}  {progress:>10s}  {on_disk:>8s}  {acc:>6s}  {errors:>6s}  {j['status']:>6s}  {j['elapsed']:>8s}  {j['agent']:<14s}  {j['model']}{tag_str}")
+                print(f"  {j['jid']:>8s}  {progress:>10s}  {on_disk:>8s}  {acc:>6s}  {errors:>6s}  {conc:>4s}  {tmout:>5s}  {j['status']:>6s}  {j['elapsed']:>8s}  {j['agent']:<14s}  {j['model']}{tag_str}")
 
     if pending:
         reasons = get_pending_reasons()
@@ -571,6 +651,8 @@ def run_live_dashboard(jobs_dir, interval, sort_key="progress", compact=False,
             table.add_column("Disk", width=8, justify="right")
             table.add_column("Acc", width=6, justify="right")
             table.add_column("Err", width=4, justify="right")
+            table.add_column("Conc", width=4, justify="right")
+            table.add_column("Tmout", width=5, justify="right")
             table.add_column("Status", width=6, justify="right")
             table.add_column("Elapsed", width=6, justify="right")
             table.add_column("Agent", width=14, no_wrap=True)
@@ -584,6 +666,8 @@ def run_live_dashboard(jobs_dir, interval, sort_key="progress", compact=False,
                 acc = f"{j['accuracy']:.1%}" if j["accuracy"] is not None else "-"
                 errors = str(j["n_invalid_errors"]) if j["n_invalid_errors"] is not None else "-"
                 error_style = "red bold" if (j["n_invalid_errors"] or 0) > 10 else ""
+                conc = str(j["n_concurrent"]) if j["n_concurrent"] is not None else "-"
+                tmout = f"{j['timeout_mult']:g}x" if j["timeout_mult"] is not None else "-"
                 tag_str = f" [{', '.join(j['tags'])}]" if j["tags"] else ""
                 model_display = j["model_full"]
 
@@ -597,6 +681,8 @@ def run_live_dashboard(jobs_dir, interval, sort_key="progress", compact=False,
                     Text(on_disk, style=style),
                     Text(acc, style="cyan" if j["accuracy"] is not None else style),
                     Text(errors, style=error_style or style),
+                    Text(conc, style=style),
+                    Text(tmout, style=style),
                     Text("resume" if skey == "active_res" else j["status"], style=style),
                     Text(j["elapsed"], style=style),
                     Text(j["agent"], style=style),
@@ -701,8 +787,15 @@ examples:
         help="In --live mode, show one benchmark per page, rotating each refresh",
     )
     parser.add_argument(
-        "--jobs-dir", type=Path, default=DEFAULT_JOBS_DIR,
-        help=f"Path to eval jobs directory (default: {DEFAULT_JOBS_DIR})",
+        "--jobs-dir", type=Path, default=None,
+        help=("Path to eval jobs directory. If omitted, resolves from "
+              "$EVAL_JOBS_DIR, then --cluster-config, then auto-detects "
+              f"from eval/clusters/*.yaml, then falls back to {DEFAULT_JOBS_DIR}"),
+    )
+    parser.add_argument(
+        "--cluster-config", type=Path, default=None,
+        help="Cluster config YAML to read paths.eval_jobs_dir from "
+             "(e.g. eval/clusters/jupiter.yaml)",
     )
     parser.add_argument(
         "--logs-dir", type=Path, default=LOGS_DIR,
@@ -716,13 +809,15 @@ def main():
     global LOGS_DIR
     LOGS_DIR = args.logs_dir
 
+    jobs_dir = resolve_jobs_dir(args.jobs_dir, args.cluster_config)
+
     if args.live:
         interval = max(3, args.interval)
-        run_live_dashboard(args.jobs_dir, interval, sort_key=args.sort,
+        run_live_dashboard(jobs_dir, interval, sort_key=args.sort,
                            compact=args.compact, benchmark_filter=args.benchmark,
                            page_mode=args.page)
     else:
-        running_data, pending = collect_job_data(args.jobs_dir)
+        running_data, pending = collect_job_data(jobs_dir)
         if args.benchmark:
             running_data = [j for j in running_data
                            if args.benchmark.lower() in j["bench"].lower()]

--- a/eval/check_resume_needed.py
+++ b/eval/check_resume_needed.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Inspect harbor eval job dirs and report which need resume.
+
+Reuses _parse_job_dir + INFRA_ERROR_TYPES + PRESETS + get_active_model_dataset_pairs
+from eval.unified_eval_listener so classification matches the listener's resume scanner.
+
+Usage:
+    # Human-readable table for all jobs across both presets (eval-org dir)
+    python eval/check_resume_needed.py \
+        --jobs-dir /e/data1/datasets/playground/mmlaion/shared/zhuang1_eval_jobs
+
+    # Only show jobs that would resume (skip DONE / IN_FLIGHT / PARTIAL_OK)
+    python eval/check_resume_needed.py --jobs-dir <dir> --needs-resume-only
+
+    # Filter by preset
+    python eval/check_resume_needed.py --jobs-dir <dir> --preset tb2
+
+    # CSV output for orchestrator consumption
+    python eval/check_resume_needed.py --jobs-dir <dir> --csv > /tmp/candidates.csv
+
+    # Permanently exclude run dirs from resume (writes .no-resume marker file).
+    # Rejected dirs are hidden from inspector output by default.
+    python eval/check_resume_needed.py --jobs-dir <dir> --reject <run_tag1> --reject <run_tag2>
+
+    # Bulk-reject every dir currently classified as needs-resume:
+    python eval/check_resume_needed.py --jobs-dir <dir> --reject-needs-resume --yes
+
+    # Show rejected dirs (default: hidden):
+    python eval/check_resume_needed.py --jobs-dir <dir> --show-rejected
+
+Status taxonomy:
+    DONE              n_completed == n_total, infra_errors <= threshold      (no resume)
+    DONE_WITH_ERRORS  n_completed == n_total, infra_errors > threshold       (RESUME)
+    INCOMPLETE        n_completed < n_total, finished_at is None             (RESUME — 12h cap case)
+    PARTIAL           n_completed < n_total, finished_at != None,
+                      infra_errors > threshold                                (RESUME)
+    PARTIAL_OK        n_completed < n_total, finished_at != None,
+                      infra_errors <= threshold                               (no resume — gave up)
+    EARLY_KILL        no result.json, n_total == 0                           (RESUME)
+    IN_FLIGHT         (model, dataset) is currently running in squeue        (no resume — wait)
+    AT_RESUME_LIMIT   total fires >= --max-total-fires (1 orig + 1 resume    (NO RESUME — 24h cap)
+                      = 2 by default), OR resume_count >= --max-resume-count
+    REJECTED          .no-resume marker file present in run dir              (NO RESUME — user-rejected)
+    UNKNOWN           failed to parse                                         (skip)
+
+Total-fires accounting (24h cap):
+    Each original fire + each resume produces one slurm log file
+    (`eval/logs/data_<JID>.out`) with a `Run tag: <run_tag>` line. We count those
+    matches across all logs and combine with `meta.env`'s RESUME_COUNT (which is
+    only updated when sbatch reaches its post-harbor write — SIGTERM-killed jobs
+    don't update it). Effective fire count = max(log-count, resume_count + 1).
+    Default `--max-total-fires 2` enforces the 1-original-plus-1-resume hard cap;
+    bump if you want more headroom or set higher if old logs are pruned.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# Make the listener importable
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+# Import strictly the things we need; the listener's top-level is mostly defs/constants
+from eval.unified_eval_listener import (  # noqa: E402
+    INFRA_ERROR_TYPES,
+    PRESETS,
+    _parse_job_dir,
+    get_active_model_dataset_pairs,
+)
+
+DEFAULT_INFRA_ERROR_THRESHOLD = 10  # matches listener CLI default --resume-error-threshold
+DEFAULT_MAX_RESUME_COUNT = 5  # matches listener CLI default --max-resume-count
+DEFAULT_MAX_TOTAL_FIRES = 2  # 1 original + 1 resume = 24h on a 12h-cap cluster
+
+
+# ---- Status classification ---------------------------------------------------
+
+STATUS_DONE = "DONE"
+STATUS_DONE_WITH_ERRORS = "DONE_WITH_ERRORS"
+STATUS_INCOMPLETE = "INCOMPLETE"
+STATUS_PARTIAL = "PARTIAL"
+STATUS_PARTIAL_OK = "PARTIAL_OK"
+STATUS_EARLY_KILL = "EARLY_KILL"
+STATUS_IN_FLIGHT = "IN_FLIGHT"
+STATUS_AT_RESUME_LIMIT = "AT_RESUME_LIMIT"
+STATUS_REJECTED = "REJECTED"
+STATUS_UNKNOWN = "UNKNOWN"
+
+NEEDS_RESUME = {
+    STATUS_DONE_WITH_ERRORS,
+    STATUS_INCOMPLETE,
+    STATUS_PARTIAL,
+    STATUS_EARLY_KILL,
+}
+
+# Marker file written inside a run dir to permanently exclude it from resume.
+# By default the inspector skips dirs with this marker entirely (they don't
+# appear in the table or CSV). Pass --show-rejected to see them.
+REJECT_MARKER = ".no-resume"
+
+
+def reject_marker_path(job_dir: Path) -> Path:
+    return job_dir / REJECT_MARKER
+
+
+def is_rejected(job_dir: Path) -> bool:
+    return reject_marker_path(job_dir).exists()
+
+
+def mark_rejected(job_dir: Path, reason: str = "") -> bool:
+    """Touch the .no-resume marker. Returns True on first-time mark, False if
+    already marked. Writes reason + UTC timestamp into the file for forensics."""
+    marker = reject_marker_path(job_dir)
+    if marker.exists():
+        return False
+    from datetime import datetime, timezone
+    body = f"# Rejected at {datetime.now(timezone.utc).isoformat()} UTC\n"
+    if reason:
+        body += f"# Reason: {reason}\n"
+    marker.write_text(body)
+    return True
+
+
+def classify(
+    info: Dict,
+    job_dir: Path,
+    active_pairs: Set[Tuple[str, str]],
+    active_run_tags: Dict[str, str],
+    infra_error_threshold: int,
+    max_resume_count: int,
+    max_total_fires: int,
+    n_fires: int,
+) -> str:
+    """Classify a parsed job dir. Mirrors scan_jobs_dir_for_resume's logic
+    but adds IN_FLIGHT, PARTIAL_OK, AT_RESUME_LIMIT for full-spectrum reporting.
+
+    AT_RESUME_LIMIT triggers when EITHER:
+      - resume_count from meta.env >= max_resume_count (matches listener), OR
+      - n_fires (slurm-log count) >= max_total_fires (24h hard cap).
+    The latter is robust against SIGTERM-killed jobs that never wrote meta.env.
+    """
+    # Active by run-tag → IN_FLIGHT (covers the case where meta.env hasn't been
+    # written yet; the listener's main loop also does this via active_pairs).
+    if info["run_tag"] in active_run_tags:
+        return STATUS_IN_FLIGHT
+    # Active by (model, dataset) pair from squeue.
+    if info["hf_model"] and info["dataset"]:
+        if (info["hf_model"], info["dataset"]) in active_pairs:
+            return STATUS_IN_FLIGHT
+
+    if info["resume_count"] >= max_resume_count:
+        return STATUS_AT_RESUME_LIMIT
+    if n_fires >= max_total_fires:
+        return STATUS_AT_RESUME_LIMIT
+
+    n_completed = info["n_completed"]
+    n_total = info["n_total"]
+    finished_at = info["finished_at"]
+    infra_errors = info["infra_errors"]
+
+    if n_total == 0 and not (job_dir / "result.json").exists():
+        return STATUS_EARLY_KILL
+
+    if n_completed < n_total and finished_at is None:
+        return STATUS_INCOMPLETE
+
+    if n_completed < n_total and finished_at is not None:
+        if infra_errors > infra_error_threshold:
+            return STATUS_PARTIAL
+        return STATUS_PARTIAL_OK
+
+    if n_total > 0 and n_completed == n_total:
+        if infra_errors > infra_error_threshold:
+            return STATUS_DONE_WITH_ERRORS
+        return STATUS_DONE
+
+    return STATUS_UNKNOWN
+
+
+# ---- Slurm-log fire count ---------------------------------------------------
+
+def build_run_tag_fire_index(log_dir: Path) -> Dict[str, List[str]]:
+    """Walk eval/logs/data_*.out, return run_tag -> [JID, ...]. Count = len(list).
+
+    A run_tag appears once per fire. Original fire + each resume each produce
+    one slurm log. Hits the first ~200 lines of each log to find the
+    `Run tag: <run_tag>` line written near sbatch start.
+    """
+    index: Dict[str, List[str]] = {}
+    if not log_dir.is_dir():
+        return index
+    for f in log_dir.glob("data_*.out"):
+        # JID is the suffix after "data_" and before ".out"
+        try:
+            jid = f.stem.split("_", 1)[1]
+        except IndexError:
+            jid = f.stem
+        try:
+            with open(f, "r", errors="replace") as fh:
+                for i, line in enumerate(fh):
+                    if i > 200:
+                        break
+                    if line.startswith("Run tag: "):
+                        rt = line[len("Run tag: "):].strip()
+                        if rt:
+                            index.setdefault(rt, []).append(jid)
+                        break
+        except (OSError, IOError):
+            continue
+    return index
+
+
+def fires_for_run_tag(index: Dict[str, List[str]], run_tag: str, resume_count: int) -> int:
+    """Effective fire count for a run_tag.
+
+    Combines two sources, taking the max so we err on the conservative side
+    (more fires counted = more likely to hit the hard cap, fail safe):
+      * log_count: number of `data_*.out` slurm logs whose `Run tag: <X>` line
+        matches. Truth source IF logs aren't pruned.
+      * rc_count: meta.env's RESUME_COUNT + 1. RESUME_COUNT is the number of
+        prior fires that reached sbatch line ~1108; the +1 reflects whichever
+        fire most recently wrote the value. Undercounts if SIGTERM kills the
+        sbatch before line ~1108 (the typical 12h-cap scenario).
+      * floor of 1: a parsed run dir means at least one fire happened, even
+        if both log + meta.env signals are missing (logs pruned, meta.env not
+        written). Prevents a 0-count classification of an obviously-fired dir.
+    """
+    log_count = len(index.get(run_tag, []))
+    rc_count = (resume_count or 0) + 1
+    return max(log_count, rc_count, 1)
+
+
+# ---- Preset / dataset prefix helpers ----------------------------------------
+
+def preset_dataset_prefixes(preset_filter: Optional[str]) -> List[Tuple[str, str]]:
+    """Return [(preset_name, dir_prefix), ...]. dir_prefix matches scan_jobs_dir_for_resume's
+    normalization: dataset short name with hyphens/dots → underscores, plus trailing '_'."""
+    out: List[Tuple[str, str]] = []
+    for name, cfg in PRESETS.items():
+        if preset_filter and name != preset_filter:
+            continue
+        for ds in cfg.get("datasets", []):
+            ds_short = ds.split("/")[-1] if "/" in ds else ds
+            ds_safe = ds_short.replace("-", "_").replace(".", "_")
+            out.append((name, f"{ds_safe}_"))
+    return out
+
+
+def detect_preset(run_tag: str, prefix_map: List[Tuple[str, str]]) -> Optional[str]:
+    for name, prefix in prefix_map:
+        if run_tag.startswith(prefix):
+            return name
+    return None
+
+
+# ---- Main scan loop ---------------------------------------------------------
+
+def scan(
+    jobs_dirs: List[Path],
+    preset_filter: Optional[str],
+    infra_error_threshold: int,
+    max_resume_count: int,
+    max_total_fires: int,
+    log_dir: str,
+    show_rejected: bool = False,
+) -> List[Dict]:
+    """Walk each --jobs-dir, classify every dir matching a preset prefix.
+
+    Rejected dirs (marked with REJECT_MARKER) are excluded by default; pass
+    show_rejected=True to include them with status=REJECTED.
+
+    Returns a list of result dicts (sorted: needs-resume first, then by run_tag).
+    """
+    prefix_map = preset_dataset_prefixes(preset_filter)
+    if not prefix_map:
+        sys.stderr.write(f"ERROR: no presets matched '{preset_filter}'\n")
+        sys.exit(2)
+
+    # Pull active SLURM state once
+    active_models, active_pairs, active_run_tags = get_active_model_dataset_pairs(log_dir=log_dir)
+
+    # Build run_tag → [JIDs] index from slurm logs once (24h-cap accounting)
+    fire_index = build_run_tag_fire_index(Path(log_dir))
+
+    rows: List[Dict] = []
+    n_skipped_rejected = 0
+    for jd in jobs_dirs:
+        if not jd.is_dir():
+            sys.stderr.write(f"WARN: skipping missing jobs-dir {jd}\n")
+            continue
+        for entry in sorted(jd.iterdir()):
+            if not entry.is_dir():
+                continue
+            preset = detect_preset(entry.name, prefix_map)
+            if preset is None:
+                continue
+            info = _parse_job_dir(entry)
+            if info is None:
+                continue
+            rejected = is_rejected(entry)
+            if rejected and not show_rejected:
+                n_skipped_rejected += 1
+                continue
+            n_fires = fires_for_run_tag(fire_index, info["run_tag"], info["resume_count"])
+            fire_jids = ",".join(fire_index.get(info["run_tag"], []))
+            if rejected:
+                status = STATUS_REJECTED
+            else:
+                status = classify(
+                    info, entry, active_pairs, active_run_tags,
+                    infra_error_threshold, max_resume_count,
+                    max_total_fires, n_fires,
+                )
+            slurm_jid = active_run_tags.get(info["run_tag"]) or (info["slurm_job_id"] or "")
+            rows.append({
+                "preset": preset,
+                "status": status,
+                "slurm_jid": slurm_jid,
+                "run_tag": info["run_tag"],
+                "hf_model": info["hf_model"] or "",
+                "dataset": info["dataset"] or "",
+                "n_completed": info["n_completed"],
+                "n_total": info["n_total"],
+                "infra_errors": info["infra_errors"],
+                "total_errors": info["total_errors"],
+                "finished_at": info["finished_at"] or "",
+                "resume_count": info["resume_count"],
+                "n_fires": n_fires,
+                "fire_jids": fire_jids,
+                "db_job_id": info["db_job_id"] or "",
+                "jobs_dir": str(jd),
+            })
+
+    if n_skipped_rejected:
+        sys.stderr.write(f"(hidden: {n_skipped_rejected} rejected dir(s); pass --show-rejected to display)\n")
+    rows.sort(key=lambda r: (r["status"] not in NEEDS_RESUME, r["preset"], r["run_tag"]))
+    return rows
+
+
+# ---- Output formatters -------------------------------------------------------
+
+def print_csv(rows: List[Dict]) -> None:
+    fieldnames = [
+        "preset", "status", "slurm_jid", "run_tag", "hf_model", "dataset",
+        "n_completed", "n_total", "infra_errors", "total_errors",
+        "finished_at", "resume_count", "n_fires", "fire_jids",
+        "db_job_id", "jobs_dir",
+    ]
+    w = csv.DictWriter(sys.stdout, fieldnames=fieldnames, lineterminator="\n")
+    w.writeheader()
+    for r in rows:
+        w.writerow(r)
+
+
+def print_table(rows: List[Dict]) -> None:
+    if not rows:
+        print("(no rows)")
+        return
+
+    # Truncate model name for terminal width
+    def short_model(m: str) -> str:
+        if len(m) <= 60:
+            return m
+        return m[:28] + "..." + m[-29:]
+
+    def short_run_tag(t: str) -> str:
+        if len(t) <= 56:
+            return t
+        return t[:24] + "..." + t[-29:]
+
+    header = f"{'STATUS':<17} {'PRESET':<9} {'SLURM':<7} {'PROGRESS':<10} {'INFRA':>5} {'TOT_ERR':>7} {'RC':>2} {'FIRES':>5} {'MODEL':<60}  {'RUN_TAG'}"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        prog = f"{r['n_completed']}/{r['n_total']}"
+        print(
+            f"{r['status']:<17} "
+            f"{r['preset']:<9} "
+            f"{(r['slurm_jid'] or '-'):<7} "
+            f"{prog:<10} "
+            f"{r['infra_errors']:>5} "
+            f"{r['total_errors']:>7} "
+            f"{r['resume_count']:>2} "
+            f"{r['n_fires']:>5} "
+            f"{short_model(r['hf_model']):<60}  "
+            f"{short_run_tag(r['run_tag'])}"
+        )
+
+    # Summary by status
+    print()
+    print("Summary:")
+    counts: Dict[str, int] = {}
+    for r in rows:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    for s in sorted(counts.keys()):
+        marker = " (RESUME)" if s in NEEDS_RESUME else ""
+        print(f"  {s:<17} {counts[s]:>4}{marker}")
+
+
+# ---- CLI --------------------------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Inspect harbor eval job dirs and report resume status.")
+    p.add_argument(
+        "--jobs-dir", action="append", required=True,
+        help="Path to harbor jobs dir (repeatable).",
+    )
+    p.add_argument(
+        "--preset", default=None,
+        help=f"Filter by preset. Choices: {', '.join(PRESETS.keys())}. Default: all.",
+    )
+    p.add_argument(
+        "--needs-resume-only", action="store_true",
+        help="Drop rows that don't need resume (DONE / IN_FLIGHT / PARTIAL_OK / AT_RESUME_LIMIT).",
+    )
+    p.add_argument(
+        "--infra-error-threshold", type=int, default=DEFAULT_INFRA_ERROR_THRESHOLD,
+        help="Min infra errors to trigger PARTIAL/DONE_WITH_ERRORS resume. Default: 10 (matches listener).",
+    )
+    p.add_argument(
+        "--max-resume-count", type=int, default=DEFAULT_MAX_RESUME_COUNT,
+        help="Treat resume_count (from meta.env) >= this as AT_RESUME_LIMIT. Default: 5.",
+    )
+    p.add_argument(
+        "--max-total-fires", type=int, default=DEFAULT_MAX_TOTAL_FIRES,
+        help=("Treat n_fires (slurm-log count, robust to SIGTERM) >= this as AT_RESUME_LIMIT. "
+              "Default: 2 (1 original + 1 resume = 24h hard cap on a 12h-walltime cluster)."),
+    )
+    p.add_argument(
+        "--log-dir", default="eval/logs",
+        help="Slurm log dir (parsed for active model+dataset+run_tag). Default: eval/logs.",
+    )
+    p.add_argument(
+        "--csv", action="store_true",
+        help="Emit CSV instead of human-readable table.",
+    )
+    p.add_argument(
+        "--reject", action="append", default=[], metavar="RUN_TAG",
+        help=("Mark a run dir as rejected (writes .no-resume marker file). "
+              "Repeatable. Rejected dirs are hidden from inspector output by default. "
+              "Specify either bare run_tag (search every --jobs-dir) or "
+              "absolute path to the run dir."),
+    )
+    p.add_argument(
+        "--reject-needs-resume", action="store_true",
+        help=("Reject ALL run dirs currently classified as needs-resume "
+              "(DONE_WITH_ERRORS / INCOMPLETE / PARTIAL / EARLY_KILL). "
+              "Useful for nuking legacy candidates in bulk."),
+    )
+    p.add_argument(
+        "--reject-reason", default="",
+        help="Free-form reason recorded in the marker file (used with --reject / --reject-needs-resume).",
+    )
+    p.add_argument(
+        "--show-rejected", action="store_true",
+        help="Include rejected dirs in the output (status=REJECTED). "
+             "By default rejected dirs are hidden entirely.",
+    )
+    p.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip confirmation prompt for bulk --reject-needs-resume.",
+    )
+    args = p.parse_args()
+
+    jobs_dirs = [Path(x).resolve() for x in args.jobs_dir]
+
+    # --- Reject handling --------------------------------------------------
+    # Two modes:
+    #   1) --reject <run_tag> [--reject ...]  → reject those run_tags directly,
+    #      skip the scan, exit. Path-form (absolute) is also accepted.
+    #   2) --reject-needs-resume              → scan first, reject every row
+    #      currently classified as needing resume.
+
+    if args.reject and not args.reject_needs_resume:
+        n_marked = 0
+        n_already = 0
+        n_missing = 0
+        for ident in args.reject:
+            target: Optional[Path] = None
+            ip = Path(ident)
+            if ip.is_absolute() and ip.is_dir():
+                target = ip
+            else:
+                # Search each --jobs-dir for a matching run dir
+                for jd in jobs_dirs:
+                    cand = jd / ident
+                    if cand.is_dir():
+                        target = cand
+                        break
+            if target is None:
+                sys.stderr.write(f"WARN: run_tag not found in any --jobs-dir: {ident}\n")
+                n_missing += 1
+                continue
+            if mark_rejected(target, reason=args.reject_reason):
+                print(f"REJECTED  {target}")
+                n_marked += 1
+            else:
+                print(f"already-rejected  {target}")
+                n_already += 1
+        print(f"\nDone: {n_marked} newly rejected, {n_already} already rejected, {n_missing} missing.",
+              file=sys.stderr)
+        return 0 if n_missing == 0 else 1
+
+    rows = scan(
+        jobs_dirs=jobs_dirs,
+        preset_filter=args.preset,
+        infra_error_threshold=args.infra_error_threshold,
+        max_resume_count=args.max_resume_count,
+        max_total_fires=args.max_total_fires,
+        log_dir=args.log_dir,
+        show_rejected=args.show_rejected,
+    )
+
+    if args.reject_needs_resume:
+        targets = [r for r in rows if r["status"] in NEEDS_RESUME]
+        if not targets:
+            print("No needs-resume rows to reject.", file=sys.stderr)
+            return 0
+        print(f"About to reject {len(targets)} run dir(s):", file=sys.stderr)
+        for r in targets:
+            print(f"  {r['status']:18s} {r['preset']:8s} {r['run_tag']}", file=sys.stderr)
+        if not args.yes and not _confirm_destructive():
+            print("Aborted.", file=sys.stderr)
+            return 1
+        n_marked = 0
+        n_already = 0
+        for r in targets:
+            target = Path(r["jobs_dir"]) / r["run_tag"]
+            if mark_rejected(target, reason=args.reject_reason or "bulk --reject-needs-resume"):
+                print(f"REJECTED  {target}")
+                n_marked += 1
+            else:
+                n_already += 1
+        print(f"\nDone: {n_marked} newly rejected, {n_already} already rejected.", file=sys.stderr)
+        return 0
+
+    if args.needs_resume_only:
+        rows = [r for r in rows if r["status"] in NEEDS_RESUME]
+
+    if args.csv:
+        print_csv(rows)
+    else:
+        print_table(rows)
+    return 0
+
+
+def _confirm_destructive() -> bool:
+    """Prompt user for confirmation when --reject-needs-resume affects multiple dirs."""
+    try:
+        ans = input("Proceed? [y/N] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return ans in ("y", "yes")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/checkin.py
+++ b/eval/checkin.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Check-in dashboard: 'what's changed since I last looked?'
+
+Shows newly-ended jobs, jobs about to hit walltime, with a per-row
+RESUME / UPLOAD / WAIT recommendation. Persists last-seen state in
+`eval/.local_notes/checkin_state.json`.
+
+Usage:
+    python eval/checkin.py                       # show diff + commit state
+    python eval/checkin.py --no-commit           # show diff, don't update state
+    python eval/checkin.py --reset               # forget all state
+    python eval/checkin.py --warn-elapsed-h 10   # flag RUNNING jobs > 10h elapsed
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "eval"))
+sys.path.insert(0, str(REPO / "database" / "unified_db"))
+from eval.check_resume_needed import scan  # noqa: E402
+
+DEFAULT_JOBS_DIR = "/e/data1/datasets/playground/mmlaion/shared/zhuang1_eval_jobs"
+STATE_FILE = REPO / "eval" / ".local_notes" / "checkin_state.json"
+DEFAULT_LOG_DIR = "eval/logs"
+WALLTIME_CAP_H = 12  # SLURM walltime cap on Jupiter
+
+# Exception types user does NOT want resumes to retry (these dominate failures
+# but resume can't fix them — the model just can't do those tasks)
+USER_EXCLUDED_EXC = {
+    "SummarizationTimeoutError",
+    "AgentTimeoutError",
+    "ContextLengthExceededError",
+}
+TRUE_INFRA_EXC = {
+    "DaytonaError",
+    "DaytonaAuthenticationError",
+    "DaytonaNotFoundError",
+    "RewardFileNotFoundError",
+    "RewardFileEmptyError",
+    "EnvironmentSetupError",
+    "AgentSetupError",
+    "EngineError",
+    "VerifierTimeoutError",
+}
+
+
+def _now() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def db_finished_run_tags(run_tags: List[str]) -> Dict[str, str]:
+    """Return {run_tag: 'Finished'|'Started'|...} for run_tags found in sandbox_jobs.
+
+    Uses a single batched query. Empty dict if Supabase env not set.
+    """
+    if not run_tags or not os.environ.get("SUPABASE_URL"):
+        return {}
+    try:
+        from supabase import create_client
+        sb = create_client(
+            os.environ["SUPABASE_URL"],
+            os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ["SUPABASE_ANON_KEY"],
+        )
+    except Exception:
+        return {}
+
+    out: Dict[str, str] = {}
+    # Batch in chunks of 50 to avoid URL-length limits
+    for i in range(0, len(run_tags), 50):
+        batch = run_tags[i:i + 50]
+        try:
+            r = sb.table("sandbox_jobs").select("job_name,job_status").in_("job_name", batch).execute()
+        except Exception:
+            continue
+        for row in r.data:
+            tag = row.get("job_name")
+            status = row.get("job_status")
+            # Prefer Finished over Started if multiple rows exist for same tag
+            if tag and (tag not in out or status == "Finished"):
+                out[tag] = status
+    return out
+
+
+def _parse_iso(s: str) -> Optional[dt.datetime]:
+    if not s:
+        return None
+    try:
+        return dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def load_state() -> Dict:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())
+    return {"last_check": None, "seen": {}}
+
+
+def save_state(state: Dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def squeue_running() -> Dict[str, Tuple[str, str]]:
+    """Return {jid: (elapsed, time_left)} for current user's RUNNING jobs."""
+    try:
+        out = subprocess.check_output(
+            ["squeue", "-u", os.environ.get("USER", ""),
+             "--format=%i|%T|%M|%L", "--noheader"],
+            text=True, timeout=10,
+        )
+    except Exception:
+        return {}
+    res = {}
+    for line in out.strip().splitlines():
+        parts = line.strip().split("|")
+        if len(parts) >= 4 and parts[1] == "RUNNING":
+            res[parts[0]] = (parts[2], parts[3])
+    return res
+
+
+def _hms_to_hours(s: str) -> float:
+    """Parse SLURM 'D-HH:MM:SS' or 'HH:MM:SS' or 'MM:SS' into hours."""
+    if "-" in s:
+        d, rest = s.split("-", 1)
+        days = int(d)
+    else:
+        days, rest = 0, s
+    parts = rest.split(":")
+    if len(parts) == 3:
+        h, m, sec = (int(x) for x in parts)
+    elif len(parts) == 2:
+        h, m, sec = 0, int(parts[0]), int(parts[1])
+    else:
+        return 0.0
+    return days * 24 + h + m / 60 + sec / 3600
+
+
+def score_dir(run_dir: Path, n_total: int) -> Tuple[int, Dict]:
+    """Compute resume-worth score from per-trial result.json files.
+
+    Score = 3 * missing_tasks + 1 * incomplete_dirs + 1 * true_infra_errors.
+    SummarizationTimeoutError + AgentTimeoutError + ContextLengthExceededError
+    are explicitly NOT counted (model can't do those tasks).
+    """
+    detail = {"missing_tasks": 0, "incomplete_dirs": 0, "true_infra": 0,
+              "summarization": 0, "agent_timeout": 0, "ctx_len": 0,
+              "valid_reward": 0, "n_dirs": 0}
+    if not run_dir.is_dir():
+        return 0, detail
+
+    task_attempted: set = set()
+    for d in run_dir.iterdir():
+        if not d.is_dir() or "__" not in d.name or d.name.startswith("_"):
+            continue
+        m = re.match(r"^(.+)__[A-Za-z0-9]{6,9}$", d.name)
+        if not m:
+            continue
+        task = m.group(1)
+        task_attempted.add(task)
+        detail["n_dirs"] += 1
+        rj = d / "result.json"
+        if not rj.exists():
+            detail["incomplete_dirs"] += 1
+            continue
+        try:
+            data = json.loads(rj.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        exc = (data.get("exception_info") or {}).get("exception_type")
+        vr = data.get("verifier_result") or {}
+        rew = (vr.get("rewards") or {}).get("reward")
+        if exc in TRUE_INFRA_EXC:
+            detail["true_infra"] += 1
+        elif exc == "SummarizationTimeoutError":
+            detail["summarization"] += 1
+        elif exc == "AgentTimeoutError":
+            detail["agent_timeout"] += 1
+        elif exc == "ContextLengthExceededError":
+            detail["ctx_len"] += 1
+        elif rew is not None:
+            detail["valid_reward"] += 1
+
+    detail["missing_tasks"] = max(0, _tasks_in_dataset_for_dir(run_dir, n_total) - len(task_attempted))
+    score = 3 * detail["missing_tasks"] + detail["incomplete_dirs"] + detail["true_infra"]
+    return score, detail
+
+
+def _tasks_in_dataset_for_dir(run_dir: Path, n_total: int) -> int:
+    """Best-effort: total UNIQUE tasks the dataset expects.
+
+    n_total in result.json is total ATTEMPTS expected (= n_tasks * n_attempts).
+    So n_unique_tasks = n_total / n_attempts. If we can't determine n_attempts,
+    fall back to assuming 3.
+    """
+    config = run_dir / "config.json"
+    n_attempts = 3
+    if config.exists():
+        try:
+            data = json.loads(config.read_text())
+            n_attempts = int(data.get("n_attempts") or 3)
+        except (json.JSONDecodeError, OSError, TypeError):
+            pass
+    return max(0, n_total // max(1, n_attempts))
+
+
+def recommend(score: int, detail: Dict, n_fires: int) -> Tuple[str, str]:
+    """Return (action, reason) — action ∈ {RESUME, UPLOAD, WAIT}."""
+    if n_fires >= 2:
+        return "UPLOAD", f"already resumed (n_fires={n_fires}); 1-resume policy → upload"
+    if score >= 3:
+        bits = []
+        if detail["missing_tasks"]: bits.append(f"{detail['missing_tasks']} missing task(s)")
+        if detail["incomplete_dirs"]: bits.append(f"{detail['incomplete_dirs']} incomplete dir(s)")
+        if detail["true_infra"]: bits.append(f"{detail['true_infra']} infra-err")
+        return "RESUME", f"score={score} ({', '.join(bits)})"
+    bits = [f"{detail['summarization']} summarization", f"{detail['agent_timeout']} agent-to",
+            f"{detail['ctx_len']} ctx-len", f"{detail['valid_reward']} valid"]
+    return "UPLOAD", f"score={score} (gap not recoverable; long-tail: {', '.join(b for b in bits if not b.startswith('0'))})"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--jobs-dir", default=DEFAULT_JOBS_DIR)
+    ap.add_argument("--log-dir", default=DEFAULT_LOG_DIR)
+    ap.add_argument("--no-commit", action="store_true",
+                    help="Don't update last-check state (default: commit after run)")
+    ap.add_argument("--reset", action="store_true",
+                    help="Wipe all state and exit")
+    ap.add_argument("--warn-elapsed-h", type=float, default=10.0,
+                    help="Flag RUNNING jobs with elapsed > this many hours (default: 10)")
+    ap.add_argument("--preset", default=None, help="Filter by preset (tb2, swebench, v2)")
+    args = ap.parse_args()
+
+    if args.reset:
+        if STATE_FILE.exists():
+            STATE_FILE.unlink()
+        print(f"State wiped: {STATE_FILE}")
+        return 0
+
+    state = load_state()
+    last_check = state.get("last_check")
+    seen = state.get("seen", {})
+
+    print(f"=== Check-in @ {_now()} ===")
+    if last_check:
+        delta = dt.datetime.now(dt.timezone.utc) - dt.datetime.fromisoformat(last_check)
+        print(f"Last check: {last_check}  (Δ {int(delta.total_seconds()/60)} min ago)")
+    else:
+        print("Last check: (first run)")
+    print()
+
+    rows = scan(
+        jobs_dirs=[Path(args.jobs_dir)],
+        preset_filter=args.preset,
+        infra_error_threshold=10,
+        max_resume_count=5,
+        max_total_fires=2,
+        log_dir=args.log_dir,
+        show_rejected=False,
+    )
+
+    running = squeue_running()
+
+    # Cross-check DB: any run_tag with Finished sandbox_jobs is already-uploaded
+    db_status = db_finished_run_tags([r["run_tag"] for r in rows])
+
+    new_ended = []   # newly classified as needs-action since last check
+    about_to_cap = []
+    in_flight_healthy = []
+    auto_cleared = 0  # count of items skipped because DB row is Finished
+
+    for r in rows:
+        run_tag = r["run_tag"]
+        status = r["status"]
+        prev = seen.get(run_tag, {})
+        prev_status = prev.get("status")
+
+        # IN_FLIGHT → check elapsed, flag if approaching walltime
+        if status == "IN_FLIGHT":
+            jid = r["slurm_jid"]
+            if jid in running:
+                elapsed_h = _hms_to_hours(running[jid][0])
+                left = running[jid][1]
+                if elapsed_h >= args.warn_elapsed_h:
+                    about_to_cap.append({**r, "elapsed_h": elapsed_h, "time_left": left})
+                else:
+                    in_flight_healthy.append({**r, "elapsed_h": elapsed_h, "time_left": left})
+            continue
+
+        # Skip dirs that already completed naturally (finished_at set AND status DONE)
+        # — those auto-uploaded in their sbatch and need no user action.
+        if status in ("DONE", "DONE_WITH_ERRORS", "AT_RESUME_LIMIT") and r.get("finished_at"):
+            seen[run_tag] = {"status": status, "n_completed": r["n_completed"],
+                             "n_total": r["n_total"], "n_fires": r["n_fires"],
+                             "last_seen": _now()}
+            continue
+
+        # Skip dirs where DB row is Finished (= already manually uploaded).
+        # The on-disk result.json may still have finished_at=None because
+        # batch_upload_eval auto-sets it in memory only.
+        if db_status.get(run_tag) == "Finished":
+            seen[run_tag] = {"status": "DB_FINISHED",
+                             "n_completed": r["n_completed"],
+                             "n_total": r["n_total"], "n_fires": r["n_fires"],
+                             "last_seen": _now()}
+            if prev_status != "DB_FINISHED":
+                auto_cleared += 1
+            continue
+
+        # Status transitioned (e.g., was IN_FLIGHT, now INCOMPLETE/DONE/EARLY_KILL)
+        if status != prev_status:
+            run_dir = Path(r["jobs_dir"]) / run_tag
+            score, detail = score_dir(run_dir, r["n_total"] or 267)
+            action, reason = recommend(score, detail, r["n_fires"])
+            new_ended.append({**r, "score": score, "detail": detail,
+                              "action": action, "reason": reason,
+                              "prev_status": prev_status})
+
+        # Update seen state
+        seen[run_tag] = {
+            "status": status, "n_completed": r["n_completed"],
+            "n_total": r["n_total"], "n_fires": r["n_fires"],
+            "last_seen": _now(),
+        }
+
+    # ----- Print report -----
+    if new_ended:
+        print(f"### NEWLY ENDED / NEEDS ACTION ({len(new_ended)})\n")
+        print(f"{'Status':<18}{'JID':<10}{'Action':<8}{'Cov':<10}{'Score':<7}Model | Reason")
+        print("-" * 130)
+        for r in new_ended:
+            cov = f"{r['n_completed']}/{r['n_total']}"
+            model_short = (r["hf_model"] or "").split("/")[-1][:40]
+            run_dir = Path(r["jobs_dir"]) / r["run_tag"]
+            print(f"{r['status']:<18}{r['slurm_jid'] or '-':<10}{r['action']:<8}{cov:<10}{r['score']:<7}{model_short} | {r['reason']}")
+            print(f"    └─ run_dir: {run_dir}")
+        print()
+
+    if about_to_cap:
+        print(f"### ABOUT TO HIT WALLTIME (>{args.warn_elapsed_h}h elapsed) ({len(about_to_cap)})\n")
+        print(f"{'JID':<10}{'Elapsed':<10}{'TimeLeft':<10}{'Cov':<10}Model")
+        print("-" * 100)
+        for r in about_to_cap:
+            cov = f"{r['n_completed']}/{r['n_total']}"
+            model_short = (r["hf_model"] or "").split("/")[-1][:50]
+            print(f"{r['slurm_jid']:<10}{r['elapsed_h']:.1f}h     {r['time_left']:<10}{cov:<10}{model_short}")
+        print()
+
+    if not new_ended and not about_to_cap:
+        msg = f"No new actions. {len(in_flight_healthy)} job(s) still in flight (healthy)"
+        if auto_cleared:
+            msg += f"; {auto_cleared} auto-cleared (DB Finished)"
+        print(msg + ".")
+    else:
+        msg = f"({len(in_flight_healthy)} other jobs in flight, healthy"
+        if auto_cleared:
+            msg += f"; {auto_cleared} auto-cleared via DB"
+        print(msg + ")")
+
+    if not args.no_commit:
+        state["last_check"] = dt.datetime.now(dt.timezone.utc).isoformat()
+        state["seen"] = seen
+        save_state(state)
+        print(f"\nState committed → {STATE_FILE}")
+    else:
+        print("\n(--no-commit: state NOT updated)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/clusters/example.yaml
+++ b/eval/clusters/example.yaml
@@ -1,0 +1,78 @@
+# Example cluster configuration for the eval listener.
+#
+#   python eval/unified_eval_listener.py --cluster-config eval/clusters/example.yaml ...
+#
+# Copy this file to eval/clusters/<your-cluster>.yaml (or anywhere outside
+# the repo, e.g. ~/.local/eval-cluster.yaml) and fill in every placeholder
+# below. Every value is required unless noted otherwise. Strings support
+# $USER and ~ expansion at load time.
+
+# Short identifier for this cluster. Used in trace tags, log dirs, and the
+# EVAL_CLUSTER_NAME env var the sbatch sees.
+cluster_name: <your-cluster>          # e.g. mbz, jupiter, leonardo
+
+# --- SLURM defaults --------------------------------------------------------
+# Override per-fire with --slurm-partition / --slurm-time on the listener.
+slurm_partition: <PARTITION>          # e.g. gpu, highprio, boost_usr_prod
+slurm_account: ""                     # leave empty if your site doesn't use accounts
+slurm_time: "24:00:00"                # walltime upper bound
+
+# --- Conda environments ----------------------------------------------------
+# Map each name to the conda env *prefix directory* (the dir containing
+# bin/python). The listener picks one via --conda-env / per-model
+# baseline-yaml conda_env override / per-preset default.
+conda_envs:
+  otagent: <path-to-conda-env>        # primary env for terminus-2 evals
+  # otagent-fix: <path-to-conda-env>  # harbor-fix variant for OOD presets
+  # otagent2: <path-to-conda-env>     # axolotl-trained Qwen3 variants
+  # otagent2-fix: <path-to-conda-env> # otagent2 + harbor-fix
+
+# --- Paths -----------------------------------------------------------------
+paths:
+  # Repository root — the directory containing eval/, hpc/, scripts/ etc.
+  # Becomes ${DCFT} for baseline-yaml extra_args expansion.
+  project_root: <path-to-OpenThoughts-Agent-checkout>
+
+  # HF_HUB_CACHE-equivalent. The listener seeds HF_TOKEN-authenticated
+  # snapshot_downloads here before submitting.
+  hf_cache: <path-to-hf-hub-cache>    # e.g. ~/.cache/huggingface/hub
+
+  # Where Harbor writes per-trial directories. The sbatch reads
+  # EVAL_JOBS_DIR from this.
+  eval_jobs_dir: <path-to-jobs>       # e.g. ${project_root}/jobs
+
+  # Where the listener and sbatch write SLURM .out logs. Relative paths
+  # are resolved against project_root.
+  eval_logs_dir: eval/logs
+  listener_logs_dir: experiments/listener_logs
+
+  # SLURM submission templates (relative to project_root).
+  sbatch_script: eval/unified_eval_harbor.sbatch
+  dp_sbatch_script: eval/unified_eval_harbor_dp.sbatch
+
+  # Editable harbor checkout (the agent runtime).
+  harbor_src: <path-to-harbor-checkout>/src   # e.g. ~/harbor/src
+
+  # Extra HF cache locations to add to HF_HOME / HF_DATASETS_CACHE.
+  datasets_dirs:
+    - <path-to-hf-hub-cache>          # usually same as hf_cache
+
+  # Sourced before every fire (HF_TOKEN, SUPABASE_*, DAYTONA_*_API_KEY, ...).
+  secrets_file: ~/secrets.env
+
+# --- Proxy / no-internet support ------------------------------------------
+# Set enabled: true on no-internet clusters (Jupiter, Leonardo, ...).
+# The sbatch will route HF / Daytona traffic via proxychains4 + an SSH
+# tunnel to login_node.
+proxy:
+  enabled: false
+  # login_node: <login-host>          # e.g. login01.jupiter.fz-juelich.de
+  # proxychains_bin: <path-to-proxychains4>
+
+# --- Hardware --------------------------------------------------------------
+hardware:
+  gpus_per_node: <N>                  # e.g. 8 for H200, 4 for A100
+  cpus_per_node: <N>                  # e.g. 96
+  mem_per_node_mb: <N>                # e.g. 1860000
+  arch: <ARCH>                        # x86_64 or aarch64
+  cuda_home: <path-to-cuda>           # e.g. /usr/local/cuda-12.8

--- a/eval/clusters/jupiter.yaml
+++ b/eval/clusters/jupiter.yaml
@@ -1,0 +1,59 @@
+# Jupiter (JSC GH200) cluster configuration for the eval listener.
+#
+#   python eval/unified_eval_listener.py --cluster-config eval/clusters/jupiter.yaml ...
+#
+# Sourced by scratch user zhuang1. Other users on Jupiter should copy this
+# file and patch the user-scoped paths (project_root, eval_jobs_dir,
+# conda_envs, harbor_src).
+
+# NOTE: cluster_name controls which dotenv the sbatch auto-sources at runtime
+# (`hpc/dotenv/${CLUSTER_NAME}.env`). Use `jupiter_eval` (not `jupiter`) so the
+# sbatch picks up `hpc/dotenv/jupiter_eval.env` instead of the existing
+# `jupiter.env`, which is the SFT/RL launcher dotenv and points DCFT at the
+# old `OpenThoughts-Agent` checkout.
+cluster_name: jupiter_eval
+
+# --- SLURM defaults --------------------------------------------------------
+# jureap59 account suspended; route through reformo.
+slurm_partition: booster
+slurm_account: reformo
+slurm_time: "12:00:00"      # reformo wallclock cap
+
+# --- Conda environments ----------------------------------------------------
+# Prefix paths (the dir containing bin/python). Both envs are created from
+# eval/envs/{otagent-fix,otagent2-fix}.yml on this cluster.
+conda_envs:
+  otagent-fix: /e/scratch/jureap59/zhuang1/conda/envs/otagent-fix
+  otagent2-fix: /e/scratch/jureap59/zhuang1/conda/envs/otagent2-fix
+  # Pre-existing env kept as fallback (older harbor pin):
+  otagent2: /e/scratch/jureap59/zhuang1/conda/envs/otagent2
+
+# --- Paths -----------------------------------------------------------------
+paths:
+  project_root: /e/scratch/jureap59/zhuang1/OpenThoughts-Agent-Latest
+  hf_cache: /e/data1/datasets/playground/ot/hf_hub
+  eval_jobs_dir: /e/data1/datasets/playground/mmlaion/shared/zhuang1_eval_jobs
+  eval_logs_dir: eval/logs
+  listener_logs_dir: experiments/listener_logs
+  sbatch_script: eval/unified_eval_harbor.sbatch
+  dp_sbatch_script: eval/unified_eval_harbor_dp.sbatch
+  harbor_src: /e/scratch/jureap59/zhuang1/harbor-fix/src
+  datasets_dirs:
+    - /e/data1/datasets/playground/ot/hf_hub
+  secrets_file: ~/secrets.env
+
+# --- Proxy / no-internet support ------------------------------------------
+# Compute nodes have no internet; sbatch SSH-tunnels HF/Daytona traffic
+# through the login node and routes via proxychains4.
+proxy:
+  enabled: true
+  login_node: jpbl-s01-02
+  proxychains_bin: /e/scratch/jureap59/feuer1/proxychains-ng-aarch64/bin/proxychains4
+
+# --- Hardware --------------------------------------------------------------
+hardware:
+  gpus_per_node: 4            # GH200
+  cpus_per_node: 72
+  mem_per_node_mb: 480000     # ~480 GB LPDDR5X aggregate
+  arch: aarch64
+  cuda_home: /usr/local/cuda-13

--- a/eval/configs/baseline_model_configs_minimal.yaml
+++ b/eval/configs/baseline_model_configs_minimal.yaml
@@ -13,7 +13,7 @@
 #     byte-identical system prompts across trials).
 #   - Dropped `trust_remote_code: true` from the group — only needed per-model
 #     for custom-code archs; set it explicitly there.
-#   - Default `tensor_parallel_size: 2` for 32B (matches MBZ listener default).
+#   - Default `tensor_parallel_size: 2` for 32B (matches the listener default).
 #
 # Format (unchanged):
 #   models:      Per-model overrides (exact HF name -> config).
@@ -190,10 +190,9 @@ models:
     trust_remote_code: true
     extra_args: "--enable-prefix-caching"
 
-  # Allen AI SERA-32B (SWE-bench model) — 2026-04-22 paper-parity update per
-  # SERA_CONFIG_PARITY.md §5: adopt SERA's own vLLM flags (enforce-eager,
-  # disable-cascade-attn, seed 42), drop prefix-caching + reasoning_parser.
-  # TP kept at 2 (not paper's 4) to fit MBZ concurrency budget.
+  # Allen AI SERA-32B (SWE-bench model) — Pattern A. Paper-parity vLLM flags
+  # (enforce-eager, disable-cascade-attn, seed 42); no prefix-caching or
+  # reasoning_parser. TP=2 (not paper's TP=4) to fit a single-node serving slot.
   "allenai/SERA-32B":
     tensor_parallel_size: 2
     max_model_len: 32768
@@ -237,9 +236,9 @@ models:
     extra_args: "--enable-prefix-caching"
 
   # Lite-Coder/LiteCoder-Terminal-30b-a3b-sft — 30B MoE (3B active), SFT for
-  # terminus scaffold. Do NOT add tool_call_parser or reasoning_parser —
-  # 2026-04-22 A/B confirmed hermes+qwen3 breaks terminus-2 (0% acc on
-  # 442278-442280); Option B (no parsers) gets 23-32% on 442275-442277.
+  # terminus scaffold. Pattern D — do NOT add tool_call_parser or
+  # reasoning_parser; both hijack the JSON the terminus-2 agent parses
+  # client-side (verified A/B: hermes+qwen3 → 0% acc; no parsers → 23–32%).
   "Lite-Coder/LiteCoder-Terminal-30b-a3b-sft":
     tensor_parallel_size: 2
     max_model_len: 32768
@@ -274,10 +273,10 @@ models:
     tool_call_parser: hermes
     reasoning_parser: qwen3
 
-  # Sera-4.5A-Full-T1-v3-axolotl Qwen3-8B finetunes — axolotl-retrained variants.
-  # 2026-04-22 probe 2: mirror SERA-8B paper-parity flags (enforce-eager,
-  # disable-cascade-attn, seed 42, drop reasoning_parser/prefix-caching) to test
-  # whether serving flags rescue the markdown-output-vs-hermes-parser mismatch.
+  # Sera-4.5A-Full-T1-v3-axolotl Qwen3-8B finetunes — axolotl-retrained
+  # variants. Pattern A serving flags (enforce-eager, disable-cascade-attn,
+  # seed 42; no reasoning_parser, no prefix-caching) to mirror SERA-8B
+  # paper-parity behavior on the markdown-output / hermes-parser interaction.
   "laion/Sera-4.5A-Full-T1-v3-316-axolotl__Qwen3-8B":
     tensor_parallel_size: 1
     max_model_len: 32768
@@ -294,10 +293,8 @@ models:
     tool_call_parser: hermes
     extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
 
-  # Sera-4.6-Lite-T2-v4-axolotl Qwen3-8B finetunes — Pattern B (hermes + qwen3 reasoning).
-  # 2026-04-23 second probe: Ben reported tokenizer fix upstream; refire both patterns
-  # on otagent-fix after clearing HF cache to pull the new tokenizer_config.
-  # (Pass 1 of this probe used Pattern A; current write is Pattern B for pass 2.)
+  # Sera-4.6-Lite-T2-v4-axolotl Qwen3-8B finetunes — Pattern B (hermes
+  # tool-call parser + qwen3 reasoning parser + prefix-caching).
   "laion/Sera-4.6-Lite-T2-v4-316-axolotl__Qwen3-8B":
     trust_remote_code: true
     tool_call_parser: hermes
@@ -315,9 +312,10 @@ models:
   "laion/CoderForge-Preview-v2-10000__Qwen3-8B":
     tool_call_parser: hermes
 
-  # CoderForge-Preview-v3-axolotl Qwen3-8B finetunes — 2026-04-23 probe on openhands
-  # native tools. Pattern B (hermes + qwen3 reasoning + prefix-caching) to handle
-  # potential <think> blocks in output (safer default for Qwen3 finetunes).
+  # CoderForge-Preview-v3-axolotl Qwen3-8B finetunes — Pattern B (hermes
+  # tool-call parser + qwen3 reasoning parser + prefix-caching). Handles the
+  # `<think>` blocks emitted by Qwen3 finetunes when run under openhands
+  # native-tool scaffolds.
   "laion/CoderForge-Preview-v3-316-axolotl__Qwen3-8B":
     trust_remote_code: true
     tool_call_parser: hermes

--- a/eval/configs/baseline_model_configs_minimal.yaml
+++ b/eval/configs/baseline_model_configs_minimal.yaml
@@ -1,0 +1,383 @@
+# Minimal vLLM serving config — treats 32B like 8B by default.
+#
+# Drop-in replacement for eval/baseline_model_configs.yaml.
+# Use via: --baseline-model-config eval/configs/baseline_model_configs_minimal.yaml
+#
+# Differences from the original:
+#   - Removed `tool_call_parser: hermes` from the 32B group (hermes parser hijacks
+#     plain-text JSON output and breaks terminus-2 agents; confirmed on 30B-A3B).
+#   - Removed redundant flags (`--dtype bfloat16`, `--block-size 16`,
+#     `--enable-chunked-prefill`) which are already vLLM defaults.
+#   - Removed `--max-num-partial-prefills 1` (conservative, throughput-negative).
+#   - Kept `--enable-prefix-caching` (genuine win for agent evals with
+#     byte-identical system prompts across trials).
+#   - Dropped `trust_remote_code: true` from the group — only needed per-model
+#     for custom-code archs; set it explicitly there.
+#   - Default `tensor_parallel_size: 2` for 32B (matches MBZ listener default).
+#
+# Format (unchanged):
+#   models:      Per-model overrides (exact HF name -> config).
+#   groups:      Apply one config to many models. Per-model entries merge on top.
+#   patterns:    Regex fallback when no exact/group match. First match wins.
+
+# --- Groups: many models sharing the same config ---
+# groups:
+#   - models:
+#       - "nvidia/Nemotron-Terminal-32B"
+#       - "DCAgent/staqc-sandboxes-traces-terminus-2_Qwen3-32B"
+#       - "NovaSky-AI/SA-SWE-32B"
+#       - "Qwen/Qwen2.5-Coder-32B-Instruct"
+#       - "Qwen/Qwen3-32B"
+#       - "R2E-Gym/R2EGym-32B-Agent"
+#       - "SWE-Swiss/SWE-Swiss-32B"
+#       - "SWE-bench/SWE-agent-LM-32B"
+#       - "Skywork/Skywork-SWE-32B"
+#       - "allenai/SERA-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_adam-beta1_0-91_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_adam-beta1_0-93_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_adam-beta1_0-95_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_global-batch-size_32_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_global-batch-size_64_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_learning-rate_1e-06_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_lr_1e-5_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_num-train-epochs_4.0_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_num-train-epochs_6.0_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_num-train-epochs_7.0_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_num-train-epochs_8-0_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_warmup-ratio_0-01_Qwen3-32B"
+#       - "laion/GLM-4.6-stackexchange-overflow-sandboxes-32eps-65k-reasoning_warmup-ratio_0-05_Qwen3-32B"
+#       - "laion/Qwen3-32B-NL2Bash-31step"
+#       - "laion/Qwen3-32B-R2EGYM-256-3epochs"
+#       - "laion/Qwen3-32B-SweSmith-20step"
+#       - "laion/open-thoughts-4-code-qwen3-32b-annotated"
+#       - "laion/rl__40GPU_base_32b__exp_rpt_codeelo-v2__sft_GLM-4-7-swesmith"
+#       - "laion/rl__40GPU_base_32b__exp_rpt_nemotron-bash__sft_GLM-4-7-swesmith"
+#       - "laion/sft_GLM-4-7-swesmith-sandboxes-with_tests-oracle_verified_120s-maxeps-131k_Qwen3-32B"
+#       - "laion/sft_r2egym-nl2bash-stackoverflow-inferredbugs-32B_Qwen3-32B"
+#       - "laion/syh-r2eg-askl-glm_4-7_trac_jupi_-gfi-swes-rand-filt-10K_glm_4-7_trac_jupi_32B"
+#       - "laion/rl__48GPU_shaped_32b__exp_rpt_nemotron-bash__Qwen3-32B-45"
+#     tensor_parallel_size: 2
+#     max_model_len: 32768
+#     swap_space: 32
+#     extra_args: "--enable-prefix-caching"
+
+# # --- Per-model overrides (merged on top of group config) ---
+models:
+  # SA-SWE-32B: authors use custom SkyRL OHCodeActAgent (engine-direct, not
+  # portable). Best knowable scaffold via OpenAI-compat: Pattern B (hermes +
+  # qwen3 reasoning) + swe-agent regular = 24.7% (paper 39.4%). Custom acc-
+  # thinking template REGRESSED to 14.3% by filling 32K context with stale
+  # <think> blocks → stuck-loop failures. See PREFERRED_HARNESS_REPRODUCTION.md §3.
+  "NovaSky-AI/SA-SWE-32B":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  # OpenSWE-32B (GAIR daVinci-Env paper, arxiv 2603.13023): vanilla Qwen2.5
+  # Hermes-style chat template — emits <tool_call>{"name":...}</tool_call> JSON
+  # (NOT XML <function=bash>; earlier subagent claim was wrong). Stock swe-agent
+  # default scaffold, parse_function: function_calling. Authors' sampling:
+  # temp 0.7 / top_p 0.8 / top_k 20 / rep_penalty 1.2 (paper §4.1). Paper 62.4%
+  # at 128k context; we cap at 32k.
+  "GAIR/OpenSWE-32B":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: '--enable-prefix-caching --override-generation-config {"temperature":0.7,"top_p":0.8,"top_k":20,"repetition_penalty":1.2}'
+
+  "GAIR/daVinci-Dev-32B":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enable-prefix-caching"
+
+  # Skywork-SWE-32B (Qwen2.5-Coder-32B finetune): plain vLLM serve, no parsers,
+  # no chat template. Authors use OpenHands 0.32.0 CodeActAgent with mock_
+  # function_calling (XML prompt parsed client-side). Paper 38.0% pass@1.
+  # See PREFERRED_HARNESS_REPRODUCTION.md.
+  "Skywork/Skywork-SWE-32B":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    extra_args: "--enable-prefix-caching"
+
+  # R2EGym-32B-Agent (Qwen2.5-Coder-32B finetune): plain vLLM serve, no parsers.
+  # Authors use custom R2E-Gym harness with XML <function=NAME><parameter=KEY>VAL
+  # </parameter></function> format which matches OpenHands text-tools (mock_
+  # function_calling). Native ctx 32k matches our cap. Paper 34.4% pass@1.
+  # See PREFERRED_HARNESS_REPRODUCTION.md.
+  "R2E-Gym/R2EGym-32B-Agent":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    extra_args: "--enable-prefix-caching"
+
+  # Mistral Devstral-Small-2507 (24B SWE model) — requires mistral-format
+  # tokenizer/config/weights and TP=2 per official Mistral recommendation.
+  "mistralai/Devstral-Small-2507":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    tool_call_parser: mistral
+    extra_args: "--tokenizer-mode mistral --config-format mistral --load-format mistral --enable-prefix-caching"
+
+  # Mistral Devstral-Small-2-24B-Instruct-2512 (v2, 24B) — standard HF loading
+  # (no mistral-format flags). Needs mistral_common >= 1.8.6 in the conda env.
+  # Native context 262144; capped at 32768 for eval parity.
+  "mistralai/Devstral-Small-2-24B-Instruct-2512":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    tool_call_parser: mistral
+    extra_args: "--enable-prefix-caching"
+
+  # Qwen3-32B — openhands native tool calling config.
+  # hermes parser for tool calls, qwen3 reasoning parser to strip <think> blocks.
+  "Qwen/Qwen3-32B":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  # Qwen3-Coder-30B-A3B-Instruct (30B MoE, 3B active) — designed for tool calling.
+  # Model card recommends qwen3_coder parser for native tool calling, newer vLLM
+  # (otagent2-fix, 0.17+) for MoE stability, and specific sampling params:
+  # temperature=0.7, top_p=0.8, top_k=20, repetition_penalty=1.05.
+  # Using --override-generation-config to apply server-side (applies to all
+  # requests regardless of client-side settings).
+  "Qwen/Qwen3-Coder-30B-A3B-Instruct":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: qwen3_coder
+    extra_args: '--enable-prefix-caching --override-generation-config {"temperature":0.7,"top_p":0.8,"top_k":20,"repetition_penalty":1.05}'
+
+  # NVIDIA Nemotron-3-Nano-30B-A3B-BF16 — 30B MoE, 3B active. Mirrors the legacy
+  # TACC sbatch `openhands_nvidia_eval_harbor.sbatch` (native tool calling
+  # with qwen3_coder parser + custom nano_v3 reasoning parser plugin +
+  # model-specific chat template). otagent2-fix required for MoE on vLLM 0.17+.
+  # Max context capped at 32768 for eval parity with other models.
+  # --enforce-eager matches legacy. Sampling temp=0.6, top_p=0.95.
+  "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16":
+    conda_env: otagent2-fix
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: qwen3_coder
+    reasoning_parser: nano_v3
+    extra_args: '--reasoning-parser-plugin ${DCFT}/eval/configs/nano_v3_reasoning_parser.py --chat-template ${DCFT}/eval/configs/nemotron_chat_template.jinja --enable-prefix-caching --override-generation-config {"temperature":0.6,"top_p":0.95}'
+
+  # Qwen3-30B-A3B-Instruct-2507 (30B MoE, 3B active) — Pattern D for terminus-2.
+  # otagent2-fix required for MoE stability on vLLM 0.17+.
+  "Qwen/Qwen3-30B-A3B-Instruct-2507":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    extra_args: "--enable-prefix-caching"
+
+  # Allen AI SERA-32B (SWE-bench model) — 2026-04-22 paper-parity update per
+  # SERA_CONFIG_PARITY.md §5: adopt SERA's own vLLM flags (enforce-eager,
+  # disable-cascade-attn, seed 42), drop prefix-caching + reasoning_parser.
+  # TP kept at 2 (not paper's 4) to fit MBZ concurrency budget.
+  "allenai/SERA-32B":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  # Allen AI SERA-8B — mirror SERA-32B paper-parity flags, scaled for 8B.
+  "allenai/SERA-8B":
+    tensor_parallel_size: 1
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  # SWE-bench/SWE-agent-LM-32B — trained for swe-agent scaffold, needs hermes parser.
+  "SWE-bench/SWE-agent-LM-32B":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enable-prefix-caching"
+
+  # SWE-bench/SWE-agent-LM-7B — trained for swe-agent scaffold (7B variant).
+  # Hermes parser for tool calls; no reasoning_parser (model doesn't emit <think>).
+  "SWE-bench/SWE-agent-LM-7B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enable-prefix-caching"
+
+  # zai-org/GLM-4.7-Flash — GLM architecture (likely MoE), otagent2-fix for safety.
+  # Pattern D for terminus-2 reg eval.
+  "zai-org/GLM-4.7-Flash":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    extra_args: "--enable-prefix-caching"
+
+  # Lite-Coder/LiteCoder-Terminal-30b-a3b-sft — 30B MoE (3B active), SFT for
+  # terminus scaffold. Do NOT add tool_call_parser or reasoning_parser —
+  # 2026-04-22 A/B confirmed hermes+qwen3 breaks terminus-2 (0% acc on
+  # 442278-442280); Option B (no parsers) gets 23-32% on 442275-442277.
+  "Lite-Coder/LiteCoder-Terminal-30b-a3b-sft":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    extra_args: "--enable-prefix-caching"
+
+  # Sera-4.5A-Full-T1-v2 Qwen3-8B finetunes — used with swe-agent SERA e2e config
+  # (native function_calling). Without tool_call_parser, vLLM 400s every request
+  # ("auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser).
+  # tool_call_parser field auto-adds --enable-auto-tool-choice via build_vllm_cmd.sh.
+  "laion/Sera-4.5A-Full-T1-v2-316__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  "laion/Sera-4.5A-Full-T1-v2-1000__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  "laion/Sera-4.5A-Full-T1-v2-3160__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  "laion/Sera-4.5A-Full-T1-v2-10000__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+
+  # Sera-4.5A-Full-T1-v3-axolotl Qwen3-8B finetunes — axolotl-retrained variants.
+  # 2026-04-22 probe 2: mirror SERA-8B paper-parity flags (enforce-eager,
+  # disable-cascade-attn, seed 42, drop reasoning_parser/prefix-caching) to test
+  # whether serving flags rescue the markdown-output-vs-hermes-parser mismatch.
+  "laion/Sera-4.5A-Full-T1-v3-316-axolotl__Qwen3-8B":
+    tensor_parallel_size: 1
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  "laion/Sera-4.5A-Full-T1-v3-1000-axolotl__Qwen3-8B":
+    tensor_parallel_size: 1
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  # Sera-4.6-Lite-T2-v4-axolotl Qwen3-8B finetunes — Pattern B (hermes + qwen3 reasoning).
+  # 2026-04-23 second probe: Ben reported tokenizer fix upstream; refire both patterns
+  # on otagent-fix after clearing HF cache to pull the new tokenizer_config.
+  # (Pass 1 of this probe used Pattern A; current write is Pattern B for pass 2.)
+  "laion/Sera-4.6-Lite-T2-v4-316-axolotl__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  "laion/Sera-4.6-Lite-T2-v4-1000-axolotl__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  # CoderForge-Preview-v2-10000 — hermes confirmed correct parser (9.4% vs 0% on
+  # qwen3_coder); kept here for potential future family fires.
+  "laion/CoderForge-Preview-v2-10000__Qwen3-8B":
+    tool_call_parser: hermes
+
+  # CoderForge-Preview-v3-axolotl Qwen3-8B finetunes — 2026-04-23 probe on openhands
+  # native tools. Pattern B (hermes + qwen3 reasoning + prefix-caching) to handle
+  # potential <think> blocks in output (safer default for Qwen3 finetunes).
+  "laion/CoderForge-Preview-v3-316-axolotl__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  "laion/CoderForge-Preview-v3-1000-axolotl__Qwen3-8B":
+    trust_remote_code: true
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    extra_args: "--enable-prefix-caching"
+
+  # Qwen/Qwen3-8B (base instruct) — baseline control for 8B openhands native tools.
+  # hermes parser + qwen3 reasoning parser to mirror Qwen3-32B entry.
+  "Qwen/Qwen3-8B":
+    tool_call_parser: hermes
+    reasoning_parser: qwen3
+    trust_remote_code: true
+
+  # SWE-Lego/SWE-Lego-Qwen3-8B — mirror Qwen/Qwen3-8B for openhands native tools.
+  # SWE-Lego authors run plain vLLM (no tool_call_parser, no reasoning_parser)
+  # and rely on OpenHands' XML prompt-based function calling (text tools), NOT
+  # native tool calls. Authors use temp=0.0 — bake via override-generation-config
+  # to get greedy decoding (biggest within-32k tweak per subagent research, +3-7pp
+  # expected). Paper 42.2% at 163k; structural floor at 32k ~25-30%.
+  "SWE-Lego/SWE-Lego-Qwen3-8B":
+    trust_remote_code: true
+    extra_args: '--enable-prefix-caching --override-generation-config {"temperature":0.0,"top_p":1.0,"top_k":-1}'
+
+# Pattern-based configs: matched by regex when no exact/group match is found.
+# Checked in order; first match wins.
+# Every pattern sets: trust_remote_code=true + --enable-prefix-caching
+#   trust_remote_code: permission-only, no-op unless model ships custom code
+#   --enable-prefix-caching: pure-win for agent evals (shared system prompt)
+patterns:
+  - match: "(?i)qwen3\\.5"
+    conda_env: otagent2-fix
+    trust_remote_code: true
+    max_model_len: 32768
+    swap_space: 32
+    extra_args: "--enable-prefix-caching"
+
+  - match: "(?i)(?:32b.*(131k|-lc)|(131k|-lc).*32b)"
+    trust_remote_code: true
+    tensor_parallel_size: 2
+    max_model_len: 131072
+    swap_space: 32
+    hf_overrides: '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768}}'
+    extra_args: "--enable-prefix-caching"
+
+  - match: "(?i)32[Bb]"
+    trust_remote_code: true
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    extra_args: "--enable-prefix-caching"
+
+  - match: "131k|-lc$"
+    trust_remote_code: true
+    max_model_len: 131072
+    swap_space: 32
+    hf_overrides: '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768}}'
+    extra_args: "--enable-prefix-caching"

--- a/eval/configs/dcagent_eval_config.yaml
+++ b/eval/configs/dcagent_eval_config.yaml
@@ -1,0 +1,50 @@
+# Harbor eval config (default)
+# NOTE: jobs_dir is NOT set here — it's passed via `--jobs-dir` CLI flag
+# from the sbatch, which reads EVAL_JOBS_DIR from the cluster config.
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 16
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: terminus-2
+    max_timeout_sec: 7200
+    trajectory_config:
+      raw_content: true
+      linear_history: true
+    kwargs:
+      record_terminal_session: false
+      enable_episode_logging: false
+      enable_pane_logging: false
+      collect_rollout_details: false
+      collect_engine_metrics: false
+      proactive_summarization_threshold: 2048
+      metrics_endpoint: https://replace-with-vllm-host/metrics
+      metrics_timeout_sec: 10
+      model_info:
+        max_input_tokens: 32768
+        max_output_tokens: 16384
+        input_cost_per_token: 0
+        output_cost_per_token: 0
+datasets:
+  - path: examples/tasks

--- a/eval/configs/dcagent_eval_config_aider_agent_nothink.yaml
+++ b/eval/configs/dcagent_eval_config_aider_agent_nothink.yaml
@@ -1,0 +1,38 @@
+# Harbor eval config — aider agent, no thinking, diff format
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 16
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: aider
+    max_timeout_sec: 7200
+    kwargs:
+      edit_format: diff
+      auto_lint: true
+      auto_test: true
+      test_cmd: "bash tests/test.sh"
+      stream: false
+      thinking_tokens: 0
+datasets:
+  - path: examples/tasks

--- a/eval/configs/dcagent_eval_config_mini_swe_agent.yaml
+++ b/eval/configs/dcagent_eval_config_mini_swe_agent.yaml
@@ -1,0 +1,34 @@
+# Harbor eval config — mini-swe-agent (installed agent, uses hosted_vllm/ prefix)
+# Minimal ReAct agent. Relies on MSWEA_MODEL_API_KEY + MSWEA_MODEL_API_BASE env vars.
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 16
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: mini-swe-agent
+    max_timeout_sec: 7200
+    kwargs:
+      cost_limit: "0"   # "0" = no cost limit; the only CLI flag mini-swe-agent exposes
+datasets:
+  - path: examples/tasks

--- a/eval/configs/dcagent_eval_config_no_override.yaml
+++ b/eval/configs/dcagent_eval_config_no_override.yaml
@@ -1,0 +1,50 @@
+# Harbor eval config (no-override variant for swebench/tb2)
+# NOTE: jobs_dir is NOT set here — it's passed via `--jobs-dir` CLI flag.
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 4
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: true
+  delete: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: terminus-2
+    max_timeout_sec: 7200
+    trajectory_config:
+      raw_content: true
+      linear_history: true
+    kwargs:
+      record_terminal_session: false
+      enable_episode_logging: false
+      enable_pane_logging: false
+      collect_rollout_details: false
+      collect_engine_metrics: false
+      proactive_summarization_threshold: 2048
+      metrics_endpoint: https://replace-with-vllm-host/metrics
+      metrics_timeout_sec: 10
+      model_info:
+        max_input_tokens: 32768
+        max_output_tokens: 16384
+        input_cost_per_token: 0
+        output_cost_per_token: 0
+datasets:
+  - path: examples/tasks

--- a/eval/configs/dcagent_eval_config_openhands.yaml
+++ b/eval/configs/dcagent_eval_config_openhands.yaml
@@ -1,0 +1,36 @@
+# Harbor eval config — openhands agent
+# disable_tool_calls: true = text-based tool invocation (<execute_bash> etc.)
+# disable_tool_calls: false = native function calling (needs vLLM tool parser)
+# Toggle this to ablate tool calling mode.
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 16
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: openhands
+    max_timeout_sec: 7200
+    kwargs:
+      disable_tool_calls: true
+datasets:
+  - path: examples/tasks

--- a/eval/configs/dcagent_eval_config_openhands_qwen3_coder.yaml
+++ b/eval/configs/dcagent_eval_config_openhands_qwen3_coder.yaml
@@ -1,0 +1,39 @@
+# Harbor eval config — openhands agent, tuned for Qwen3-Coder-30B-A3B-Instruct
+# - Native tool calling ON (disable_tool_calls=false) — model is designed for it
+# - Recommended sampling: temperature=0.7, top_p=0.8 (per HF model card)
+# - Pairs with baseline override: tool_call_parser=qwen3_coder on vLLM side
+# - Model is non-thinking only; no enable_thinking toggle needed
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 16
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: openhands
+    max_timeout_sec: 7200
+    kwargs:
+      disable_tool_calls: false
+      temperature: "0.7"
+      top_p: "0.8"
+datasets:
+  - path: examples/tasks

--- a/eval/configs/dcagent_eval_config_openhands_toolcall.yaml
+++ b/eval/configs/dcagent_eval_config_openhands_toolcall.yaml
@@ -1,0 +1,36 @@
+# Harbor eval config — openhands agent
+# disable_tool_calls: true = text-based tool invocation (<execute_bash> etc.)
+# disable_tool_calls: false = native function calling (needs vLLM tool parser)
+# Toggle this to ablate tool calling mode.
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 16
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: openhands
+    max_timeout_sec: 7200
+    kwargs:
+      disable_tool_calls: false
+datasets:
+  - path: examples/tasks

--- a/eval/configs/dcagent_eval_config_swe_agent.yaml
+++ b/eval/configs/dcagent_eval_config_swe_agent.yaml
@@ -1,0 +1,37 @@
+# Harbor eval config — SWE-agent (installed agent, uses hosted_vllm/ prefix)
+# Full SWE-agent framework (SWE-agent/SWE-agent). Installed inside the sandbox
+# via install-swe-agent.sh.j2, reads SWEAGENT_CONFIG (URL or local path) from
+# host env for agent behavior, and OPENAI_BASE_URL for routing to vLLM.
+# For hosted_vllm models the agent auto-sets per_instance_cost_limit=0,
+# total_cost_limit=0, max_input_tokens=0 — no CLI flags needed by default.
+n_attempts: 3
+timeout_multiplier: 1.0
+orchestrator:
+  type: local
+  n_concurrent_trials: 16
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - AgentEnvironmentTimeoutError
+      - BadRequestError
+      - VerifierTimeoutError
+      - SummarizationTimeout
+      - SummarizationTimeoutError
+      - ContextLengthExceededError
+    wait_multiplier: 1.0
+    min_wait_sec: 1.0
+    max_wait_sec: 60.0
+environment:
+  type: daytona
+  force_build: false
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: swe-agent
+    max_timeout_sec: 7200
+    kwargs: {}
+datasets:
+  - path: examples/tasks

--- a/eval/configs/nano_v3_reasoning_parser.py
+++ b/eval/configs/nano_v3_reasoning_parser.py
@@ -1,0 +1,15 @@
+from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+
+
+@ReasoningParserManager.register_module("nano_v3")
+class NanoV3ReasoningParser(DeepSeekR1ReasoningParser):
+    def extract_reasoning(self, model_output, request):
+        reasoning_content, final_content = super().extract_reasoning(
+            model_output, request
+        )
+        # If final_content is None but reasoning_content exists, swap them
+        if final_content is None and reasoning_content:
+            reasoning_content, final_content = None, reasoning_content
+
+        return reasoning_content, final_content

--- a/eval/configs/nemotron_chat_template.jinja
+++ b/eval/configs/nemotron_chat_template.jinja
@@ -1,0 +1,204 @@
+{% macro render_extra_keys(json_dict, handled_keys) %}
+    {%- if json_dict is mapping %}
+        {%- for json_key in json_dict if json_key not in handled_keys %}
+            {%- if json_dict[json_key] is mapping or (json_dict[json_key] is sequence and json_dict[json_key] is not string) %}
+                {{- '\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | tojson | safe) ~ '</' ~ json_key ~ '>' }}
+            {%- else %}
+                {{-'\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | string) ~ '</' ~ json_key ~ '>' }}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+{% endmacro %}
+{%- set enable_thinking = enable_thinking if enable_thinking is defined else True %}
+{%- set truncate_history_thinking = truncate_history_thinking if truncate_history_thinking is defined else True %}
+
+{%- set ns = namespace(last_user_idx = -1) %}
+{%- set loop_messages = messages %}
+{%- for m in loop_messages %}
+  {%- if m["role"] == "user" %}
+    {%- set ns.last_user_idx = loop.index0 %}
+  {%- endif %}
+{%- endfor %}
+
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "" %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = [] %}
+{%- endif %}
+{# Recompute last_user_idx relative to loop_messages after handling system #}
+{%- set ns = namespace(last_user_idx = -1) %}
+{%- for m in loop_messages %}
+  {%- if m["role"] == "user" %}
+    {%- set ns.last_user_idx = loop.index0 %}
+  {%- endif %}
+{%- endfor %}
+{%- if system_message is defined %}
+    {{- "<|im_start|>system\n" + system_message }}
+{%- else %}
+    {%- if tools is iterable and tools | length > 0 %}
+        {{- "<|im_start|>system\n" }}
+    {%- endif %}
+{%- endif %}
+{%- if tools is iterable and tools | length > 0 %}
+    {%- if system_message is defined and system_message | length > 0 %}
+        {{- "\n\n" }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n" }}
+    {{- "<tools>" }}
+    {%- for tool in tools %}
+        {%- if tool.function is defined %}
+            {%- set tool = tool.function %}
+        {%- endif %}
+        {{- "\n<function>\n<name>" ~ tool.name ~ "</name>" }}
+        {%- if tool.description is defined %}
+            {{- '\n<description>' ~ (tool.description | trim) ~ '</description>' }}
+        {%- endif %}
+        {{- '\n<parameters>' }}
+        {%- if tool.parameters is defined and tool.parameters is mapping and tool.parameters.properties is defined and tool.parameters.properties is mapping %}
+            {%- for param_name, param_fields in tool.parameters.properties|items %}
+                {{- '\n<parameter>' }}
+                {{- '\n<name>' ~ param_name ~ '</name>' }}
+                {%- if param_fields.type is defined %}
+                    {{- '\n<type>' ~ (param_fields.type | string) ~ '</type>' }}
+                {%- endif %}
+                {%- if param_fields.description is defined %}
+                    {{- '\n<description>' ~ (param_fields.description | trim) ~ '</description>' }}
+                {%- endif %}
+                {%- if param_fields.enum is defined %}
+                    {{- '\n<enum>' ~ (param_fields.enum | tojson | safe) ~ '</enum>' }}
+                {%- endif %}
+                {%- set handled_keys = ['name', 'type', 'description', 'enum'] %}
+                {{- render_extra_keys(param_fields, handled_keys) }}
+                {{- '\n</parameter>' }}
+            {%- endfor %}
+        {%- endif %}
+        {% set handled_keys = ['type', 'properties', 'required'] %}
+        {{- render_extra_keys(tool.parameters, handled_keys) }}
+        {%- if tool.parameters is defined and tool.parameters.required is defined %}
+            {{- '\n<required>' ~ (tool.parameters.required | tojson | safe) ~ '</required>' }}
+        {%- endif %}
+        {{- '\n</parameters>' }}
+        {%- set handled_keys = ['type', 'name', 'description', 'parameters'] %}
+        {{- render_extra_keys(tool, handled_keys) }}
+        {{- '\n</function>' }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+{%- endif %}
+
+
+{%- if system_message is defined %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if tools is iterable and tools | length > 0 %}
+        {{- '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+
+{%- for message in loop_messages %}
+    {%- if message.role == "assistant" %}
+        {# Add reasoning content in to content field for unified processing below. #}
+        {%- if message.reasoning_content is defined and message.reasoning_content is string and message.reasoning_content | trim | length > 0 %}
+            {%- set content = "<think>\n" ~ message.reasoning_content ~ "\n</think>\n" ~ (message.content | default('', true)) %}
+        {%- else %}
+            {%- set content = message.content | default('', true) %}
+            {%- if content is string -%}
+                {# Allow downstream logic to to take care of broken thought, only handle coherent reasoning here. #}
+                {%- if '<think>' not in content and '</think>' not in content -%}
+                    {%- set content = "<think></think>" ~ content -%}
+                {%- endif -%}
+            {%- else -%}
+                {%- set content = content -%}
+            {%- endif -%}
+        {%- endif %}
+        {%- if message.tool_calls is defined and message.tool_calls is iterable and message.tool_calls | length > 0 %}
+            {# Assistant message has tool calls. #}
+            {{- '<|im_start|>assistant\n' }}
+                {%- set include_content = not (truncate_history_thinking and loop.index0 < ns.last_user_idx) %}
+                {%- if content is string and content | trim | length > 0 %}
+                    {%- if include_content %}
+                        {{- (content | trim) ~ '\n' -}}
+                    {%- else %}
+                        {%- set c = (content | string) %}
+                        {%- if '</think>' in c %}
+                            {# Keep only content after the last closing think. Also generation prompt causes this. #}
+                            {%- set c = c.split('</think>')[-1] %}
+                        {%- elif '<think>' in c %}
+                            {# If <think> was opened but never closed, drop the trailing think segment #}
+                            {%- set c = c.split('<think>')[0] %}
+                        {%- endif %}
+                        {%- set c = "<think></think>" ~ c | trim %}
+                        {%- if c | length > 0 %}
+                            {{- c ~ '\n' -}}
+                        {%- endif %}
+                    {%- endif %}
+                {%- else %}
+                    {{- "<think></think>" -}}
+                {%- endif %}
+                {%- for tool_call in message.tool_calls %}
+                    {%- if tool_call.function is defined %}
+                        {%- set tool_call = tool_call.function %}
+                    {%- endif %}
+                    {{- '<tool_call>\n<function=' ~ tool_call.name ~ '>\n' -}}
+                        {%- if tool_call.arguments is defined %}
+                            {%- for args_name, args_value in tool_call.arguments|items %}
+                                {{- '<parameter=' ~ args_name ~ '>\n' -}}
+                                    {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                                {{- args_value ~ '\n</parameter>\n' -}}
+                            {%- endfor %}
+                        {%- endif %}
+                    {{- '</function>\n</tool_call>\n' -}}
+                {%- endfor %}
+                {{- '<|im_end|>\n' }}
+        {%- else %}
+            {# Assistant message doesn't have tool calls. #}
+            {%- if not (truncate_history_thinking and loop.index0 < ns.last_user_idx) %}
+                {{- '<|im_start|>assistant\n' ~ (content | default('', true) | string | trim) ~ '<|im_end|>\n' }}
+            {%- else %}
+                {%- set c = (content | default('', true) | string) %}
+                {%- if '<think>' in c and '</think>' in c %}
+                    {%- set c = "<think></think>" ~ c.split('</think>')[-1] %}
+                {%- endif %}
+                {%- set c = c | trim %}
+                {%- if c | length > 0 %}
+                    {{- '<|im_start|>assistant\n' ~ c ~ '<|im_end|>\n' }}
+                {%- else %}
+                    {{- '<|im_start|>assistant\n<|im_end|>\n' }}
+                {%- endif %}
+            {%- endif %}
+        {%- endif %}
+    {%- elif message.role == "user" or message.role == "system" %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- set content = message.content | string %}
+        {{- content }}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user\n' }}
+        {%- endif %}
+        {{- '<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>\n' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endfor %}
+
+{%- if add_generation_prompt %}
+    {%- if enable_thinking %}
+        {{- '<|im_start|>assistant\n<think>\n' }}
+    {%- else %}
+        {{- '<|im_start|>assistant\n<think></think>' }}
+    {%- endif %}
+{%- endif %}

--- a/eval/docs/PREFERRED_HARNESS_REPRODUCTION.md
+++ b/eval/docs/PREFERRED_HARNESS_REPRODUCTION.md
@@ -1,0 +1,219 @@
+# Preferred-harness reproduction (PHR)
+
+Per-model recipes for reproducing paper accuracy via the model
+author's intended scaffold (swe-agent / openhands / mini-swe-agent /
+aider) running the **installed-agent CLI inside a Daytona sandbox**,
+talking back to the served model via Pinggy. This is Cat 3 of the
+[`EVAL_GUIDE`](../EVAL_GUIDE.md).
+
+Each entry below pins:
+
+- **scaffold** + which `--config-yaml` to pass
+- **conda env** + `tp-size` / `dp-size` / `timeout-multiplier`
+- **baseline-yaml shape** (Pattern A/B/C/D — see EVAL_GUIDE §4)
+- **observed accuracy** (n ≥ 150 unless noted) and the paper number
+- known **scaffold-bound ceiling** (where reproduction isn't full)
+
+> **Trust threshold**: numbers below are stable only at n ≥ 150.
+> Earlier runs at n=50 drifted 5–10 pp pessimistic as more trials
+> landed.
+
+---
+
+## §1 — Quick-fire reference
+
+| Model | Scaffold | Env | tp/dp/tm | Pattern | Acc | Paper | Δ |
+|---|---|---|---|---|---|---|---|
+| `allenai/SERA-32B` | swe-agent SERA-e2e | otagent-fix | 2/2/16 | A | 48.2% | 49.5% | -1.3 |
+| `allenai/SERA-8B` | swe-agent SERA-e2e | otagent-fix | 1/2/2 | A | 31.8% | 31.7% | +0.1 |
+| `SWE-bench/SWE-agent-LM-32B` | swe-agent regular | otagent-fix | 2/2/16 | B | 42.4% | ~40% | +2.4 |
+| `SWE-bench/SWE-agent-LM-7B` | swe-agent regular | otagent-fix | 1/2/2 | B | — | — | recipe known |
+| `GAIR/daVinci-Dev-32B` | swe-agent regular | otagent-fix | 2/2/16 | B (no `reasoning_parser`) | 55.5% | — | matched |
+| `Qwen/Qwen3-Coder-30B-A3B-Instruct` | openhands Qwen3-Coder native | otagent2-fix | 2/2/16 | C | recipe set | — | not re-measured |
+| `Skywork/Skywork-SWE-32B` | openhands text-tools | otagent-fix | 2/2/16 | D | 29.6% | 38.0% | -8.4 (drift) |
+| `R2E-Gym/R2EGym-32B` | openhands text-tools | otagent-fix | 2/2/16 | D | 26.4% | 34.4% | -8.0 (drift) |
+| `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` | openhands Nemotron native | otagent2-fix | 2/2/16 | C | 33.7% | 38.8% | -5.1 (ctx + drift) |
+| `SWE-Lego/SWE-Lego-Qwen3-8B` | openhands text-tools | otagent-fix | 1/2/2 | D | 17.6% | 42.2% | -24.6 (32k ctx) |
+| `SWE-Lego/SWE-Lego-Qwen3-32B` | openhands text-tools | otagent-fix | 2/2/16 | D | not fired | ~50s expected | — |
+| `NovaSky-AI/SA-SWE-32B` | swe-agent regular | otagent-fix | 2/2/16 | best-of-bad | 24.7% | 39.4% | engine-direct, not portable |
+| `GAIR/OpenSWE-32B` | (no config worked) | otagent-fix | 2/2/16 | — | 0% × 4 | 62.4% | structurally broken |
+
+### Δ legend
+
+- **drift**: scaffold ↔ training mismatch outside our control; the
+  paper recipe isn't fully reproducible via Harbor + installed CLI.
+- **32k ctx**: paper trained at 64k+; eval pinned at 32k can't
+  surface the model's behavior on long-context tasks.
+- **engine-direct, not portable**: paper used SkyRL's engine-direct
+  agent (bypasses the OpenAI API); custom chat templates aren't
+  reproducible via Harbor.
+- **structurally broken**: no scaffold config we tried produces
+  non-zero accuracy; flagged for the model owner.
+
+---
+
+## §2 — Per-model serving config
+
+The yaml fragments below go into
+[`../configs/baseline_model_configs_minimal.yaml`](../configs/baseline_model_configs_minimal.yaml).
+Each is the *flipped state* — what to use for the listed scaffold.
+For a Cat 4 flip back to terminus-2, drop the parser lines (see
+EVAL_GUIDE §5).
+
+### `allenai/SERA-32B` — Pattern A (SERA-e2e)
+
+```yaml
+"allenai/SERA-32B":
+  conda_env: otagent-fix
+  tensor_parallel_size: 2
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: hermes
+  extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+```
+
+Fire with `SWEAGENT_CONFIG=https://huggingface.co/datasets/DCAgent2/swe-agent-configs/resolve/main/sera_e2e.yaml`
+exported. Pass `--vllm-max-retries 30` to the listener (eager mode
+needs the longer warmup window — see EVAL_GUIDE §4).
+
+### `allenai/SERA-8B` — Pattern A
+
+```yaml
+"allenai/SERA-8B":
+  conda_env: otagent-fix
+  tensor_parallel_size: 1
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: hermes
+  extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+```
+
+### `SWE-bench/SWE-agent-LM-32B` — Pattern B
+
+```yaml
+"SWE-bench/SWE-agent-LM-32B":
+  conda_env: otagent-fix
+  tensor_parallel_size: 2
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: hermes
+  reasoning_parser: qwen3
+  extra_args: "--enable-prefix-caching"
+```
+
+### `SWE-bench/SWE-agent-LM-7B` — Pattern B
+
+```yaml
+"SWE-bench/SWE-agent-LM-7B":
+  conda_env: otagent-fix
+  tensor_parallel_size: 1
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: hermes
+  reasoning_parser: qwen3
+  extra_args: "--enable-prefix-caching"
+```
+
+### `GAIR/daVinci-Dev-32B` — Pattern B (no `reasoning_parser`)
+
+```yaml
+"GAIR/daVinci-Dev-32B":
+  conda_env: otagent-fix
+  tensor_parallel_size: 2
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: hermes
+  extra_args: "--enable-prefix-caching"
+```
+
+> **Note**: earlier drafts of this recipe carried
+> `reasoning_parser: qwen3`. The validated 55.5% reproduction was
+> served with **no** reasoning_parser — confirmed by reading the vLLM
+> log of that fire (`reasoning_parser=none`). Don't add it here.
+
+### `Qwen/Qwen3-Coder-30B-A3B-Instruct` — Pattern C
+
+```yaml
+"Qwen/Qwen3-Coder-30B-A3B-Instruct":
+  conda_env: otagent2-fix
+  tensor_parallel_size: 2
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: qwen3_coder
+  extra_args: "--enable-prefix-caching"
+```
+
+### `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` — Pattern C
+
+```yaml
+"nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16":
+  conda_env: otagent2-fix
+  tensor_parallel_size: 2
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  tool_call_parser: qwen3_coder
+  reasoning_parser: nano_v3
+  extra_args: '--reasoning-parser-plugin ${DCFT}/eval/configs/nano_v3_reasoning_parser.py --chat-template ${DCFT}/eval/configs/nemotron_chat_template.jinja --enable-prefix-caching --override-generation-config {"temperature":0.6,"top_p":0.95}'
+```
+
+`${DCFT}` is expanded by the listener (see EVAL_GUIDE §4 / Pattern C).
+
+### `Skywork/Skywork-SWE-32B`, `R2E-Gym/R2EGym-32B`, `SWE-Lego/SWE-Lego-Qwen3-{8B,32B}` — Pattern D
+
+These run through openhands text-tools (no native tool calls; the
+agent extracts JSON itself). Pattern D yaml — no parsers:
+
+```yaml
+"<model>":
+  conda_env: otagent-fix
+  tensor_parallel_size: 2          # 1 for the 8B
+  max_model_len: 32768
+  swap_space: 32
+  trust_remote_code: true
+  extra_args: "--enable-prefix-caching"
+```
+
+### Models with structural reproduction issues
+
+- `NovaSky-AI/SA-SWE-32B` — paper used SkyRL's engine-direct
+  `OHCodeActAgent`, which bypasses the OpenAI API. Best-of-bad via
+  swe-agent regular reaches 24.7% vs paper 39.4%.
+- `GAIR/OpenSWE-32B` — terminus-2 fires hit 75–77% `STOE` (stuck on
+  exception); `override-generation-config` from the paper's
+  `rep_penalty 1.2` triggers it. Dropping the override gives 0% × 4
+  configs. Flagged for the model owner.
+
+---
+
+## §3 — Firing checklist
+
+Before each Cat 3 fire:
+
+- [ ] Source `~/pinggy_pairs.env` and confirm at least one pair is
+      free (EVAL_GUIDE §3 occupancy check).
+- [ ] Cross-cluster collision check on the chosen pair (curl
+      `/v1/models`, verify `root` is on this cluster).
+- [ ] Source `~/.local/eval.env` for `HF_TOKEN`, `SUPABASE_*`,
+      `DAYTONA_API_KEY`.
+- [ ] If the model needs `otagent2-fix`, confirm the env exists in the
+      cluster config's `conda_envs:` block.
+- [ ] For Pattern A 32B fires, pass `--vllm-max-retries 30`.
+- [ ] For SERA-e2e, export `SWEAGENT_CONFIG=...` before fire.
+- [ ] Pass `--no-auto-snapshot` (or omit `--auto-snapshot`) — the
+      preset's authoritative `auto_snapshot` field handles caching;
+      CLI flips have caused silent 0%.
+
+After fire:
+
+- [ ] Wait n ≥ 150 trials before reading accuracy.
+- [ ] Sample one `trajectory.json` to verify tool-call format hasn't
+      regressed (broken `<function=...>` markers).
+- [ ] Verify Supabase shows the correct HF model name (not a numeric
+      vLLM-served id) — see EVAL_GUIDE §8.

--- a/eval/docs/RESUME_HANDOFF.md
+++ b/eval/docs/RESUME_HANDOFF.md
@@ -1,0 +1,294 @@
+# Resume Handoff — Lessons & Fixes from Jupiter
+
+This doc transfers hard-won lessons about the eval-listener resume path from
+Jupiter to other clusters running the same stack (Leonardo, Perlmutter, …).
+If you operate a continuous-eval-listener workload elsewhere, read this
+before you trust `harbor jobs resume` in production.
+
+The TL;DR: out-of-the-box, `harbor jobs resume` on this stack **re-runs the
+entire dataset, not just unfinished trials**, and silently retries trials it
+should treat as final. Four code fixes (one of them upstream) plus an
+operational protocol turn it into a real resume.
+
+---
+
+## Architecture recap
+
+- vLLM port is derived from SLURM JID: `VLLM_PORT = 10000 + (SLURM_JOB_ID % 50000)`.
+  Every fresh fire / resume gets a new port.
+- Harbor stores agent configs in `<run_dir>/config.json` (job-level) **and**
+  one per trial in `<run_dir>/<task>__<id>/config.json`.
+- On resume, harbor regenerates the job-level config from CLI args, then
+  compares it against the on-disk per-trial configs via `TrialConfig.__eq__`.
+  Trials whose stored config matches the new one are skipped. Mismatches get
+  the whole trial dir rmtree'd and re-run.
+- DB row in `sandbox_jobs` is found via `get_sandbox_job_by_name(run_tag)`
+  and flipped Pending → Started → Finished by the sbatch + upload script.
+
+These three facts produce four landmines.
+
+---
+
+## Bug G10 — `api_base` port mismatch (FIXED, in-repo sbatch)
+
+**Symptom**: every trial fails with `Cannot connect to host localhost:NNNNN`
+where NNNNN is the *original* fire's vLLM port. All retries logged as
+`LiteLLMInternalServerError`. Dir ends up worse than before resume.
+
+**Cause**: `config.json::agents[0].kwargs.api_base` is frozen at the original
+fire's port. The new fire's vLLM listens on a *different* port.
+
+**Fix** (already in `eval/unified_eval_harbor.sbatch:829-834`): sed-rewrite
+the api_base in `<run_dir>/config.json` to the current `${VLLM_PORT}`
+immediately before `harbor jobs resume`. Backup written to `config.json.bak-port`.
+
+```bash
+sed -i.bak-port -E \
+  "s|localhost:[0-9]+|localhost:${VLLM_PORT}|g" \
+  "${RUN_DIR}/config.json"
+```
+
+**On any other cluster**: verify this sed runs before `harbor jobs resume` in
+your sbatch. Without it, resume cannot work at all.
+
+---
+
+## Bug G12 — resume re-runs every trial (FIXED, in-repo sbatch)
+
+**Symptom**: harbor resume reports `Existing trial X not found in generated
+configs; skipping` for hundreds of trials, then schedules the entire dataset
+anyway. Trial directory count *doubles* (e.g. 305 old + 267 new = 572 dirs).
+Compute wasted.
+
+**Cause**: G10's sed patch only fixes the *job-level* `config.json`. Each
+per-trial `<task>__<id>/config.json` still has the stale port. When harbor
+resume compares per-trial configs to the regenerated one, `TrialConfig.__eq__`
+fails on every trial → trial is treated as "from a different config" and
+re-scheduled.
+
+**Fix** (commit a762aea7 on this repo): extend the sed patch to walk every
+per-trial `config.json` as well:
+
+```bash
+# Job-level (G10):
+sed -i.bak-port -E "s|localhost:[0-9]+|localhost:${VLLM_PORT}|g" \
+  "${RUN_DIR}/config.json"
+
+# Per-trial (G12):
+find "${RUN_DIR}" -mindepth 2 -maxdepth 2 -name config.json -print0 \
+  | xargs -0 -I{} sed -i.bak-port -E \
+      "s|localhost:[0-9]+|localhost:${VLLM_PORT}|g" "{}"
+echo "[resume] Patching api_base port in $N per-trial config.json files"
+```
+
+**Verification after a resume fires** (do this every time):
+```bash
+grep -c "not found in generated configs; skipping" eval/logs/data_<NEW_JID>.out
+# expect: 0
+grep "Patching api_base port in [0-9]+ per-trial" eval/logs/data_<NEW_JID>.out
+# expect: count matches the dataset size
+grep -c "^Starting trial" eval/logs/data_<NEW_JID>.out
+# expect: matches the *in-flight* count from inspector, NOT the dataset total
+```
+
+If `count == dataset total`, G12 has resurfaced.
+
+---
+
+## Bug G13 — DB row stays Pending after resume (FIXED, in-repo utils)
+
+**Symptom**: resume runs to completion but the `sandbox_jobs` row never
+flips to Started. Stays Pending forever. Upload script then can't find the
+right row, or worse, finds a stale older row from a prior fire.
+
+**Cause**: `get_sandbox_job_by_name` returned an arbitrary row when multiple
+exist (e.g. an old Pending from a prior fire + the current one). Listener
+saw the old already-Started row, short-circuited as `already_started`, and
+never flipped the current row.
+
+**Fix** (commit a762aea7 on this repo): add deterministic ordering to
+`database/unified_db/utils.py::get_sandbox_job_by_name`:
+
+```python
+.select("*").eq("job_name", name) \
+    .order("submitted_at", desc=True).limit(1).execute()
+```
+
+**Verification**:
+```python
+from database.unified_db.utils import get_sandbox_job_by_name
+print(get_sandbox_job_by_name("<run_tag>")["job_status"])
+# expect: "Started" within 60s of sbatch start, "Finished" on completion
+```
+
+---
+
+## Harbor Bug #1 — `--retry-exclude` silently overrides YAML (FIXED locally, filed upstream as #1617)
+
+**Symptom**: 9-10 hour tail trials, log filled with
+`ContextLengthExceededError. Retrying (1/10)`, `(2/10)`, … This exception
+type is in your harbor YAML's `exclude_exceptions`, but harbor retries it
+anyway up to `max_retries=10`.
+
+**Cause**: `harbor jobs start --retry-exclude` CLI flag default was a
+non-empty list, which silently *replaced* the YAML's `exclude_exceptions`
+instead of merging. The YAML loses.
+
+**Fix** (in `harbor-fix/src/harbor/cli/jobs.py:304`): default the CLI flag
+to `None` so the YAML wins when no override is passed.
+
+**Upstream**: filed as harbor #1617. Watch passively for merge; until then,
+every cluster needs the local harbor-fix patch.
+
+---
+
+## Harbor Bug #2 — proactive ContextLengthExceeded wrap (FIXED locally, BEN-ONLY)
+
+**Symptom**: even after the #1 fix, you still see retry loops, but the
+cause is now `OutputLengthExceededError` (from the SubagentSummarizer Step 3
+"Answer providing" path) being wrapped as `ContextLengthExceededError`.
+
+**Cause**: `_check_context_length` in `terminus_2.py` proactively wraps
+non-timeout summarization failures as `ContextLengthExceededError` *before*
+the retry path sees them. Even with exclude_exceptions configured correctly,
+the wrong type slips through.
+
+**Important caveat**: this code path is **Ben-only divergence** on
+`penfever/temp-override`. It is **NOT on harbor main**. If your cluster
+uses harbor main, you don't have this bug. If your cluster uses
+`harbor-fix` (the penfever branch), you need the patch.
+
+**Fix** (in `harbor-fix/src/harbor/agents/terminus_2/terminus_2.py:953`):
+wrap as `SummarizationTimeoutError` (which IS in the default exclude list)
+instead of `ContextLengthExceededError`.
+
+**Verification post-patch**:
+```bash
+grep -c "ContextLengthExceededError. Retrying" eval/logs/data_<JID>.out
+# expect: 0
+grep -c "SummarizationTimeoutError .* not retrying" eval/logs/data_<JID>.out
+# expect: > 0 if any Step 3 failures occurred
+```
+
+---
+
+## Operational patterns
+
+### Pre-walltime cancel (zombie Daytona avoidance)
+
+Daytona sandboxes run remotely in Daytona's cloud, **not on your compute
+node**. When SLURM SIGTERM fires at walltime, harbor on the compute node
+dies but the sandboxes keep running and **keep writing back to the run dir
+on shared FS for 30-60 minutes** after sbatch death.
+
+Observed on Jupiter: a 267-task dir went from 267 trial_dirs to 352 after
+walltime, `n_completed` went 267 → 305 (overshooting `n_total`).
+
+This breaks the resume scanner — `n_completed > n_total` doesn't match any
+classification branch, dir gets silently skipped.
+
+**Mitigation**: cancel cleanly *before* walltime hits. The rule of thumb
+that worked on Jupiter (12h cap):
+
+```bash
+# At 11h45m elapsed (TIME_LEFT ≤ 15min), scancel proactively.
+squeue -u $USER --format='%.10i %.10M %.10L' --noheader \
+  | awk '$3 ~ /^0:[0-3][0-9]:/ { print $1 }' | xargs -r scancel
+```
+
+After a clean scancel, wait ~60s, then run inspector.
+After a walltime-killed dir, wait ~60min for zombies to finish writing.
+
+### Resume of "stuck-at-full DONE" dirs
+
+A walltime-killed dir at full trial coverage (267/267) but with
+`finished_at=None` classifies as DONE in the inspector and gets hidden from
+`--needs-resume-only`. The inspector logic is "DONE means no work needed",
+but in this case the run dir really *does* need a resume — to write
+`finished_at` and to fill in 4-10 missing reward.txt files from interrupted
+trials.
+
+**Override**: pass `--resume-error-threshold -1` to the listener. This
+promotes infra_errors=0 dirs from DONE → DONE_WITH_ERRORS, making them
+eligible for resume.
+
+```bash
+python eval/resume_chunked.py \
+  --priority-file /tmp/priority.txt \
+  --preset tb2 --org eval \
+  --jobs-dir $JOBS_DIR \
+  --tag-prefix r_$(date -u +%H%M%S) \
+  --tp-size 2 --dp-size 2 --timeout-multiplier 16.0 \
+  --conda-env <your_env> \
+  --resume-error-threshold -1 \
+  --chunk-size N --sleep-between 0
+```
+
+### n_fires cap (24h hard limit)
+
+Default `--max-total-fires=2`. Original fire + 1 resume = 2 fires. After
+that, dir is `AT_RESUME_LIMIT` and should be uploaded as-is, not resumed
+again. Daytona auth tokens have a 24h validity window in this org config;
+beyond that the resumes start failing in interesting ways anyway.
+
+If a dir genuinely needs a third fire (rare), use `--max-total-fires 3
+--max-resume-count 3` with the listener directly.
+
+---
+
+## Verification checklist (run after every resume fire)
+
+For each new JID:
+
+```bash
+# 1. squeue confirms RUNNING within 30s
+squeue -j <new_jid> --format='%.10i %.10T'
+
+# 2. G12 verification — per-trial sed patch ran
+grep "Patching api_base port in [0-9]+ per-trial" eval/logs/data_<new_jid>.out
+
+# 3. G12 verification — zero "skipping" warnings
+grep -c "not found in generated configs; skipping" eval/logs/data_<new_jid>.out
+# expect: 0
+
+# 4. Harbor scheduled only the in-flight trials, not the whole dataset
+grep -c "^Starting trial" eval/logs/data_<new_jid>.out
+# expect: matches in_flight count from inspector pre-resume
+
+# 5. G13 verification — DB row flipped to Started
+python -c "from database.unified_db.utils import get_sandbox_job_by_name; \
+  print(get_sandbox_job_by_name('<run_tag>')['job_status'])"
+# expect: "Started"
+```
+
+---
+
+## Files of interest
+
+| Path | Purpose |
+|---|---|
+| `eval/check_resume_needed.py` | Inspector — classifier, reject mechanism |
+| `eval/resume_chunked.py` | Orchestrator — chunked fires per (preset, org) |
+| `eval/unified_eval_harbor.sbatch:828-859` | G10/G12 sed patch + harbor jobs resume call |
+| `eval/unified_eval_listener.py:910-913` | DONE classification (the line `--resume-error-threshold -1` overrides) |
+| `database/unified_db/utils.py::get_sandbox_job_by_name` | G13 ORDER BY fix |
+| `harbor-fix/src/harbor/cli/jobs.py:304` | Harbor Bug #1 patch (default None) |
+| `harbor-fix/src/harbor/agents/terminus_2/terminus_2.py:953` | Harbor Bug #2 patch (Ben-only) |
+
+## Open issues
+
+- **harbor #1617**: filed upstream, awaiting maintainer response.
+- **SubagentSummarizer Step 3 OOM dominance**: empirical disk audit on
+  Jupiter showed Step 3 (Answer providing) fails ~118× vs Step 2's 40×
+  across all run dirs. Mitigation candidate: cap question-subagent
+  response length at `summarizers.py:139-142`. Not patched as of this
+  handoff — track tail latency post-patches before investing in this.
+- **Inspector misclassifies stuck-at-full as DONE**: known limitation,
+  use `--resume-error-threshold -1` workaround. Long-term fix would be a
+  new classification branch like `DONE_NEEDS_FINALIZE`.
+
+---
+
+*Originally captured during the Jupiter eval-ops 3-agent split (firing /
+resume / upload), 2026-05-06 → 2026-05-11. Apply with cluster-specific
+adjustments (env paths, conda env name, jobs dir location).*

--- a/eval/envs/README.md
+++ b/eval/envs/README.md
@@ -1,0 +1,124 @@
+# eval/envs/
+
+Conda env recipes for the eval listener. Two envs ship because some
+models can't be loaded by the same `transformers` line as the
+default agent runtime — see [otagent-fix vs otagent2-fix](#which-env-when)
+below.
+
+## Files
+
+- [`otagent-fix.yml`](otagent-fix.yml) — primary env (transformers 4.x).
+- [`otagent2-fix.yml`](otagent2-fix.yml) — axolotl/Qwen3.5 + Pattern C
+  reasoning-parser-plugin env (transformers 5.x, vLLM 0.17.x).
+
+Both envs install [harbor](https://github.com/harbor-framework/harbor)
+**editable** from the same checkout. The exact commit matters — see
+the next section.
+
+## Pinning harbor-fix
+
+The eval pipeline depends on a curated stack of harbor patches that
+isn't (yet) merged to upstream `main`. Pin your harbor checkout to a
+state that includes them:
+
+```bash
+git clone https://github.com/harbor-framework/harbor.git ~/harbor-fix
+git -C ~/harbor-fix checkout penfever/temp-override
+git -C ~/harbor-fix checkout 9980f967    # Daytona connection-pool fix (PR #1460)
+```
+
+`9980f967` is the verified-working tip of `penfever/temp-override` as
+of 2026-04-29. Newer commits on that branch are usually fine — this
+is what was last fired against.
+
+### Why this branch (not upstream main)
+
+The patches the eval listener relies on, beyond what's in upstream
+`main`:
+
+| Area | Why it matters |
+|---|---|
+| Daytona connection pool 500 (#1460) | Stops "Bearer token invalid" load-shedding under high concurrency |
+| Loading-gate semaphore | Prevents unbounded sandbox creation; cap = `n_concurrent * 2` |
+| Treat "Bearer token invalid" as transient | Retry instead of fail-fast on transient Daytona auth |
+| `assume_global_snapshot` flag | Lets the listener pin its `auto_snapshot` decision |
+| max_timeout_sec multiplier ordering | Caps after multiplier so `--timeout-multiplier 16` doesn't blow past the agent/verifier max |
+| Tmux dummy-session PTY + history-limit | Required for terminus-2 on swebench / tb2 task images |
+| swerex `dirs_exist_ok` | swe-agent on dev_set_v2/tb2 — see EVAL_GUIDE §7 mode 12 |
+| ContextLengthExceeded → run verifier | Don't drop a partial trial; let the verifier score what we have |
+| Summarization timeout default raised | terminus-2 on 32B long-context — see EVAL_GUIDE §7 mode 6 |
+| LiteLLM timeouts treated as env failures | Doesn't burn vLLM slots on transient client errors |
+
+### Three uncommitted installed-agent patches
+
+The MBZ working checkout carries three small in-tree patches on top
+of `9980f967` that the upstream branch hasn't accepted yet. If your
+fire is Cat 3 (preferred-harness reproduction — see EVAL_GUIDE §2),
+apply these locally:
+
+1. **`src/harbor/agents/installed/aider.py`** — propagate
+   `OPENAI_API_BASE` so aider/litellm can reach a local vLLM, and
+   keep the `openai/` provider prefix when routing through the
+   OpenAI-compatible vLLM endpoint. Also expose an `--edit-format`
+   CLI flag.
+
+2. **`src/harbor/agents/installed/mini_swe_agent.py`** — handle the
+   `get_api_key_var_names_from_model_name` API change (returns a list
+   of provider env-var names instead of a single string), and don't
+   crash when the model is unknown.
+
+3. **`src/harbor/agents/installed/swe_agent.py`** — prepend
+   `/opt/sweagent-venv/bin` to PATH (the venv `install.sh` puts
+   sweagent there), and guard the `set -u` trap when sourcing
+   `/etc/profile.d/testbed-conda.sh` (it references
+   `CONDA_DEFAULT_ENV` unbound, which under `set -u` terminates the
+   whole shell — `|| true` can't rescue a sourced script's trap).
+
+If you don't run installed-agent fires, you don't need these patches.
+
+## Which env, when?
+
+| Env | Use for |
+|---|---|
+| **`otagent-fix`** (transformers 4.x) | Default for everything. Terminus-2 reg eval, OOD presets, swe-agent / openhands text-tools / mini-swe-agent / aider installed-agent fires. Most baseline-yaml entries default to this env. |
+| **`otagent2-fix`** (transformers 5.x) | Models that don't load on transformers 4.x: axolotl-trained Qwen3 finetunes (the `extra_special_tokens` list crash), Qwen3.5 family. Also required for Pattern C scaffolds that use `--reasoning-parser-plugin` (Nemotron-Nano, Qwen3-Coder native) — needs vLLM ≥ 0.17. |
+
+Per-model env selection lives in
+[`../configs/baseline_model_configs_minimal.yaml`](../configs/baseline_model_configs_minimal.yaml)
+under each model's `conda_env:` field. The listener reads it and sets
+`PYTHON_BIN` for the sbatch from your cluster config's
+`conda_envs:` map.
+
+## Verification (per env)
+
+```bash
+conda activate otagent-fix
+python - <<'PY'
+import vllm, torch, transformers, harbor
+print("vllm",         vllm.__version__)
+print("torch",        torch.__version__)
+print("transformers", transformers.__version__)
+print("harbor.__file__", harbor.__file__)   # should point inside ~/harbor-fix
+PY
+```
+
+Expected (otagent-fix):
+
+```
+vllm         0.13.0
+torch        2.9.0+cu128
+transformers 4.57.3
+harbor       <your-harbor-fix-checkout>/src/harbor/__init__.py
+```
+
+For otagent2-fix, expect `vllm 0.17.1`, `torch 2.10.0+cu128`,
+`transformers 5.6.x`.
+
+## When the recipe drifts
+
+These yamls pin the *eval-shaping* deps. If you upgrade vLLM, torch,
+or transformers, retest at least one model from each Pattern (A/B/C/D
+in EVAL_GUIDE §4) before relying on the new pins for a batch fire —
+small version bumps have changed agent behavior in non-obvious ways
+(reasoning-parser plugin API, eos-token reading, NCCL flashinfer
+autotune). Update this README when you do.

--- a/eval/envs/README.md
+++ b/eval/envs/README.md
@@ -51,10 +51,10 @@ The patches the eval listener relies on, beyond what's in upstream
 
 ### Three uncommitted installed-agent patches
 
-The MBZ working checkout carries three small in-tree patches on top
-of `9980f967` that the upstream branch hasn't accepted yet. If your
-fire is Cat 3 (preferred-harness reproduction — see EVAL_GUIDE §2),
-apply these locally:
+The maintainer's working checkout carries three small in-tree patches
+on top of `9980f967` that the upstream branch hasn't accepted yet. If
+your fire is Cat 3 (preferred-harness reproduction — see EVAL_GUIDE
+§2), apply these locally:
 
 1. **`src/harbor/agents/installed/aider.py`** — propagate
    `OPENAI_API_BASE` so aider/litellm can reach a local vLLM, and

--- a/eval/envs/otagent-fix.yml
+++ b/eval/envs/otagent-fix.yml
@@ -1,0 +1,57 @@
+# otagent-fix — primary eval conda env (transformers 4.x line)
+#
+# Use for: terminus-2 reg eval, OOD presets, all installed-agent
+# preferred-harness reproductions whose models load on transformers
+# 4.x. This is the default --conda-env for the listener.
+#
+# Recreate:
+#   conda env create -f eval/envs/otagent-fix.yml
+#   conda activate otagent-fix
+#   # Editable harbor (pin matters — see eval/envs/README.md):
+#   git clone https://github.com/harbor-framework/harbor.git ~/harbor-fix
+#   git -C ~/harbor-fix checkout penfever/temp-override   # @ 9980f967 or newer
+#   pip install -e ~/harbor-fix
+#   # Apply the three installed-agent patches documented in eval/envs/README.md.
+#
+# This file pins only the eval-load-bearing deps. A full
+# `conda env export` is intentionally NOT shipped — build pins are
+# platform-specific and stale fast.
+
+name: otagent-fix
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.12
+  - pip
+  - pip:
+      # Inference / runtime — versions matter for agent behavior
+      - vllm==0.13.0
+      - torch==2.9.0
+      - transformers==4.57.3
+      - accelerate==1.12.0
+      - flashinfer-python==0.5.3
+      - triton==3.5.0
+      - numpy==2.2.6
+
+      # Agent-side LLM clients
+      - openai==2.28.0
+      - anthropic==0.71.0
+
+      # Sandbox runtime
+      - daytona==0.164.0
+
+      # HF
+      - huggingface-hub==0.36.2
+
+      # Database / supabase (eval upload)
+      - supabase
+      - python-dotenv
+      - pyyaml
+
+      # Listener helpers
+      - rich
+      - psutil
+
+      # Harbor itself is installed editable from a checkout — see header.
+      # `pip install -e <harbor-fix-checkout>` after creating this env.

--- a/eval/envs/otagent2-fix.yml
+++ b/eval/envs/otagent2-fix.yml
@@ -1,0 +1,55 @@
+# otagent2-fix — secondary eval conda env (transformers 5.x line)
+#
+# Use for: axolotl-trained Qwen3 finetunes that fail to load on the
+# transformers 4.x line (extra_special_tokens list crash), and
+# Pattern C scaffolds that need vLLM 0.17+ for reasoning-parser
+# plugins (Nemotron-Nano nano_v3, Qwen3-Coder native).
+#
+# Recreate:
+#   conda env create -f eval/envs/otagent2-fix.yml
+#   conda activate otagent2-fix
+#   # Editable harbor (same checkout as otagent-fix):
+#   pip install -e ~/harbor-fix
+#
+# This file pins only the eval-load-bearing deps; build pins are
+# intentionally not shipped.
+
+name: otagent2-fix
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.12
+  - pip
+  - pip:
+      # Inference / runtime — versions matter for agent behavior
+      - vllm==0.17.1
+      - torch==2.10.0
+      # transformers 5.x dev — needed for Qwen3.5 / axolotl variants.
+      # Replace with the latest stable >= 5.6 once released.
+      - transformers==5.6.0.dev0
+      - accelerate==1.12.0
+      - flashinfer-python==0.6.4
+      - triton==3.6.0
+      - numpy==2.2.6
+
+      # Agent-side LLM clients
+      - openai==2.24.0
+      - anthropic==0.71.0
+
+      # Sandbox runtime
+      - daytona==0.164.0
+
+      # HF (1.x line — note this is the divergence vs otagent-fix)
+      - huggingface-hub==1.11.0
+
+      # Database / supabase (eval upload)
+      - supabase
+      - python-dotenv
+      - pyyaml
+
+      # Listener helpers
+      - rich
+      - psutil
+
+      # Harbor itself is installed editable — see header.

--- a/eval/lists/EXAMPLE.txt
+++ b/eval/lists/EXAMPLE.txt
@@ -1,0 +1,13 @@
+# Example priority file for unified_eval_listener.py.
+#
+# One HuggingFace model id per line. Blank lines and lines starting
+# with '#' are ignored. The listener filters this list against the
+# baseline model config and against already-evaluated jobs in
+# Supabase (use --force-reeval to override the latter).
+#
+# Drop a copy of this file as eval/lists/<your-list>.txt and edit.
+
+# Qwen/Qwen3-32B
+# Qwen/Qwen3-Coder-30B-A3B-Instruct
+# allenai/SERA-32B
+# SWE-bench/SWE-agent-LM-32B

--- a/eval/lists/README.md
+++ b/eval/lists/README.md
@@ -1,0 +1,32 @@
+# eval/lists/
+
+Priority files consumed by `unified_eval_listener.py --priority-file`.
+One HuggingFace model id per line; blank lines and `# ...` comments are
+ignored.
+
+```
+# example list — one model per line
+Qwen/Qwen3-32B
+Qwen/Qwen3-Coder-30B-A3B-Instruct
+allenai/SERA-32B
+```
+
+The listener filters this list against:
+1. The baseline model config (`baseline_model_configs_minimal.yaml`)
+   — models without an entry use defaults.
+2. Already-evaluated jobs in Supabase (skipped unless `--force-reeval`).
+3. `--require-priority-list` — when set, only models in the file fire,
+   even if other models would otherwise be eligible.
+
+## Generating lists
+
+The DB-aware helper picks models with no eval row yet for a given
+benchmark family:
+
+```bash
+python scripts/database/query_unevaled_models.py \
+  --benchmark dev_set_v2 --size 8 \
+  -o eval/lists/<your-list>.txt
+```
+
+Requires `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`.

--- a/eval/lists/to_run.txt
+++ b/eval/lists/to_run.txt
@@ -1,0 +1,4 @@
+EtashGuha/tezos100k_continue_top8diverse100k__Qwen3-32B
+EtashGuha/tezos100k_continue_top8diverse100k_step4520__Qwen3-32B
+EtashGuha/gptlong_continue_top8diverse100k__Qwen3-32B
+EtashGuha/gptlong_continue_top8diverse100k_step4520__Qwen3-32B

--- a/eval/resume_chunked.py
+++ b/eval/resume_chunked.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Fire chunked resume listeners against a list of (model, preset) pairs.
+
+Reads a CSV produced by `eval/check_resume_needed.py --csv` (or accepts a
+priority file directly), chunks the candidate models, and fires one
+unified_eval_listener.py invocation per chunk with --resume-only +
+--priority-file + --max-jobs-submitted = chunk size. Sleeps between chunks
+to keep the sbatch rate under the 6/min cap and ramp Daytona load smoothly.
+
+Per-chunk listener invocation matches the original-fire flag set so
+config.json conflict (Harbor FileExistsError) is avoided. **You must pass
+the same sizing / yaml / conda-env you used on the original fire.**
+
+Usage:
+    # Dry-run — show planned invocations without firing
+    python eval/resume_chunked.py \
+        --csv /tmp/cands.csv --preset tb2 --org eval \
+        --tp-size 2 --dp-size 2 --timeout-multiplier 16.0 \
+        --jobs-dir /e/data1/datasets/playground/mmlaion/shared/zhuang1_eval_jobs \
+        --tag-prefix etashguha_resume_20260507 --dry-run
+
+    # Fire 4 at a time, 120s sleep between chunks
+    python eval/resume_chunked.py \
+        --csv /tmp/cands.csv --preset tb2 --org eval \
+        --tp-size 2 --dp-size 2 --timeout-multiplier 16.0 \
+        --jobs-dir /e/data1/datasets/playground/mmlaion/shared/zhuang1_eval_jobs \
+        --tag-prefix etashguha_resume_20260507 \
+        --chunk-size 4 --sleep-between 120
+
+The orchestrator runs each listener invocation foreground; you'll see the
+"Submitted batch job N" lines per chunk in the listener log path it prints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# These come straight from the inspector — restate here only so we don't
+# import the listener (and its log spam) just for two strings.
+NEEDS_RESUME = {"DONE_WITH_ERRORS", "INCOMPLETE", "PARTIAL", "EARLY_KILL"}
+STATUS_AT_LIMIT = "AT_RESUME_LIMIT"
+
+# Org → dotenv map. Add new orgs here as needed.
+ORG_DOTENVS = {
+    "eval": "hpc/dotenv/jupiter_eval.env",
+    "data": "hpc/dotenv/jupiter_eval_data_org.env",
+}
+
+
+def parse_csv(csv_path: Path, preset: Optional[str]) -> Tuple[List[dict], List[dict]]:
+    """Return (resume_rows, at_limit_rows) from inspector CSV, filtered by preset.
+
+    resume_rows: status in NEEDS_RESUME — these will be fired.
+    at_limit_rows: status == AT_RESUME_LIMIT — these will be WARNED about and skipped
+                   (24h hard cap or other resume-count limit). The orchestrator
+                   surfaces these so the user is aware of dropouts.
+    """
+    resume_rows: List[dict] = []
+    at_limit_rows: List[dict] = []
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            if preset and row.get("preset") != preset:
+                continue
+            status = row.get("status", "")
+            if status in NEEDS_RESUME:
+                resume_rows.append(row)
+            elif status == STATUS_AT_LIMIT:
+                at_limit_rows.append(row)
+    return resume_rows, at_limit_rows
+
+
+def parse_priority_file(path: Path) -> List[str]:
+    return [
+        ln.strip() for ln in path.read_text().splitlines()
+        if ln.strip() and not ln.lstrip().startswith("#")
+    ]
+
+
+def chunkify(items: List[str], n: int) -> List[List[str]]:
+    return [items[i : i + n] for i in range(0, len(items), n)]
+
+
+def build_listener_argv(
+    py: str,
+    preset: str,
+    priority_file: Path,
+    chunk_size: int,
+    args: argparse.Namespace,
+    log_path: Path,
+) -> List[str]:
+    cmd = [
+        py, "eval/unified_eval_listener.py",
+        "--cluster-config", args.cluster_config,
+        "--preset", preset,
+        "--priority-file", str(priority_file),
+        "--baseline-model-config", args.baseline_model_config,
+        "--conda-env", args.conda_env,
+        "--tp-size", str(args.tp_size),
+        "--dp-size", str(args.dp_size),
+        "--timeout-multiplier", str(args.timeout_multiplier),
+        "--slurm-partition", args.slurm_partition,
+        "--slurm-time", args.slurm_time,
+        "--max-jobs-submitted", str(chunk_size),
+        "--n-concurrent", str(args.n_concurrent),
+        "--jobs-dir", args.jobs_dir,
+        "--max-resume-count", str(args.max_resume_count),
+        "--resume-only",
+        "--auto-snapshot",
+        "--pre-download",
+        "--stagger-delay", "2",
+        "--chain-batch-size", str(chunk_size),
+        "--once",
+        "--force-reeval",
+    ]
+    if args.enable_thinking:
+        cmd.append("--enable-thinking")
+    return cmd
+
+
+def run_chunk(
+    chunk_idx: int,
+    n_chunks: int,
+    chunk: List[str],
+    preset: str,
+    args: argparse.Namespace,
+    log_dir: Path,
+    tmp_dir: Path,
+    py: str,
+    dotenv_abs: Path,
+) -> int:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    pf = tmp_dir / f"{args.tag_prefix}_{preset}_chunk{chunk_idx:02d}_{ts}.txt"
+    pf.write_text("\n".join(chunk) + "\n")
+
+    log_path = log_dir / f"resume_{args.tag_prefix}_{preset}_chunk{chunk_idx:02d}_{ts}.log"
+
+    listener_cmd = build_listener_argv(py, preset, pf, len(chunk), args, log_path)
+
+    # We invoke listener inside a bash shell so we can `. dotenv` first; this matches
+    # the canonical Jupiter fire pattern and ensures Daytona / SLURM env vars are set.
+    cmd_str = (
+        f"cd {shlex.quote(str(_REPO_ROOT))} && "
+        f". {shlex.quote(str(dotenv_abs))} >/dev/null 2>&1 && "
+        + " ".join(shlex.quote(c) for c in listener_cmd)
+    )
+    print(
+        f"\n[chunk {chunk_idx}/{n_chunks}] preset={preset} size={len(chunk)} "
+        f"priority_file={pf} log={log_path}"
+    )
+    for m in chunk:
+        print(f"  - {m}")
+    if args.dry_run:
+        print(f"  [DRY-RUN] would run: {cmd_str}")
+        print(f"  [DRY-RUN] would log to: {log_path}")
+        return 0
+
+    with open(log_path, "wb") as logf:
+        proc = subprocess.Popen(
+            ["bash", "-c", cmd_str], stdout=logf, stderr=subprocess.STDOUT,
+        )
+    rc = proc.wait()
+    print(f"  → listener exited rc={rc}")
+    if rc == 0:
+        # Print the JIDs from the log for visibility
+        try:
+            txt = log_path.read_text()
+            for line in txt.splitlines():
+                if "Submitted batch job" in line:
+                    print(f"  {line.strip()}")
+        except Exception:
+            pass
+    return rc
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Chunked resume orchestrator (PR #27 listener).")
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--csv", help="Inspector CSV path (output of check_resume_needed.py --csv).")
+    src.add_argument("--priority-file", help="Pre-built priority file with model names (one per line).")
+
+    p.add_argument("--preset", required=True, help="Preset to fire (one per orchestrator run, e.g. tb2 / swebench).")
+    p.add_argument("--org", required=True, choices=sorted(ORG_DOTENVS.keys()),
+                   help="Daytona org. Routes to the matching dotenv.")
+    p.add_argument("--jobs-dir", required=True, help="Path to harbor jobs dir for --jobs-dir on the listener.")
+    p.add_argument("--tag-prefix", required=True,
+                   help="Used in priority-file + log paths for traceability (e.g. etashguha_resume_20260507).")
+
+    p.add_argument("--chunk-size", type=int, default=4,
+                   help="Models per listener invocation. Also passed as --max-jobs-submitted. Default: 4.")
+    p.add_argument("--sleep-between", type=int, default=120,
+                   help="Seconds to sleep between chunks (Daytona ramp + sbatch rate). Default: 120.")
+
+    # Listener flag pass-through (must match the original fire to avoid config.json conflict)
+    p.add_argument("--cluster-config", default="eval/clusters/jupiter.yaml")
+    p.add_argument("--baseline-model-config", default="eval/configs/baseline_model_configs_minimal.yaml")
+    p.add_argument("--conda-env", default="otagent-fix")
+    p.add_argument("--tp-size", type=int, required=True)
+    p.add_argument("--dp-size", type=int, default=2)
+    p.add_argument("--timeout-multiplier", type=float, required=True)
+    p.add_argument("--n-concurrent", type=int, default=32)
+    p.add_argument("--enable-thinking", action="store_true", default=True)
+    p.add_argument("--slurm-partition", default="booster")
+    p.add_argument("--slurm-time", default="11:59:00")
+    p.add_argument("--max-resume-count", type=int, default=1,
+                   help=("Listener-side --max-resume-count (defense-in-depth backstop alongside the "
+                         "inspector's slurm-log-based --max-total-fires filter). Default: 1, "
+                         "meaning the listener will also refuse to resume a dir whose meta.env "
+                         "shows >= 1 prior resume completed. Bump if you raised --max-total-fires."))
+
+    p.add_argument("--python", default="/e/scratch/jureap59/zhuang1/conda/envs/otagent-fix/bin/python",
+                   help="Python interpreter to invoke listener with.")
+    p.add_argument("--log-dir", default="experiments/listener_logs",
+                   help="Where to write listener logs.")
+    p.add_argument("--tmp-dir", default="/tmp",
+                   help="Where to write per-chunk priority files.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print planned invocations but don't fire.")
+    args = p.parse_args()
+
+    # Resolve dotenv
+    dotenv_rel = ORG_DOTENVS[args.org]
+    dotenv_abs = (_REPO_ROOT / dotenv_rel).resolve()
+    if not dotenv_abs.is_file():
+        sys.stderr.write(f"ERROR: dotenv not found: {dotenv_abs}\n")
+        return 2
+
+    # Build candidate model list
+    if args.csv:
+        resume_rows, at_limit_rows = parse_csv(Path(args.csv), args.preset)
+
+        # Surface AT_RESUME_LIMIT rows as warnings — these are the "already at 24h cap"
+        # entries the user wanted called out. We do NOT silently drop them.
+        if at_limit_rows:
+            sys.stderr.write(
+                f"\n*** WARNING: {len(at_limit_rows)} (preset={args.preset}) row(s) at resume/time-fire limit — SKIPPING ***\n"
+            )
+            for r in at_limit_rows:
+                sys.stderr.write(
+                    f"  SKIP  n_fires={r.get('n_fires','?')} resume_count={r.get('resume_count','?')}  "
+                    f"{r.get('hf_model','')}  run_tag={r.get('run_tag','')}\n"
+                )
+            sys.stderr.write(
+                "  (Bump --max-total-fires on the inspector if intentional; otherwise treat these as terminated.)\n\n"
+            )
+
+        models: List[str] = []
+        seen = set()
+        for r in resume_rows:
+            m = r.get("hf_model", "").strip()
+            if m and m not in seen:
+                seen.add(m)
+                models.append(m)
+    else:
+        models = parse_priority_file(Path(args.priority_file))
+
+    if not models:
+        print("(no resume candidates — nothing to fire)")
+        return 0
+
+    print(f"Resume orchestrator")
+    print(f"  preset             {args.preset}")
+    print(f"  org                {args.org}  ({dotenv_rel})")
+    print(f"  jobs-dir           {args.jobs_dir}")
+    print(f"  candidates         {len(models)} model(s)")
+    print(f"  chunk-size         {args.chunk_size}")
+    print(f"  sleep-between      {args.sleep_between}s")
+    print(f"  sizing             tp={args.tp_size} dp={args.dp_size} tm={args.timeout_multiplier} n_concurrent={args.n_concurrent}")
+    print(f"  conda-env          {args.conda_env}")
+    print(f"  dry-run            {args.dry_run}")
+
+    chunks = chunkify(models, args.chunk_size)
+    print(f"  → {len(chunks)} chunk(s)")
+
+    log_dir = Path(args.log_dir).resolve()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(args.tmp_dir).resolve()
+
+    fail = 0
+    for i, chunk in enumerate(chunks, start=1):
+        rc = run_chunk(
+            chunk_idx=i, n_chunks=len(chunks),
+            chunk=chunk, preset=args.preset, args=args,
+            log_dir=log_dir, tmp_dir=tmp_dir,
+            py=args.python, dotenv_abs=dotenv_abs,
+        )
+        if rc != 0:
+            fail += 1
+            print(f"  WARNING: chunk {i} listener returned non-zero ({rc}); continuing")
+        if i < len(chunks):
+            if args.dry_run:
+                print(f"  [DRY-RUN] would sleep {args.sleep_between}s before next chunk")
+            else:
+                print(f"  sleeping {args.sleep_between}s before next chunk...")
+                time.sleep(args.sleep_between)
+
+    print(f"\nDone. Chunks fired: {len(chunks)}, failed: {fail}")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/resume_chunked.py
+++ b/eval/resume_chunked.py
@@ -123,6 +123,14 @@ def build_listener_argv(
         "--once",
         "--force-reeval",
     ]
+    # Pass --resume-error-threshold only when explicitly set, so we don't shadow
+    # the listener's own default. Setting this to -1 promotes DONE dirs (with
+    # infra_errors=0) into DONE_WITH_ERRORS classification, which is the only
+    # way to resume a dir that has n_completed == n_total but is genuinely
+    # stuck-at-full (finished_at=None). See RESUME_RUNBOOK.md "Resuming
+    # stuck-at-full DONE dirs" for rationale.
+    if args.resume_error_threshold is not None:
+        cmd += ["--resume-error-threshold", str(args.resume_error_threshold)]
     if args.enable_thinking:
         cmd.append("--enable-thinking")
     return cmd
@@ -217,6 +225,15 @@ def main() -> int:
                          "inspector's slurm-log-based --max-total-fires filter). Default: 1, "
                          "meaning the listener will also refuse to resume a dir whose meta.env "
                          "shows >= 1 prior resume completed. Bump if you raised --max-total-fires."))
+    p.add_argument("--resume-error-threshold", type=int, default=None,
+                   help=("Listener-side --resume-error-threshold passthrough. When omitted, the "
+                         "listener uses its own default (10). Pass -1 to enable resuming "
+                         "stuck-at-full DONE dirs (n_completed==n_total, finished_at=None, "
+                         "infra_errors below normal threshold) — the listener's resume scanner "
+                         "skips DONE dirs unless infra_errors > threshold, so threshold=-1 makes "
+                         "any infra_errors >= 0 promote the dir to DONE_WITH_ERRORS classification "
+                         "and become resume-eligible. Combined with the per-trial G12 sed patch, "
+                         "harbor will only run the actual missing trials and then finalize+upload."))
 
     p.add_argument("--python", default="/e/scratch/jureap59/zhuang1/conda/envs/otagent-fix/bin/python",
                    help="Python interpreter to invoke listener with.")

--- a/eval/snapshot_download.py
+++ b/eval/snapshot_download.py
@@ -1,0 +1,165 @@
+import os
+import sys
+import argparse
+import fcntl
+import time
+from huggingface_hub import snapshot_download
+
+def is_valid_task_dir(path):
+    """
+    Check if a directory is a valid task directory by verifying it has instruction.md
+    and excludes Git-related files.
+    """
+    # Skip Git-related files and directories
+    basename = os.path.basename(path)
+    if basename.startswith('.git') or basename in {'.gitignore', '.gitattributes', '.github'}:
+        return False
+
+    # Check if it's a directory and has instruction.md
+    return (os.path.isdir(path) and
+            os.path.isfile(os.path.join(path, 'instruction.md')))
+
+def get_dataset_path(repo_id):
+    """
+    Get the path to the dataset without downloading
+    Returns the path if it exists, None otherwise
+
+    Args:
+        repo_id (str): The repository ID to look for
+    """
+
+    # Construct the path using HF_HUB_CACHE environment variable
+    hf_cache = os.getenv('HF_HUB_CACHE', os.path.expanduser('~/.cache/huggingface/hub'))
+    dataset_path = os.path.join(hf_cache, f"datasets--{repo_id.replace('/', '--')}")
+
+    # Find the latest snapshot
+    snapshots_dir = os.path.join(dataset_path, 'snapshots')
+    if os.path.exists(snapshots_dir):
+        try:
+            snapshots = [d for d in os.listdir(snapshots_dir) if os.path.isdir(os.path.join(snapshots_dir, d))]
+        except OSError as e:
+            print(f"Could not read snapshots directory {snapshots_dir}: {e}", file=sys.stderr)
+            snapshots = []
+        if snapshots:
+            latest_snapshot = sorted(snapshots)[-1]  # Get the latest snapshot
+            snapshot_path = os.path.join(snapshots_dir, latest_snapshot)
+
+            # Verify we have valid task directories
+            if os.path.exists(snapshot_path):
+                task_dirs = [d for d in os.listdir(snapshot_path)
+                            if is_valid_task_dir(os.path.join(snapshot_path, d))]
+
+                if task_dirs:
+                    print(f"Found dataset at {snapshot_path}")
+                    print(f"Found {len(task_dirs)} valid task directories")
+                    return snapshot_path
+                else:
+                    print("No valid task directories found in snapshot")
+                    return None
+
+    print("Dataset not found, downloading...")
+    return None
+
+def download_sandboxes_dataset(repo_id, local_dir=None, cache_dir=None):
+    """
+    Download the dataset using snapshot_download
+
+    Args:
+        repo_id (str): The repository ID (e.g., 'mlfoundations-dev/sandboxes-tasks')
+        local_dir (str, optional): Local directory to save the dataset
+        cache_dir (str, optional): Cache directory for huggingface hub
+    """
+
+    try:
+        print(f"Starting download of {repo_id}...")
+
+        # Download the entire dataset repository
+        local_path = snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            local_dir=local_dir,
+            cache_dir=cache_dir,
+        )
+
+        # Remove .gitattributes file if it exists
+        gitattributes_path = os.path.join(local_path, '.gitattributes')
+        if os.path.exists(gitattributes_path):
+            os.remove(gitattributes_path)
+            print("Removed .gitattributes file")
+
+        # Verify we have valid task directories
+        task_dirs = [d for d in os.listdir(local_path)
+                    if is_valid_task_dir(os.path.join(local_path, d))]
+
+        if task_dirs:
+            print(f"DATASET_PATH={local_path}")
+            print(f"Found {len(task_dirs)} valid task directories")
+            return local_path
+        else:
+            print("No valid task directories found in downloaded dataset")
+            return None
+
+    except Exception as e:
+        print(f"Error downloading dataset: {e}")
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Download or locate a Hugging Face dataset')
+    parser.add_argument('repo_id', help='Repository ID (e.g., mlfoundations-dev/clean-sandboxes-tasks)')
+    parser.add_argument('--local-dir', help='Local directory to save the dataset')
+    parser.add_argument('--cache-dir', help='Cache directory for huggingface hub')
+
+    args = parser.parse_args()
+
+    path = None
+    if args.local_dir:
+        # When --local-dir is specified, download real files (no symlinks).
+        # Use a file lock to prevent race conditions when multiple SLURM jobs
+        # download the same dataset concurrently.
+        lock_path = args.local_dir.rstrip("/") + ".lock"
+        os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+        lock_fd = open(lock_path, "w")
+        try:
+            print(f"Acquiring dataset lock: {lock_path}", file=sys.stderr)
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            print("Lock acquired.", file=sys.stderr)
+
+            # Check if local_dir already has valid task dirs
+            if os.path.isdir(args.local_dir):
+                task_dirs = [d for d in os.listdir(args.local_dir)
+                            if is_valid_task_dir(os.path.join(args.local_dir, d))]
+                if task_dirs:
+                    print(f"Found existing dataset at {args.local_dir} with {len(task_dirs)} tasks")
+                    path = args.local_dir
+            if not path:
+                print("Downloading dataset to local dir (real files, no symlinks)...", file=sys.stderr)
+                path = download_sandboxes_dataset(
+                    repo_id=args.repo_id,
+                    local_dir=args.local_dir,
+                    cache_dir=args.cache_dir
+                )
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            lock_fd.close()
+    else:
+        # First try to get existing cached path
+        path = get_dataset_path(args.repo_id)
+        if not path:
+            # If not found, download it
+            print("Dataset not found, downloading...", file=sys.stderr)
+            path = download_sandboxes_dataset(
+                repo_id=args.repo_id,
+                local_dir=args.local_dir,
+                cache_dir=args.cache_dir
+            )
+
+    if path:
+        print(f"DATASET_PATH={path}")
+        return 0
+    else:
+        print("Failed to download dataset", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/unified_eval_harbor.sbatch
+++ b/eval/unified_eval_harbor.sbatch
@@ -1,0 +1,1318 @@
+#!/bin/bash
+#SBATCH -p booster
+#SBATCH --time=12:00:00
+#SBATCH --signal=B:TERM@120
+#SBATCH --nodes 1
+#SBATCH --ntasks-per-node 1
+#SBATCH --cpus-per-task=24
+#SBATCH --gres=gpu:2
+#SBATCH --output=eval/logs/%x_%j.out
+#SBATCH --job-name=eval
+
+# ==============================================================================
+# Unified Eval Harbor v4 — Jupiter Cluster (JSC GH200)
+#
+# Starts vLLM, runs Harbor eval, checks errors, uploads results.
+# Merged from Jupiter v1 env setup + TACC v4 features (configurable params,
+# Pending→Started DB flow, unified error checking, thinking, export-traces).
+#
+# Positional args:
+#   $1 = MODEL (HF model name, e.g. mlfoundations-dev/some_model)
+#   $2 = REPO_ID (HF dataset repo, e.g. DCAgent/dev_set_v2)
+#   $3 = BENCHMARK_ID (optional, DB benchmark UUID)
+#   $4 = RUN_TAG_ARG (optional, override run tag)
+#
+# Env vars from listener (v4 SbatchParams.to_env()):
+#   EVAL_N_CONCURRENT       (default: 128)
+#   EVAL_N_ATTEMPTS         (default: 3)
+#   EVAL_GPU_MEMORY_UTIL    (default: 0.95)
+#   EVAL_DAYTONA_THRESHOLD  (default: 999999)
+#   EVAL_VLLM_MAX_RETRIES   (default: 20)
+#   EVAL_AGENT_PARSER       (default: "")
+#   EVAL_ENABLE_THINKING    (default: "false")
+#   EVAL_AGENT_NAME         (default: "terminus-2")
+#   EVAL_STARTS_LOG         (optional, shared eval starts log)
+#   EVAL_TIMEOUT_MULTIPLIER (default: 1.0)
+#   EVAL_CONFIG_YAML        (default: dcagent_eval_config.yaml)
+#   EVAL_DB_JOB_ID          (optional, pre-created Pending job ID)
+#   EVAL_UPLOAD_USERNAME    (optional, override upload username)
+#   EVAL_OVERRIDE_MEMORY_MB (optional, memory override for harbor)
+#   EVAL_AUTO_SNAPSHOT      (optional, "true"/"false" override for auto_snapshot)
+#   EVAL_SNAPSHOT_NAME      (optional, Daytona snapshot template)
+#   EVAL_AGENT_ENVS         (optional, comma-separated KEY=VALUE pairs to pass via --ae into sandbox)
+# ==============================================================================
+
+set -eo pipefail
+ulimit -c 0  # Disable core dumps
+ulimit -n 65536 2>/dev/null || true
+
+TIMESTAMP=$(date +'%Y%m%d_%H%M%S')
+
+# --- Parse positional args ---
+MODEL="${1:-mlfoundations-dev/claude_3_7_20250219_tbench_traces_sharegptv1}"
+REPO_ID="${2:-DCAgent/dev_set_71_tasks}"
+BENCHMARK_ID="${3:-}"
+RUN_TAG_ARG="${4:-}"
+
+# --- Read env vars from listener (with defaults) ---
+N_CONCURRENT="${EVAL_N_CONCURRENT:-128}"
+N_ATTEMPTS="${EVAL_N_ATTEMPTS:-3}"
+GPU_MEMORY_UTIL="${EVAL_GPU_MEMORY_UTIL:-0.95}"
+ERROR_THRESHOLD="${EVAL_DAYTONA_THRESHOLD:-999999}"
+VLLM_MAX_RETRIES="${EVAL_VLLM_MAX_RETRIES:-20}"
+AGENT_PARSER="${EVAL_AGENT_PARSER:-}"
+ENABLE_THINKING="${EVAL_ENABLE_THINKING:-false}"
+AGENT_NAME="${EVAL_AGENT_NAME:-terminus-2}"
+EVAL_STARTS_LOG="${EVAL_STARTS_LOG:-}"
+TIMEOUT_MULTIPLIER="${EVAL_TIMEOUT_MULTIPLIER:-1.0}"
+CONFIG_YAML="${EVAL_CONFIG_YAML:-dcagent_eval_config.yaml}"
+DB_JOB_ID="${EVAL_DB_JOB_ID:-}"
+UPLOAD_USERNAME="${EVAL_UPLOAD_USERNAME:-$USER}"
+
+# Strip slashes and special chars for file-safe names
+SAFE_MODEL=$(echo "$MODEL" | tr '/:' '_')
+if [[ "$REPO_ID" == /* ]]; then
+    # Local path: use basename as the safe repo name
+    SAFE_REPO=$(basename "$REPO_ID")
+else
+    SAFE_REPO=$(echo "$REPO_ID" | tr '/:' '_')
+fi
+
+# Derive benchmark shorthand for SLURM job name (for squeue readability)
+# Listener passes --job-name to override, but for manual runs derive from REPO_ID.
+declare -A BENCH_SHORT=(
+    ["DCAgent_dev_set_v2"]="v2"
+    ["DCAgent2_swebench-verified-random-100-folders"]="swe"
+    ["DCAgent2_terminal_bench_2"]="tb2"
+    ["DCAgent_swebench-verified"]="swefull"
+    ["DCAgent2_aider_polyglot"]="aider"
+    ["DCAgent2_bfcl-parity"]="bfcl"
+    ["DCAgent_medagentbench"]="medagent"
+    ["DCAgent_gaia_127"]="gaia"
+    ["DCAgent_financeagent_terminal"]="finance"
+    ["DCAgent_dev_set_71_tasks"]="v1"
+)
+BENCH_TAG="${BENCH_SHORT[$SAFE_REPO]:-${SAFE_REPO:0:12}}"
+# Only rename if still the default "eval" (i.e. listener didn't override)
+if [ "$SLURM_JOB_NAME" = "eval" ]; then
+    scontrol update JobId="$SLURM_JOB_ID" JobName="eval_${BENCH_TAG}"
+fi
+
+echo "=============================================="
+echo "Jupiter Eval Harbor v4"
+echo "=============================================="
+echo "Model: $MODEL"
+echo "Dataset: $REPO_ID"
+echo "Benchmark ID: ${BENCHMARK_ID:-<auto>}"
+echo "N concurrent: $N_CONCURRENT"
+echo "N attempts: $N_ATTEMPTS"
+echo "GPU memory util: $GPU_MEMORY_UTIL"
+echo "Error threshold: $ERROR_THRESHOLD"
+echo "vLLM max retries: $VLLM_MAX_RETRIES"
+echo "Agent: $AGENT_NAME"
+echo "Agent parser: ${AGENT_PARSER:-<default>}"
+echo "Thinking: $ENABLE_THINKING"
+echo "Timeout multiplier: $TIMEOUT_MULTIPLIER"
+echo "Config YAML: $CONFIG_YAML"
+echo "DB Job ID (pending): ${DB_JOB_ID:-<none>}"
+echo "Upload username: $UPLOAD_USERNAME"
+echo "=============================================="
+
+# ==============================================================================
+# Cluster-Agnostic Environment Setup
+# ==============================================================================
+
+DCFT="${EVAL_PROJECT_ROOT:-${DCFT:?ERROR: EVAL_PROJECT_ROOT not set. Launch via the listener with --cluster-config.}}"
+CLUSTER_NAME="${EVAL_CLUSTER_NAME:?ERROR: EVAL_CLUSTER_NAME not set. Launch via the listener with --cluster-config.}"
+
+# Reset PYTHONPATH to avoid inheriting submitter's environment (e.g. numpy 2.4
+# from guha1/site-packages which breaks numba/vLLM).
+unset PYTHONPATH
+
+# Preserve listener-provided overrides before dotenv clobbers them
+_SAVED_SECRET_ENV="${DC_AGENT_SECRET_ENV:-}"
+
+# Source cluster-specific dotenv (e.g. hpc/dotenv/jupiter.env or hpc/dotenv/mbz.env)
+DOTENV_FILE="$DCFT/hpc/dotenv/${CLUSTER_NAME}.env"
+if [ -f "$DOTENV_FILE" ]; then
+    source "$DOTENV_FILE"
+    echo "Sourced dotenv: $DOTENV_FILE"
+else
+    echo "WARNING: dotenv not found: $DOTENV_FILE"
+fi
+
+# Source secrets (listener override takes precedence over dotenv)
+DC_AGENT_SECRET_ENV="${_SAVED_SECRET_ENV:-${DC_AGENT_SECRET_ENV:-$HOME/secrets.env}}"
+if [ -f "$DC_AGENT_SECRET_ENV" ]; then
+    source "$DC_AGENT_SECRET_ENV"
+fi
+
+# --- Daytona API key (sourced from secrets.env above) ---
+if [ -z "${DAYTONA_API_KEY:-}" ]; then
+    echo "WARNING: DAYTONA_API_KEY not set. Check $DC_AGENT_SECRET_ENV"
+fi
+echo "Daytona API key: ${DAYTONA_API_KEY:0:12}..."
+
+# --- vLLM / Ray / Triton env vars ---
+export VLLM_USE_V1=1
+export RAY_RUNTIME_ENV_HOOK=ray._private.runtime_env.uv_runtime_env_hook.hook
+export VLLM_CONFIG_ROOT="${VLLM_CACHE_ROOT:-/tmp/vllm_config_${USER}}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-/tmp/triton_cache_${USER}}"
+export FLASHINFER_WORKSPACE_BASE="${FLASHINFER_CACHE_DIR:-/tmp/flashinfer_cache_${USER}}"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv_cache_${USER}}"
+export HYDRA_FULL_ERROR=1
+# Use naive all2all backend for DP (pplx_kernels requires separate install)
+export VLLM_ALL2ALL_BACKEND="${VLLM_ALL2ALL_BACKEND:-naive}"
+# Model/dataset cache — overridden by EVAL_HF_CACHE from listener
+export HF_HUB_CACHE="${EVAL_HF_CACHE:-${HF_HUB_CACHE:?ERROR: HF_HUB_CACHE not set. Source your cluster dotenv or use --cluster-config.}}"
+export HF_HOME="${HF_HUB_CACHE}"
+export HF_CACHE_DIR="$HF_HUB_CACHE"
+# XET staging cache — must be user-writable
+export HF_XET_CACHE="${HF_XET_CACHE:-/tmp/hf_xet_cache_${USER}}"
+mkdir -p "$HF_XET_CACHE"
+
+# Harbor and DB operations
+HARBOR_SRC="${EVAL_HARBOR_SRC:-}"
+export PYTHONPATH="${HARBOR_SRC}:${DCFT}:${PYTHONPATH:-}"
+
+# ==============================================================================
+# LD_LOADER Wrappers (needed on aarch64 Jupiter where shared conda lacks exec perms)
+# ==============================================================================
+
+OTAGENT_DIR="${OTAGENT_DIR:?ERROR: OTAGENT_DIR not set. Use --conda-env with the listener.}"
+export PATH="$OTAGENT_DIR/bin:$PATH"
+export CONDA_PREFIX="$OTAGENT_DIR"
+
+PYTHON_REAL="$OTAGENT_DIR/bin/python3.12"
+
+# LD_LOADER Wrappers: required on aarch64 (Jupiter GH200) where shared conda
+# lacks execute permissions.  Skipped on x86_64 where the conda env is directly usable.
+if [ "$(uname -m)" = "aarch64" ] && [ -f /lib/ld-linux-aarch64.so.1 ]; then
+    LD_LOADER="/lib/ld-linux-aarch64.so.1"
+    WRAPPER_DIR="/tmp/eval_wrappers_${SLURM_JOB_ID}"
+    mkdir -p "$WRAPPER_DIR"
+
+    cat > "$WRAPPER_DIR/python3" <<WEOF
+#!/bin/bash
+exec $LD_LOADER $PYTHON_REAL "\$@"
+WEOF
+    cat > "$WRAPPER_DIR/python" <<WEOF
+#!/bin/bash
+exec $LD_LOADER $PYTHON_REAL "\$@"
+WEOF
+    cat > "$WRAPPER_DIR/harbor" <<WEOF
+#!/bin/bash
+exec $LD_LOADER $PYTHON_REAL -c "import sys; from harbor.cli.main import app; sys.exit(app())" "\$@"
+WEOF
+    chmod +x "$WRAPPER_DIR/python3" "$WRAPPER_DIR/python" "$WRAPPER_DIR/harbor"
+    export PATH="$WRAPPER_DIR:$PATH"
+    PYTHON_BIN="$WRAPPER_DIR/python3"
+    HARBOR_BIN="$WRAPPER_DIR/harbor"
+else
+    PYTHON_BIN="$PYTHON_REAL"
+    WRAPPER_DIR=""
+    HARBOR_BIN="harbor"
+fi
+
+# Set LD_LIBRARY_PATH so vLLM can find CUDA runtime libs (libcudart.so.12, etc.)
+# The nvidia pip packages install libs under site-packages/nvidia/*/lib/
+NVIDIA_LIB_DIR="$OTAGENT_DIR/lib/python3.12/site-packages/nvidia"
+if [ -d "$NVIDIA_LIB_DIR" ]; then
+    for libdir in "$NVIDIA_LIB_DIR"/*/lib; do
+        [ -d "$libdir" ] && export LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+    done
+fi
+
+echo "Python: $($PYTHON_BIN --version)"
+harbor --help >/dev/null
+export RAY_DEDUP_LOGS=0
+
+# Set CUDA_HOME for flashinfer JIT compilation (needs nvcc)
+# The CUDA module provides nvcc at this path on Jupiter GH200 nodes.
+_CUDA_HOME="${EVAL_CUDA_HOME:-/e/software/default/stages/2026/software/CUDA/13}"
+if [ -n "${_CUDA_HOME}" ] && [ -d "${_CUDA_HOME}" ]; then
+    export CUDA_HOME="${_CUDA_HOME}"
+    export PATH="$CUDA_HOME/bin:$PATH"
+fi
+
+
+# ==============================================================================
+# SSH Tunnel + Proxychains Setup (no internet on compute nodes)
+# ==============================================================================
+
+NODE_HOST=$(hostname -s)
+TUNNEL_PORT=7003
+LOGIN_NODE="${EVAL_LOGIN_NODE:-jpbl-s01-02}"
+PROXYCHAINS_BIN="${EVAL_PROXYCHAINS_BIN:-}"
+TUNNEL_PID=""
+
+setup_proxy() {
+    echo "[proxy] Setting up SSH tunnel to $LOGIN_NODE..."
+
+    if [ -z "${SSH_KEY:-}" ]; then
+        echo "[proxy] WARNING: SSH_KEY not set, skipping tunnel setup"
+        echo "[proxy] External connectivity (Daytona, HF) will fail"
+        return 1
+    fi
+
+    # Get node IP for multi-node access
+    NODE_IP=$(nslookup "$NODE_HOST" 2>/dev/null | grep 'Address' | tail -n1 | awk '{print $2}')
+    NODE_IP="${NODE_IP:-127.0.0.1}"
+
+    # Create SSH tunnel with SOCKS5 proxy
+    ssh -g -f -N -D ${TUNNEL_PORT} \
+        -o StrictHostKeyChecking=no \
+        -o ConnectTimeout=1000 \
+        -o ServerAliveInterval=10 \
+        -o ServerAliveCountMax=30 \
+        -o TCPKeepAlive=yes \
+        -o ExitOnForwardFailure=yes \
+        -o BatchMode=yes \
+        -i "${SSH_KEY}" \
+        "${USER}@${LOGIN_NODE}"
+
+    sleep 5
+
+    # Verify tunnel
+    if pgrep -f "ssh.*-D.*${TUNNEL_PORT}" > /dev/null; then
+        echo "[proxy] SSH tunnel started successfully"
+        TUNNEL_PID=$(pgrep -f "ssh.*-D.*${TUNNEL_PORT}" | head -1)
+    else
+        echo "[proxy] ERROR: SSH tunnel failed to start"
+        return 1
+    fi
+
+    # Generate proxychains config
+    CFG_PATH="$HOME/.proxychains/proxychains_${SLURM_JOB_ID}.conf"
+    mkdir -p "$HOME/.proxychains"
+
+    cat > "$CFG_PATH" <<PCEOF
+strict_chain
+quiet_mode
+tcp_read_time_out 30000
+tcp_connect_time_out 15000
+localnet 127.0.0.0/255.0.0.0
+localnet 10.0.0.0/255.0.0.0
+localnet 172.16.0.0/255.240.0.0
+localnet 192.168.0.0/255.255.0.0
+localnet 169.254.0.0/255.255.0.0
+[ProxyList]
+socks5 ${NODE_IP} ${TUNNEL_PORT}
+PCEOF
+
+    export PROXYCHAINS_CONF_FILE="$CFG_PATH"
+    export PROXYCHAINS_SOCKS5_HOST="${NODE_IP}"
+    export PROXYCHAINS_SOCKS5_PORT="${TUNNEL_PORT}"
+
+    echo "[proxy] Config at $CFG_PATH (socks5://${NODE_IP}:${TUNNEL_PORT})"
+
+    # Daytona timeout/retry settings
+    export DAYTONA_MAX_RETRIES=5
+    export DAYTONA_RETRY_DELAY=30
+    export DAYTONA_BACKOFF_FACTOR=2
+    export DAYTONA_TIMEOUT=1800
+    export AIOHTTP_CLIENT_TIMEOUT=900
+    export AIOHTTP_CONNECTOR_TIMEOUT=900
+    export AIOHTTP_SOCK_CONNECT_TIMEOUT=300
+    export AIOHTTP_TOTAL_TIMEOUT=1800
+
+    # Disable SSL verification (JSC cert issues)
+    export PYTHONHTTPSVERIFY=0
+    unset SSL_CERT_FILE
+    unset CURL_CA_BUNDLE
+    unset REQUESTS_CA_BUNDLE
+    unset SSL_CERT_DIR
+
+    # NOTE: Do NOT set HTTPS_PROXY/HTTP_PROXY env vars — `requests` library reads
+    # them but fails without PySocks. Proxychains LD_PRELOAD handles all proxying.
+
+    # Test connectivity (HuggingFace)
+    if [ -x "$PROXYCHAINS_BIN" ]; then
+        if "$PROXYCHAINS_BIN" -f "$CFG_PATH" curl -s --connect-timeout 10 https://huggingface.co -o /dev/null 2>/dev/null; then
+            echo "[proxy] HuggingFace connectivity test passed"
+        else
+            echo "[proxy] WARNING: HuggingFace connectivity test failed"
+        fi
+    fi
+
+    # Test Daytona API connectivity
+    if [ -n "${DAYTONA_API_KEY:-}" ]; then
+        echo "[daytona] Testing API connectivity..."
+        DAYTONA_HTTP_CODE=$("$PROXYCHAINS_BIN" -f "$CFG_PATH" curl -s --connect-timeout 15 \
+            -H "Authorization: Bearer $DAYTONA_API_KEY" \
+            "${DAYTONA_API_URL:-https://app.daytona.io/api}/health" \
+            -o /tmp/daytona_health_$$.json -w "%{http_code}" 2>/dev/null) || DAYTONA_HTTP_CODE="FAIL"
+        echo "[daytona] Health check HTTP code: $DAYTONA_HTTP_CODE"
+        if [ -f /tmp/daytona_health_$$.json ]; then
+            echo "[daytona] Response: $(cat /tmp/daytona_health_$$.json | head -c 200)"
+            rm -f /tmp/daytona_health_$$.json
+        fi
+        if [ "$DAYTONA_HTTP_CODE" = "200" ]; then
+            echo "[daytona] API connectivity OK"
+        else
+            echo "[daytona] WARNING: API returned $DAYTONA_HTTP_CODE — sandbox creation may fail"
+        fi
+    fi
+
+    echo "[proxy] Setup complete"
+    return 0
+}
+
+# Helper: run command through proxychains
+proxied() {
+    if [ -x "$PROXYCHAINS_BIN" ] && [ -n "${PROXYCHAINS_CONF_FILE:-}" ]; then
+        "$PROXYCHAINS_BIN" -f "$PROXYCHAINS_CONF_FILE" "$@"
+    else
+        "$@"
+    fi
+}
+
+# Setup proxy (skip if EVAL_PROXY_ENABLED=false, e.g. clusters with direct internet)
+if [ "${EVAL_PROXY_ENABLED:-true}" = "true" ]; then
+    setup_proxy || echo "[proxy] Continuing without proxy (some operations may fail)"
+else
+    echo "[proxy] Proxy disabled (EVAL_PROXY_ENABLED=false), assuming direct internet access"
+fi
+
+# ==============================================================================
+# Cleanup trap
+# ==============================================================================
+cleanup() {
+    echo "Cleaning up..."
+    # Kill vLLM
+    if [ -n "${VLLM_PID:-}" ]; then
+        kill "$VLLM_PID" 2>/dev/null || true
+    fi
+    # Kill SSH tunnel
+    if [ -n "${TUNNEL_PID:-}" ]; then
+        kill "$TUNNEL_PID" 2>/dev/null || true
+    fi
+    # Kill ngrok
+    if [ -n "${NGROK_PID:-}" ]; then
+        kill "$NGROK_PID" 2>/dev/null || true
+    fi
+    # Kill pinggy
+    if [ -n "${PINGGY_PID:-}" ]; then
+        kill "$PINGGY_PID" 2>/dev/null || true
+    fi
+    # Kill GLM-5 → terminus-2 JSON proxy
+    if [ -n "${GLM5_PROXY_PID:-}" ]; then
+        kill "$GLM5_PROXY_PID" 2>/dev/null || true
+    fi
+    # Remove wrappers and per-job cache
+    [ -n "${WRAPPER_DIR:-}" ] && rm -rf "$WRAPPER_DIR" 2>/dev/null || true
+    [ -n "${_JOB_CACHE:-}" ] && rm -rf "$_JOB_CACHE" 2>/dev/null || true
+    # Remove proxychains config
+    rm -f "${PROXYCHAINS_CONF_FILE:-}" 2>/dev/null || true
+    echo "Cleanup done."
+}
+trap cleanup EXIT
+
+# ==============================================================================
+# Start vLLM Server
+# ==============================================================================
+EVAL_LOGS_DIR="${EVAL_LOGS_DIR:-eval/logs}"
+mkdir -p "$EVAL_LOGS_DIR"
+
+# Derive unique vLLM port. When the listener packs jobs (EVAL_VLLM_PORT is set),
+# use the listener-assigned port directly — it centrally plans non-overlapping
+# port ranges across all jobs on a node. Otherwise fall back to job-ID-based port.
+# IMPORTANT: Do NOT export VLLM_PORT as an env var — vLLM's _get_open_port()
+# reads the VLLM_PORT env var and all DP subprocess children would try to bind
+# the same port, causing an infinite port-collision loop.
+_PHYSICAL_GPUS="${SLURM_JOB_GPUS:-0}"
+FIRST_GPU=$(echo "$_PHYSICAL_GPUS" | cut -d',' -f1)
+if [ -n "${EVAL_VLLM_PORT:-}" ]; then
+    VLLM_PORT="$EVAL_VLLM_PORT"
+else
+    VLLM_PORT=$(( 10000 + (SLURM_JOB_ID % 50000) ))
+fi
+unset -v VLLM_PORT_ENV  # ensure no VLLM_PORT env var leaks to subprocesses
+echo "Physical GPUs: $_PHYSICAL_GPUS (CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES), vLLM port: $VLLM_PORT"
+
+# Pre-download model via proxychains (compute nodes have no direct internet)
+echo "Pre-downloading model: $MODEL"
+proxied $PYTHON_BIN -c "
+from huggingface_hub import snapshot_download
+import os
+cache = os.environ.get('HF_HUB_CACHE')
+path = snapshot_download('$MODEL', cache_dir=cache)
+print(f'Model cached at: {path}')
+"
+if [ $? -ne 0 ]; then
+    echo "ERROR: Model pre-download failed for $MODEL. Exiting."
+    exit 1
+fi
+
+echo "Starting vLLM server for model: $MODEL"
+source "$DCFT/eval/build_vllm_cmd.sh"
+build_vllm_cmd "$PYTHON_BIN" "$MODEL" "$GPU_MEMORY_UTIL"
+
+# Per-job cache dirs to avoid JIT compilation conflicts when packing
+_JOB_CACHE="/tmp/${USER}_${SLURM_JOB_ID}"
+mkdir -p "$_JOB_CACHE"
+
+# With DP > 1, vLLM needs torch.compile (TORCHDYNAMO_DISABLE must be unset)
+_DP_SIZE="${EVAL_VLLM_DATA_PARALLEL_SIZE:-1}"
+_DYNAMO_DISABLE=1
+if [ "$_DP_SIZE" -gt 1 ] 2>/dev/null; then
+    _DYNAMO_DISABLE=0
+fi
+
+env TORCHDYNAMO_DISABLE=$_DYNAMO_DISABLE \
+    TMPDIR="$_JOB_CACHE" \
+    TRITON_CACHE_DIR="$_JOB_CACHE/triton" \
+    TORCH_COMPILE_CACHE_DIR="$_JOB_CACHE/torch" \
+    TORCHINDUCTOR_CACHE_DIR="$_JOB_CACHE/torchinductor" \
+    RAY_TMPDIR="$_JOB_CACHE/ray" \
+    HF_HOME="$HF_HOME" \
+    HF_HUB_CACHE="$HF_HUB_CACHE" \
+    HF_HUB_OFFLINE=1 \
+"${VLLM_CMD[@]}" \
+    > "$EVAL_LOGS_DIR/vllm_${SLURM_JOB_ID}.log" 2>&1 &
+VLLM_PID=$!
+
+# Health check loop (use configurable retries)
+MAX_RETRIES=$VLLM_MAX_RETRIES
+RETRY_INTERVAL=100
+for i in $(seq 1 $MAX_RETRIES); do
+    if curl -s http://localhost:${VLLM_PORT}/v1/models > /dev/null 2>&1; then
+        echo "vLLM server is ready"
+        break
+    fi
+    echo "Waiting for vLLM server (attempt $i/$MAX_RETRIES)..."
+    sleep $RETRY_INTERVAL
+    if [ $i -eq $MAX_RETRIES ]; then
+        echo "ERROR: vLLM server failed to start"
+        # Dump last 50 lines of vLLM log
+        tail -50 "$EVAL_LOGS_DIR/vllm_${SLURM_JOB_ID}.log" 2>/dev/null || true
+        exit 1
+    fi
+done
+
+# ==============================================================================
+# GLM-5 → terminus-2 JSON adapter sidecar (optional, gated by EVAL_USE_GLM5_PROXY)
+#
+# When enabled, harbor's terminus-2 agent talks to a local FastAPI proxy that
+# rewrites GLM-5 native output into the JSON shape terminus-2 reads. The proxy
+# is a no-op for non-GLM-5 models (pass-through fallback in the adapter), but
+# we still gate launch on the env var to keep default fires byte-identical.
+# Skip when EVAL_HARBOR_CONFIG is set (installed-agent / Cat 3 fires reach
+# vLLM through pinggy — not through this api_base).
+# ==============================================================================
+HARBOR_API_PORT="$VLLM_PORT"
+if [ "${EVAL_USE_GLM5_PROXY:-0}" = "1" ] && [ -z "${EVAL_HARBOR_CONFIG:-}" ]; then
+    PROXY_PORT=$(( VLLM_PORT + 10000 ))
+    PROXY_LOG="$EVAL_LOGS_DIR/glm5_proxy_${SLURM_JOB_ID}.log"
+    echo "[glm5-proxy] starting on port $PROXY_PORT, backend=http://localhost:$VLLM_PORT"
+    "$PYTHON_BIN" "$DCFT/eval/proxy/glm5_proxy.py" \
+        --backend "http://localhost:$VLLM_PORT" \
+        --port "$PROXY_PORT" > "$PROXY_LOG" 2>&1 &
+    GLM5_PROXY_PID=$!
+    for _i in $(seq 1 15); do
+        if curl -sf "http://localhost:$PROXY_PORT/v1/models" > /dev/null 2>&1; then
+            echo "[glm5-proxy] healthy on port $PROXY_PORT (pid=$GLM5_PROXY_PID)"
+            HARBOR_API_PORT="$PROXY_PORT"
+            break
+        fi
+        sleep 1
+    done
+    if [ "$HARBOR_API_PORT" = "$VLLM_PORT" ]; then
+        echo "[glm5-proxy] FAILED to start; aborting"
+        tail -50 "$PROXY_LOG" 2>/dev/null || true
+        exit 1
+    fi
+fi
+
+# Ngrok state (initialized here, started later if needed)
+NGROK_PID=""
+NGROK_URL=""
+
+# ==============================================================================
+# Download dataset (via proxychains for HF access)
+# Use --local-dir to get real files instead of symlinks (Daytona needs real files)
+# Supports local paths: if REPO_ID starts with /, use it directly.
+# ==============================================================================
+if [[ "$REPO_ID" == /* ]]; then
+    # Local dataset path
+    echo "Using local dataset path: $REPO_ID"
+    DATASET_PATH="$REPO_ID"
+    if [ ! -d "$DATASET_PATH" ]; then
+        echo "ERROR: Local dataset path does not exist: $DATASET_PATH"
+        exit 1
+    fi
+    TASK_COUNT=$(ls -d "$DATASET_PATH"/*/instruction.md 2>/dev/null | wc -l)
+    echo "[DEBUG] Found $TASK_COUNT tasks with instruction.md"
+else
+    echo "Downloading/locating dataset: $REPO_ID"
+    # Check dataset directories (from EVAL_DATASETS_DIRS or fallback)
+    _DS_DIRS="${EVAL_DATASETS_DIRS:?ERROR: EVAL_DATASETS_DIRS not set. Set datasets_dirs in cluster config YAML.}"
+    DATASET_LOCAL_DIR=""
+    IFS=':' read -ra _DS_DIRS_ARR <<< "$_DS_DIRS"
+    for _ds_dir in "${_DS_DIRS_ARR[@]}"; do
+        if [ -d "${_ds_dir}/${SAFE_REPO}" ]; then
+            DATASET_LOCAL_DIR="${_ds_dir}/${SAFE_REPO}"
+            break
+        fi
+    done
+    # Default to first dir if nothing found (snapshot_download will create it)
+    DATASET_LOCAL_DIR="${DATASET_LOCAL_DIR:-${_DS_DIRS_ARR[0]}/${SAFE_REPO}}"
+    DATASET_LOCAL_DIR_ALT=""  # no longer needed; absorbed into EVAL_DATASETS_DIRS
+    echo "[DEBUG] DATASET_LOCAL_DIR=$DATASET_LOCAL_DIR"
+    echo "[DEBUG] Local dir exists: $([ -d "$DATASET_LOCAL_DIR" ] && echo yes || echo no)"
+    if [ -d "$DATASET_LOCAL_DIR" ]; then
+        TASK_COUNT=$(ls -d "$DATASET_LOCAL_DIR"/*/instruction.md 2>/dev/null | wc -l)
+        echo "[DEBUG] Found $TASK_COUNT tasks with instruction.md in local dir"
+        echo "[DEBUG] Sample files:"
+        file "$DATASET_LOCAL_DIR"/$(ls "$DATASET_LOCAL_DIR" | head -1)/environment/Dockerfile 2>/dev/null || echo "[DEBUG] No Dockerfile found"
+    fi
+    DOWNLOAD_LOG=$(mktemp /tmp/download_XXXXXX.log)
+    proxied $PYTHON_BIN "$DCFT/eval/snapshot_download.py" "$REPO_ID" --local-dir "$DATASET_LOCAL_DIR" > "$DOWNLOAD_LOG" 2>&1
+    DOWNLOAD_EXIT=$?
+    cat "$DOWNLOAD_LOG"
+    DATASET_PATH=$(grep DATASET_PATH "$DOWNLOAD_LOG" | tail -n 1 | cut -d'=' -f2)
+    rm -f "$DOWNLOAD_LOG"
+    if [ $DOWNLOAD_EXIT -ne 0 ] || [ -z "${DATASET_PATH:-}" ]; then
+        echo "ERROR: Failed to get dataset path (exit code: $DOWNLOAD_EXIT)"
+        exit 1
+    fi
+fi
+echo "Using dataset path: $DATASET_PATH"
+echo "[DEBUG] Dataset source: $([ -L "$DATASET_PATH/$(ls "$DATASET_PATH" | head -1)/environment/Dockerfile" ] && echo 'SYMLINK' || echo 'REAL FILE')"
+echo "[DEBUG] Task count in dataset: $(ls -d "$DATASET_PATH"/*/instruction.md 2>/dev/null | wc -l)"
+
+# ==============================================================================
+# Construct run tag and directory
+# ==============================================================================
+if [ -n "$RUN_TAG_ARG" ]; then
+    RUN_TAG="$RUN_TAG_ARG"
+else
+    RUN_TAG="${SAFE_REPO}_${SAFE_MODEL}"
+fi
+EVAL_JOBS_DIR="${EVAL_JOBS_DIR:?ERROR: EVAL_JOBS_DIR not set. Set eval_jobs_dir in cluster config YAML.}"
+RUN_DIR="${EVAL_JOBS_DIR}/${RUN_TAG}"
+mkdir -p "$RUN_DIR"
+
+echo "Run tag: $RUN_TAG"
+echo "Run dir: $RUN_DIR"
+
+# --- Compute canonical benchmark name for DB uploads ---
+declare -A BENCHMARK_NAME_MAP=(
+    ["DCAgent2_aider_polyglot"]="aider_polyglot"
+    ["DCAgent_dev_set_v2"]="dev_set_v2"
+    ["DCAgent_dev_set_71_tasks"]="dev_set_71_tasks"
+    ["DCAgent2_terminal_bench_2"]="terminal_bench_2"
+    ["DCAgent_swebench_verified_eval_set"]="swebench-verified-random-100-folders"
+    ["DCAgent2_bfcl-parity"]="bfcl-parity"
+    ["DCAgent_swebench-verified"]="swebench-verified"
+    ["DCAgent_medagentbench"]="medagentbench"
+    ["DCAgent_gaia_127"]="gaia_127"
+    ["DCAgent_financeagent_terminal"]="financeagent_terminal"
+)
+BASE_NAME="${BENCHMARK_NAME_MAP[$SAFE_REPO]:-$SAFE_REPO}"
+
+# Append suffix for non-default timeout/memory configs.
+BENCHMARK_SUFFIX=""
+if [ -n "${EVAL_OVERRIDE_MEMORY_MB:-}" ] && [ "$EVAL_OVERRIDE_MEMORY_MB" != "1024" ]; then
+    mem_gb=$(( EVAL_OVERRIDE_MEMORY_MB / 1024 ))
+    BENCHMARK_SUFFIX="${BENCHMARK_SUFFIX}_${mem_gb}gb"
+fi
+if [ "$TIMEOUT_MULTIPLIER" != "1" ] && [ "$TIMEOUT_MULTIPLIER" != "1.0" ]; then
+    BENCHMARK_SUFFIX="${BENCHMARK_SUFFIX}_${TIMEOUT_MULTIPLIER}x"
+fi
+if [ -n "$BENCHMARK_SUFFIX" ]; then
+    BENCHMARK_NAME="${BASE_NAME}${BENCHMARK_SUFFIX}"
+else
+    BENCHMARK_NAME="$BASE_NAME"
+fi
+export BENCHMARK_NAME
+echo "Benchmark name: $BENCHMARK_NAME"
+
+# ==============================================================================
+# Update DB: Pending → Started (v4 flow)
+# ==============================================================================
+echo "Creating/updating DB job entry..."
+export MODEL REPO_ID RUN_TAG SLURM_JOB_ID BENCHMARK_NAME
+
+HARBOR_VERSION=$($PYTHON_BIN -c "import harbor; print(harbor.__version__)" 2>/dev/null || echo "unknown")
+export HARBOR_VERSION
+
+if [ -n "$DB_JOB_ID" ]; then
+    # v4 flow: listener already created a Pending entry — transition to Started
+    echo "Updating Pending job $DB_JOB_ID → Started (run_tag=$RUN_TAG)"
+    _db_fallback_marker="/tmp/.db_fallback_$$"
+    rm -f "$_db_fallback_marker"
+    proxied $PYTHON_BIN - <<'PY' || true
+import os, sys, json
+from database.unified_db.utils import update_job_status_to_started
+
+run_tag = os.environ["RUN_TAG"]
+agent_name = os.environ.get("EVAL_AGENT_NAME", "terminus-2")
+n_concurrent = int(os.environ.get("EVAL_N_CONCURRENT", "128"))
+n_attempts = int(os.environ.get("EVAL_N_ATTEMPTS", "3"))
+timeout_multiplier = float(os.environ.get("EVAL_TIMEOUT_MULTIPLIER", "1.0"))
+harbor_version = os.environ.get("HARBOR_VERSION", "unknown")
+
+config = {
+    "agent": agent_name,
+    "env": "daytona",
+    "timeout_multiplier": timeout_multiplier,
+}
+
+result = update_job_status_to_started(
+    job_name=run_tag,
+    n_trials=n_concurrent,
+    n_rep_eval=n_attempts,
+    config=config,
+    harbor_package_version=harbor_version,
+)
+if not result.get("success"):
+    print(f"WARNING: Pending→Started update failed: {result.get('error')}", file=sys.stderr)
+    print("Will create a new Started entry as fallback.", file=sys.stderr)
+    # Signal fallback needed via marker file (can't use exit code due to set -e)
+    import pathlib
+    pathlib.Path(f"/tmp/.db_fallback_{os.getpid()}").parent  # ensure /tmp exists
+    open(f"/tmp/.db_fallback_{os.environ.get('SLURM_JOB_ID', os.getpid())}", "w").close()
+else:
+    print(f"DB job {run_tag} → Started")
+PY
+    _db_update_rc=0
+    [ -f "/tmp/.db_fallback_${SLURM_JOB_ID}" ] && _db_update_rc=1 && rm -f "/tmp/.db_fallback_${SLURM_JOB_ID}"
+else
+    _db_update_rc=1  # No DB_JOB_ID — force fallback
+fi
+
+if [ "$_db_update_rc" -ne 0 ]; then
+    # Fallback: create Started entry directly (Pending entry missing/deleted, or no DB_JOB_ID)
+    echo "Creating new Started entry (fallback)..."
+    proxied $PYTHON_BIN - <<'PY' || true
+import os, sys
+
+from database.unified_db.utils import create_job_entry_started
+
+model_hf = os.environ["MODEL"]
+dataset_hf = os.environ["REPO_ID"]
+run_tag = os.environ["RUN_TAG"]
+slurm_job_id = os.environ["SLURM_JOB_ID"]
+harbor_version = os.environ.get("HARBOR_VERSION", "unknown")
+agent_name = os.environ.get("EVAL_AGENT_NAME", "terminus-2")
+n_concurrent = int(os.environ.get("EVAL_N_CONCURRENT", "128"))
+n_attempts = int(os.environ.get("EVAL_N_ATTEMPTS", "3"))
+
+result = create_job_entry_started(
+    model_hf_name=model_hf,
+    benchmark_hf_name=dataset_hf,
+    job_name=run_tag,
+    username=os.environ.get("USER", "jupiter"),
+    slurm_job_id=slurm_job_id,
+    harbor_package_version=harbor_version,
+    agent_name=agent_name,
+    config={"agent": agent_name, "env": "daytona"},
+    n_trials=n_concurrent,
+    n_rep_eval=n_attempts
+)
+
+if not result.get("success"):
+    print(f"WARNING: DB create failed: {result.get('error')}", file=sys.stderr)
+    sys.exit(0)
+
+db_job_id = result["job"]["id"]
+print(f"DB job created with ID: {db_job_id}")
+PY
+
+    # Get the DB job ID for later use
+    DB_JOB_ID=$(proxied $PYTHON_BIN - <<'PY' || true
+import os, sys
+
+from database.unified_db.utils import get_latest_job_for_model_benchmark
+
+model_hf = os.environ["MODEL"]
+dataset_hf = os.environ["REPO_ID"]
+
+try:
+    result = get_latest_job_for_model_benchmark(model_hf, dataset_hf)
+    if result and result.get("id"):
+        print(result["id"])
+except Exception as e:
+    print(f"WARNING: DB lookup failed: {e}", file=sys.stderr)
+PY
+)
+fi
+
+if [ -z "${DB_JOB_ID:-}" ]; then
+    echo "WARNING: Failed to get DB job ID"
+else
+    echo "DB job entry: $DB_JOB_ID"
+fi
+
+# ==============================================================================
+# Eval Starts Log (v4 — for model retry tracking)
+# ==============================================================================
+if [ -n "$EVAL_STARTS_LOG" ]; then
+    echo "${TIMESTAMP} ${MODEL} ${REPO_ID} ${SLURM_JOB_ID} ${RUN_TAG}" >> "$EVAL_STARTS_LOG"
+    echo "Logged eval start to: $EVAL_STARTS_LOG"
+fi
+
+# ==============================================================================
+# Run Harbor Eval (via proxychains for Daytona access)
+# ==============================================================================
+set +e
+
+# Resolve config path: check eval/configs/ (canonical), then legacy per-cluster dirs
+if [[ "$CONFIG_YAML" != /* ]]; then
+    if [ -f "$DCFT/eval/configs/$CONFIG_YAML" ]; then
+        HARBOR_CONFIG="$DCFT/eval/configs/$CONFIG_YAML"
+    elif [ -f "$DCFT/eval/${CLUSTER_NAME}/$CONFIG_YAML" ]; then
+        HARBOR_CONFIG="$DCFT/eval/${CLUSTER_NAME}/$CONFIG_YAML"
+    elif [ -f "$DCFT/eval/MBZ/$CONFIG_YAML" ]; then
+        HARBOR_CONFIG="$DCFT/eval/MBZ/$CONFIG_YAML"
+    else
+        echo "ERROR: Harbor config not found: $CONFIG_YAML"
+        exit 1
+    fi
+else
+    HARBOR_CONFIG="$CONFIG_YAML"
+fi
+echo "Resolved harbor config: $HARBOR_CONFIG"
+
+# Build extra harbor args
+EXTRA_HARBOR_ARGS=""
+if [ -n "${EVAL_SNAPSHOT_NAME:-}" ]; then
+    echo "Using Daytona snapshot: $EVAL_SNAPSHOT_NAME"
+    EXTRA_HARBOR_ARGS="--environment-kwarg snapshot_template_name=$EVAL_SNAPSHOT_NAME --no-force-build"
+fi
+if [ "$TIMEOUT_MULTIPLIER" != "1" ] && [ "$TIMEOUT_MULTIPLIER" != "1.0" ]; then
+    echo "Using timeout multiplier: $TIMEOUT_MULTIPLIER"
+    EXTRA_HARBOR_ARGS="$EXTRA_HARBOR_ARGS --timeout-multiplier $TIMEOUT_MULTIPLIER"
+fi
+if [ -n "${EVAL_OVERRIDE_MEMORY_MB:-}" ]; then
+    echo "Using memory override: ${EVAL_OVERRIDE_MEMORY_MB}MB"
+    EXTRA_HARBOR_ARGS="$EXTRA_HARBOR_ARGS --override-memory-mb $EVAL_OVERRIDE_MEMORY_MB"
+fi
+# auto_snapshot override from listener (overrides YAML config value)
+if [ -n "${EVAL_AUTO_SNAPSHOT:-}" ]; then
+    echo "Auto snapshot override: $EVAL_AUTO_SNAPSHOT"
+    EXTRA_HARBOR_ARGS="$EXTRA_HARBOR_ARGS --environment-kwarg auto_snapshot=$EVAL_AUTO_SNAPSHOT"
+fi
+
+# Build thinking args
+THINKING_ARGS=""
+if [ "$ENABLE_THINKING" = "true" ]; then
+    echo "Thinking enabled"
+    THINKING_ARGS='--agent-kwarg "enable_thinking=true"'
+fi
+
+# Build agent-parser args
+PARSER_ARGS=""
+if [ -n "$AGENT_PARSER" ]; then
+    echo "Agent parser: $AGENT_PARSER"
+    PARSER_ARGS="--agent-kwarg \"parser=$AGENT_PARSER\""
+fi
+
+echo "[DEBUG] EXTRA_HARBOR_ARGS=$EXTRA_HARBOR_ARGS"
+echo "[DEBUG] DAYTONA_API_KEY=${DAYTONA_API_KEY:0:20}..."
+
+# Check if a previous job dir exists for this run tag (for resume)
+# Skip resume if EVAL_FORCE_FRESH=true
+EXISTING_JOB_DIR="${EVAL_JOBS_DIR}/${RUN_TAG}"
+if [ "${EVAL_FORCE_FRESH:-false}" != "true" ] && [ -d "$EXISTING_JOB_DIR" ] && [ -f "$EXISTING_JOB_DIR/config.json" ]; then
+    echo "Found existing job dir, resuming: $EXISTING_JOB_DIR"
+    proxied $HARBOR_BIN jobs resume \
+        -p "$EXISTING_JOB_DIR" \
+        --filter-error-type EnvironmentStartTimeoutError \
+        --filter-error-type DaytonaError \
+        --filter-error-type DaytonaAuthenticationError \
+        --filter-error-type DaytonaAuthorizationError \
+        --filter-error-type DaytonaNotFoundError \
+        --filter-error-type DaytonaRateLimitError \
+        --filter-error-type CancelledError \
+        --filter-error-type AgentEnvironmentTimeoutError \
+        --filter-error-type SandboxBuildFailedError
+else
+    echo "Starting new job"
+
+    # Short-term fix: inject model_name into a temp copy of the YAML config so that
+    # we do NOT pass --agent on the CLI. Passing --agent causes Harbor to wipe the
+    # entire agents[] section from the YAML and rebuild from CLI flags only, losing
+    # all YAML agent settings (max_timeout_sec, trajectory_config, kwargs like
+    # proactive_summarization_threshold, etc.). By omitting --agent, Harbor uses the
+    # YAML agents[] and --agent-kwarg values are MERGED into it.
+    # See: harbor/src/harbor/cli/jobs.py lines 715-748
+    # Long-term fix: Harbor PR to merge CLI --agent with YAML instead of replacing.
+    RUNTIME_HARBOR_CONFIG="/tmp/harbor_config_${SLURM_JOB_ID}.yaml"
+    python3 -c "
+import yaml
+
+with open('${HARBOR_CONFIG}') as f:
+    cfg = yaml.safe_load(f)
+
+agent = cfg['agents'][0]
+
+# Model prefix routing for litellm:
+# - hosted_vllm/: terminus family (in-process), oracle/nop (utility), mini-swe-agent
+#   (installed agent but routes via hosted_vllm provider + auto-generates registry)
+# - openai/: aider, openhands, and other installed agents using openai-compatible provider
+_HOSTED_VLLM_PREFIX_AGENTS = {
+    'terminus', 'terminus-1', 'terminus-2', 'terminus-kira',
+    'oracle', 'nop',
+    'mini-swe-agent',
+    'swe-agent',
+}
+agent_name = agent.get('name', 'terminus-2')
+if agent_name in _HOSTED_VLLM_PREFIX_AGENTS:
+    agent['model_name'] = 'hosted_vllm/${MODEL}'
+else:
+    agent['model_name'] = 'openai/${MODEL}'
+
+# Merge model_info and max_tokens: YAML values take priority, CLI defaults fill gaps.
+kwargs = agent.setdefault('kwargs', {})
+
+# Default model_info values (used only if YAML doesn't specify them)
+defaults = {
+    'max_output_tokens': ${EVAL_MAX_OUTPUT_TOKENS:-16384},
+    'max_input_tokens': ${EVAL_MAX_INPUT_TOKENS:-32768},
+    'input_cost_per_token': 0.0,
+    'output_cost_per_token': 0.0,
+}
+yaml_model_info = kwargs.get('model_info', {})
+# Fill in any missing keys from defaults
+for k, v in defaults.items():
+    yaml_model_info.setdefault(k, v)
+kwargs['model_info'] = yaml_model_info
+
+# max_tokens defaults to max_output_tokens from the resolved model_info
+kwargs.setdefault('max_tokens', yaml_model_info['max_output_tokens'])
+
+with open('${RUNTIME_HARBOR_CONFIG}', 'w') as f:
+    yaml.dump(cfg, f, default_flow_style=False)
+"
+    echo "[DEBUG] Injected model_name + model_info into runtime config: $RUNTIME_HARBOR_CONFIG"
+
+    # ==========================================================================
+    # Tunnel for installed agents (Pinggy preferred, ngrok fallback)
+    # Installed agents (aider, openhands, etc.) execute their CLI inside the
+    # remote Daytona container and cannot reach localhost on the SLURM node.
+    # A public tunnel exposes the vLLM server via a URL the sandbox can reach.
+    # ==========================================================================
+    _CFG_AGENT_NAME=$($PYTHON_BIN -c "
+import yaml
+with open('$RUNTIME_HARBOR_CONFIG') as f:
+    cfg = yaml.safe_load(f)
+agents = cfg.get('agents', [])
+print(agents[0].get('name', 'terminus-2') if agents else 'terminus-2')
+" 2>/dev/null || echo "terminus-2")
+
+    _NEEDS_TUNNEL=false
+    case "$_CFG_AGENT_NAME" in
+        terminus|terminus-1|terminus-2|terminus-kira|oracle|nop)
+            echo "[tunnel] Agent '$_CFG_AGENT_NAME' runs on host — tunnel not needed."
+            ;;
+        *)
+            _NEEDS_TUNNEL=true
+            echo "[tunnel] Installed agent '$_CFG_AGENT_NAME' runs in sandbox — need tunnel to vLLM."
+            ;;
+    esac
+
+    if [ "$_NEEDS_TUNNEL" = true ]; then
+        TUNNEL_URL=""
+
+        # --- Try Pinggy first (SSH-based, persistent URL, no bandwidth limit) ---
+        if [ -n "${EVAL_PINGGY_URL:-}" ] && [ -n "${EVAL_PINGGY_TOKEN:-}" ]; then
+            echo "[pinggy] Starting SSH tunnel to ${EVAL_PINGGY_URL} (port $VLLM_PORT)..."
+            PINGGY_LOG="$EVAL_LOGS_DIR/pinggy_${SLURM_JOB_ID}.log"
+
+            bash -c "while true; do ssh -p 443 \
+                -R0:localhost:${VLLM_PORT} \
+                -o StrictHostKeyChecking=no \
+                -o ServerAliveInterval=30 \
+                -o ExitOnForwardFailure=yes \
+                ${EVAL_PINGGY_TOKEN}@pro.pinggy.io; \
+                sleep 10; done" > "$PINGGY_LOG" 2>&1 &
+            PINGGY_PID=$!
+            echo "[pinggy] Started with PID $PINGGY_PID"
+
+            # Wait for SSH to establish (5s stabilization)
+            _PINGGY_OK=true
+            for _pg_i in $(seq 1 5); do
+                sleep 1
+                if ! kill -0 "$PINGGY_PID" 2>/dev/null; then
+                    echo "[pinggy] ERROR: tunnel process died during startup"
+                    cat "$PINGGY_LOG" 2>/dev/null || true
+                    PINGGY_PID=""
+                    _PINGGY_OK=false
+                    break
+                fi
+            done
+
+            if [ "$_PINGGY_OK" = true ]; then
+                TUNNEL_URL="https://${EVAL_PINGGY_URL}"
+                # Verify connectivity
+                if curl -sk "${TUNNEL_URL}/v1/models" 2>/dev/null | grep -q "object"; then
+                    echo "[pinggy] Connectivity verified: $TUNNEL_URL"
+                else
+                    echo "[pinggy] WARNING: connectivity test failed, continuing anyway..."
+                fi
+            fi
+        fi
+
+        # --- Fallback to ngrok ---
+        if [ -z "$TUNNEL_URL" ]; then
+            echo "[tunnel] Pinggy not available, trying ngrok..."
+            NGROK_PATH="${EVAL_NGROK_PATH:-$HOME/ngrok}"
+            NGROK_LOG="$EVAL_LOGS_DIR/ngrok_${SLURM_JOB_ID}.log"
+
+            if [ -x "$NGROK_PATH" ]; then
+                # Check if an existing ngrok tunnel is available (from another job on same node)
+                NGROK_URL=$(curl -s localhost:4040/api/tunnels 2>/dev/null \
+                    | grep -o '"public_url":"https://[^"]*"' | head -1 | cut -d'"' -f4)
+                if [ -n "$NGROK_URL" ]; then
+                    echo "[ngrok] Reusing existing tunnel: $NGROK_URL"
+                    TUNNEL_URL="$NGROK_URL"
+                else
+                    "$NGROK_PATH" http "$VLLM_PORT" --log=stdout > "$NGROK_LOG" 2>&1 &
+                    NGROK_PID=$!
+                    echo "[ngrok] Started with PID $NGROK_PID, tunneling port $VLLM_PORT"
+
+                    for _ng_i in $(seq 1 15); do
+                        NGROK_URL=$(curl -s localhost:4040/api/tunnels 2>/dev/null \
+                            | grep -o '"public_url":"https://[^"]*"' | head -1 | cut -d'"' -f4)
+                        [ -n "$NGROK_URL" ] && break
+                        echo "[ngrok] Waiting for tunnel (attempt $_ng_i/15)..."
+                        sleep 2
+                    done
+
+                    if [ -n "$NGROK_URL" ]; then
+                        TUNNEL_URL="$NGROK_URL"
+                        echo "[ngrok] Tunnel established: $NGROK_URL"
+                    else
+                        echo "[ngrok] ERROR: Failed to establish ngrok tunnel"
+                        cat "$NGROK_LOG" 2>/dev/null || true
+                    fi
+                fi
+            else
+                echo "[ngrok] Binary not found at $NGROK_PATH, skipping."
+            fi
+        fi
+
+        # --- Final check ---
+        if [ -z "$TUNNEL_URL" ]; then
+            echo "ERROR: No tunnel available for installed agent '$_CFG_AGENT_NAME'."
+            echo "  Set EVAL_PINGGY_URL + EVAL_PINGGY_TOKEN, or install ngrok at $HOME/ngrok"
+            exit 1
+        fi
+
+        export OPENAI_API_KEY="fake_key"
+        export OPENAI_API_BASE="${TUNNEL_URL}/v1"
+        echo "[tunnel] OPENAI_API_BASE=${TUNNEL_URL}/v1"
+        # OpenHands-specific: it reads LLM_BASE_URL which takes priority over
+        # --agent-kwarg api_base=localhost. Export explicitly to override.
+        if [ "$_CFG_AGENT_NAME" = "openhands" ]; then
+            export LLM_BASE_URL="${TUNNEL_URL}/v1"
+            export LLM_API_KEY="fake_key"
+            echo "[tunnel] LLM_BASE_URL=${TUNNEL_URL}/v1 (openhands)"
+        fi
+        # mini-swe-agent reads MSWEA_MODEL_API_KEY (not LLM_API_KEY) and MSWEA_MODEL_API_BASE.
+        # Gate on agent name so other installed agents' env is untouched.
+        if [ "$_CFG_AGENT_NAME" = "mini-swe-agent" ]; then
+            export MSWEA_MODEL_API_KEY="fake_key"
+            export MSWEA_MODEL_API_BASE="${TUNNEL_URL}/v1"
+            # litellm's hosted_vllm provider reads HOSTED_VLLM_API_BASE inside the
+            # sandbox (NOT OPENAI_API_BASE or MSWEA_MODEL_API_BASE). Without this,
+            # litellm falls back to https://api.openai.com and every call 404s.
+            # The harbor agent forwards this env var into the sandbox via setdefault.
+            export HOSTED_VLLM_API_BASE="${TUNNEL_URL}/v1"
+            # Token limits used by mini-swe-agent to auto-generate litellm cost-registry in sandbox.
+            # Match our default max_input/max_output so the registry reflects real vLLM capacity.
+            export MSWEA_MODEL_MAX_TOKENS="${EVAL_MAX_INPUT_TOKENS:-32768}"
+            export MSWEA_MODEL_MAX_OUTPUT_TOKENS="${EVAL_MAX_OUTPUT_TOKENS:-16384}"
+            # Tiny non-zero per-token costs so the auto-generated registry's cost
+            # calculation returns > 0 (mini-swe-agent crashes with "Cost must be > 0.0"
+            # when cost == 0). Local vLLM has no real cost; this is a placeholder.
+            export MSWEA_MODEL_INPUT_COST_PER_TOKEN="${MSWEA_MODEL_INPUT_COST_PER_TOKEN:-1e-10}"
+            export MSWEA_MODEL_OUTPUT_COST_PER_TOKEN="${MSWEA_MODEL_OUTPUT_COST_PER_TOKEN:-1e-10}"
+            echo "[tunnel] MSWEA_MODEL_API_BASE=${TUNNEL_URL}/v1 (for mini-swe-agent)"
+            echo "[tunnel] HOSTED_VLLM_API_BASE=${TUNNEL_URL}/v1 (for mini-swe-agent)"
+        fi
+        # swe-agent needs SWEAGENT_CONFIG (URL or local path) and reads OPENAI_BASE_URL
+        # with priority over the --agent-kwarg api_base=localhost (which would fail in sandbox).
+        if [ "$_CFG_AGENT_NAME" = "swe-agent" ]; then
+            # Upstream config on harbor/main. The legacy URL pointed to Negin's branch
+            # which has since been deleted (404s silently via curl -sSL, causing sweagent
+            # to parse a "404: Not Found" body as YAML and fail with NonZeroAgentExitCodeError).
+            export SWEAGENT_CONFIG="${SWEAGENT_CONFIG:-https://raw.githubusercontent.com/laude-institute/harbor/refs/heads/main/examples/configs/swe-agent-infer-single.yaml}"
+            export OPENAI_BASE_URL="${TUNNEL_URL}/v1"
+            echo "[tunnel] SWEAGENT_CONFIG=$SWEAGENT_CONFIG (for swe-agent)"
+            echo "[tunnel] OPENAI_BASE_URL=${TUNNEL_URL}/v1 (for swe-agent)"
+        fi
+    fi
+
+    # Build command as array to handle quoting properly
+    # NOTE: --agent and --model are NOT passed here. Agent name and model come from
+    # the YAML config. model_info and max_tokens are set in the Python config injection
+    # above (YAML values take priority, CLI env var defaults fill gaps).
+    HARBOR_CMD=(
+        proxied $HARBOR_BIN jobs start
+        -p "$DATASET_PATH"
+        --n-concurrent "$N_CONCURRENT"
+        --env "daytona"
+        --agent-kwarg "api_base=http://localhost:${HARBOR_API_PORT}/v1"
+        --agent-kwarg "key=fake_key"
+        --n-attempts "$N_ATTEMPTS"
+        --job-name "$RUN_TAG"
+        --export-traces
+        --config "$RUNTIME_HARBOR_CONFIG"
+        --jobs-dir "$EVAL_JOBS_DIR"
+        --debug
+    )
+    # Add optional args
+    if [ "$ENABLE_THINKING" = "true" ]; then
+        HARBOR_CMD+=(--agent-kwarg "enable_thinking=true")
+    fi
+    if [ -n "$AGENT_PARSER" ]; then
+        HARBOR_CMD+=(--agent-kwarg "parser=$AGENT_PARSER")
+    fi
+
+    # Forward env vars into the Daytona sandbox (e.g. API keys for tools).
+    # EVAL_AGENT_ENVS is a comma-separated list of KEY=VALUE pairs.
+    if [ -n "${EVAL_AGENT_ENVS:-}" ]; then
+        IFS=',' read -ra _AE_PAIRS <<< "$EVAL_AGENT_ENVS"
+        for _ae in "${_AE_PAIRS[@]}"; do
+            _ae=$(echo "$_ae" | xargs)  # trim whitespace
+            [ -n "$_ae" ] && HARBOR_CMD+=(--ae "$_ae")
+        done
+        echo "[DEBUG] Agent env vars: ${#_AE_PAIRS[@]} pairs forwarded via --ae"
+    fi
+
+    # Print command with secrets redacted
+    _DEBUG_CMD="${HARBOR_CMD[*]} $EXTRA_HARBOR_ARGS"
+    _DEBUG_CMD=$(echo "$_DEBUG_CMD" | sed -E 's/(--ae [A-Z_]+=)[^ ]*/\1<redacted>/g')
+    echo "[DEBUG] Full harbor command:"
+    echo "  $_DEBUG_CMD"
+
+    "${HARBOR_CMD[@]}" $EXTRA_HARBOR_ARGS
+fi
+SB_EXIT=$?
+set -e
+
+# ==============================================================================
+# Save meta.env (v4 — extended fields)
+# ==============================================================================
+# Track resume count
+RESUME_COUNT=0
+if [ -f "$RUN_DIR/meta.env" ]; then
+    OLD_RESUME_COUNT=$(grep -oP 'RESUME_COUNT=\K[0-9]+' "$RUN_DIR/meta.env" 2>/dev/null || echo "0")
+    RESUME_COUNT=$((OLD_RESUME_COUNT + 1))
+    echo "Resume count: $RESUME_COUNT (was $OLD_RESUME_COUNT)"
+fi
+
+mkdir -p "$RUN_DIR"
+{
+    echo "MODEL=$MODEL"
+    echo "REPO_ID=$REPO_ID"
+    echo "TIMESTAMP=$TIMESTAMP"
+    echo "SLURM_JOB_ID=$SLURM_JOB_ID"
+    echo "DB_JOB_ID=${DB_JOB_ID:-}"
+    echo "BENCHMARK_ID=${BENCHMARK_ID:-}"
+    echo "N_CONCURRENT=$N_CONCURRENT"
+    echo "N_ATTEMPTS=$N_ATTEMPTS"
+    echo "GPU_MEMORY_UTIL=$GPU_MEMORY_UTIL"
+    echo "AGENT_NAME=$AGENT_NAME"
+    echo "AGENT_PARSER=${AGENT_PARSER:-}"
+    echo "ENABLE_THINKING=$ENABLE_THINKING"
+    echo "TIMEOUT_MULTIPLIER=$TIMEOUT_MULTIPLIER"
+    echo "BENCHMARK_NAME=$BENCHMARK_NAME"
+    echo "RESUME_COUNT=$RESUME_COUNT"
+} > "$RUN_DIR/meta.env"
+
+# If eval failed, don't attempt upload
+if [ ${SB_EXIT:-0} -ne 0 ]; then
+    echo "Harbor eval exited with non-zero status: ${SB_EXIT}. Skipping upload."
+    exit ${SB_EXIT}
+fi
+
+# Ensure run dir exists
+if [ ! -d "$RUN_DIR" ]; then
+    echo "Expected run directory not found: $RUN_DIR"
+    exit 2
+fi
+
+# ==============================================================================
+# Check for errors before upload (v4 unified error checking)
+# Counts ALL errors except known-benign types:
+#   AgentTimeoutError, BadRequestError, ContextLengthExceededError,
+#   SummarizationTimeout, SummarizationTimeoutError
+# NOTE: AgentEnvironmentTimeoutError is NOT benign (infra issue, not model's fault)
+#   but is excluded from retry (retrying won't help)
+# ==============================================================================
+RESULT_FILE="$RUN_DIR/result.json"
+ERROR_LOG="${EVAL_JOBS_DIR}/invalid_errors_${SLURM_JOB_ID}.log"
+
+if [ -f "$RESULT_FILE" ]; then
+    echo "Checking for invalid errors in $RESULT_FILE..."
+
+    INVALID_COUNT=$($PYTHON_BIN -c "
+import json, sys
+try:
+    with open('$RESULT_FILE', 'r') as f:
+        data = json.load(f)
+
+    BENIGN_ERRORS = {
+        'AgentTimeoutError',
+        'BadRequestError',
+        'ContextLengthExceededError',
+        'SummarizationTimeout',
+        'SummarizationTimeoutError',
+    }
+
+    total_invalid = 0
+    if 'stats' in data and 'evals' in data['stats']:
+        for eval_key, eval_data in data['stats']['evals'].items():
+            if 'exception_stats' in eval_data:
+                for err_type, err_ids in eval_data['exception_stats'].items():
+                    if err_type not in BENIGN_ERRORS:
+                        if isinstance(err_ids, list):
+                            total_invalid += len(err_ids)
+    print(total_invalid)
+except Exception as e:
+    print(f'Error parsing result.json: {e}', file=sys.stderr)
+    print('0')
+" 2>&1 | tail -n 1)
+
+    echo "Invalid error count: ${INVALID_COUNT} (threshold: ${ERROR_THRESHOLD})"
+
+    if [ "${INVALID_COUNT:-0}" -gt "$ERROR_THRESHOLD" ]; then
+        echo "Job has ${INVALID_COUNT} invalid errors (> ${ERROR_THRESHOLD}), skipping upload"
+
+        {
+            echo "==============================================="
+            echo "Timestamp: $(date)"
+            echo "Job: ${RUN_TAG}"
+            echo "SLURM_JOB_ID: ${SLURM_JOB_ID}"
+            echo "Model: ${MODEL}"
+            echo "Repo: ${REPO_ID}"
+            echo "Invalid errors: ${INVALID_COUNT}"
+            echo "Result file: ${RESULT_FILE}"
+            $PYTHON_BIN -c "
+import json
+BENIGN = {'AgentTimeoutError', 'ContextLengthExceededError', 'SummarizationTimeout', 'SummarizationTimeoutError'}
+with open('$RESULT_FILE', 'r') as f:
+    data = json.load(f)
+if 'stats' in data and 'evals' in data['stats']:
+    for eval_key, eval_data in data['stats']['evals'].items():
+        if 'exception_stats' in eval_data:
+            for err_type, err_ids in eval_data['exception_stats'].items():
+                if err_type not in BENIGN and err_ids:
+                    print(f'Eval: {eval_key} / {err_type}')
+                    for i, error_id in enumerate(err_ids[:10], 1):
+                        print(f'  {i}. {error_id}')
+                    if len(err_ids) > 10:
+                        print(f'  ... and {len(err_ids) - 10} more')
+" 2>/dev/null || true
+            echo "==============================================="
+        } >> "$ERROR_LOG"
+
+        echo "Error details logged to: $ERROR_LOG"
+        echo "Job completed but not uploaded due to excessive invalid errors"
+        exit 0
+    fi
+else
+    echo "Warning: result.json not found, continuing with upload"
+fi
+
+# ==============================================================================
+# Upload results to DB (via proxychains for HF upload)
+# ==============================================================================
+export RUN_DIR
+export UPLOAD_USERNAME
+export UPLOAD_MODE="${UPLOAD_MODE:-skip_on_error}"
+export RUN_TAG
+
+UPLOAD_LOG="${EVAL_LOGS_DIR:-eval/logs}/upload_${SLURM_JOB_ID}.log"
+mkdir -p "$(dirname "$UPLOAD_LOG")"
+
+echo "Uploading results from: $RUN_DIR" | tee -a "$UPLOAD_LOG"
+echo "Using username=${UPLOAD_USERNAME}, mode=${UPLOAD_MODE}" | tee -a "$UPLOAD_LOG"
+
+proxied $PYTHON_BIN - <<'PY' 2>&1 | tee -a "$UPLOAD_LOG"
+import os, sys, re, hashlib
+
+from database.unified_db.utils import upload_eval_results
+
+
+def sanitize_hf_repo_id(repo_id: str, max_length: int = 96) -> str:
+    def collapse(s: str) -> str:
+        prev = None
+        while s != prev:
+            prev = s
+            s = s.replace("--", "-").replace("..", ".")
+        return s
+
+    org, name = repo_id.split("/", 1) if "/" in repo_id else (None, repo_id)
+    name = re.sub(r"[^A-Za-z0-9._-]", "-", name)
+    name = collapse(name).strip("-.")
+    if not name:
+        name = "repo"
+
+    limit = max_length - (len(org) + 1 if org else 0)
+    if len(name) > limit:
+        digest = hashlib.sha1(name.encode()).hexdigest()[:8]
+        keep = max(1, limit - len(digest))
+        base = name[:keep].rstrip("-.")
+        if not base:
+            base = "r"
+        name = f"{base}{digest}"
+        name = collapse(name).strip("-.")
+
+    name = collapse(name).strip("-.")
+    if name[0] in "-.":
+        name = "r" + name[1:]
+    if name[-1] in "-.":
+        name = name[:-1] + "0"
+
+    return f"{org}/{name}" if org else name
+
+
+run_dir = os.environ["RUN_DIR"]
+run_tag = os.environ["RUN_TAG"]
+username = os.environ.get("UPLOAD_USERNAME", os.environ.get("USER", "jupiter"))
+error_mode = os.environ.get("UPLOAD_MODE", "skip_on_error")
+hf_repo_id = sanitize_hf_repo_id(f"DCAgent2/{run_tag}")
+hf_token = os.environ["HF_TOKEN"]
+
+print(f"[uploader] upload_eval_results(path={run_dir!r}, username={username!r}, "
+      f"error_mode={error_mode!r}, hf_repo_id={hf_repo_id!r})")
+dataset_hf = os.environ.get("REPO_ID", "")
+# Use the canonical benchmark name computed in the shell section,
+# which handles local paths and timeout/memory suffixes correctly.
+benchmark_name = os.environ.get("BENCHMARK_NAME", "")
+if not benchmark_name:
+    # Fallback: derive from REPO_ID (legacy behavior)
+    benchmark_name = dataset_hf.split("/")[-1] if "/" in dataset_hf else dataset_hf
+
+# Compute a stable benchmark_version_hash from the benchmark name
+import hashlib
+benchmark_version_hash = hashlib.sha256(benchmark_name.encode()).hexdigest()
+print(f"[uploader] benchmark_name={benchmark_name!r}, version_hash={benchmark_version_hash[:16]}...")
+
+upload_eval_results(
+    run_dir,
+    username=username,
+    error_mode=error_mode,
+    hf_token=hf_token,
+    hf_repo_id=hf_repo_id,
+    register_benchmark=True,
+    benchmark_name=benchmark_name,
+    benchmark_version_hash=benchmark_version_hash,
+)
+print("[uploader] done.")
+PY
+UPLOAD_EXIT=${PIPESTATUS[0]}
+
+if [ $UPLOAD_EXIT -ne 0 ]; then
+    echo "Upload failed with exit code: $UPLOAD_EXIT"
+    exit $UPLOAD_EXIT
+fi
+
+echo "=============================================="
+echo "Eval and upload finished successfully."
+echo "=============================================="

--- a/eval/unified_eval_harbor.sbatch
+++ b/eval/unified_eval_harbor.sbatch
@@ -827,6 +827,28 @@ echo "[DEBUG] DAYTONA_API_KEY=${DAYTONA_API_KEY:0:20}..."
 EXISTING_JOB_DIR="${EVAL_JOBS_DIR}/${RUN_TAG}"
 if [ "${EVAL_FORCE_FRESH:-false}" != "true" ] && [ -d "$EXISTING_JOB_DIR" ] && [ -f "$EXISTING_JOB_DIR/config.json" ]; then
     echo "Found existing job dir, resuming: $EXISTING_JOB_DIR"
+    # Patch stale api_base port from prior SLURM run → current vLLM port. The
+    # vLLM port formula is JID-derived (10000 + SLURM_JOB_ID%50000), so every
+    # resume has a different port than the saved config.json. Without this
+    # patch, terminus agents call the OLD port → "Connect call failed" → all
+    # trials fail. (Confirmed empirically on JID 428153, 2026-05-07.)
+    #
+    # We must patch BOTH the job-level config.json AND every per-trial
+    # config.json. Harbor's resume code (harbor/job.py:_init_remaining_trial_configs)
+    # compares per-trial TrialConfig equality (excluding trial_name) to subtract
+    # finished trials from the run queue. Without per-trial patches, every
+    # existing trial's saved api_base mismatches the freshly generated config →
+    # __eq__ fails → harbor logs "Existing trial X not found in generated configs;
+    # skipping" → all n_attempts × n_tasks trials get re-run from scratch.
+    # (Confirmed empirically on JID 428210, 2026-05-08.)
+    echo "Patching api_base port in config.json: -> localhost:${VLLM_PORT}"
+    sed -i.bak-port "s|\"api_base\": \"http://localhost:[0-9]\+/|\"api_base\": \"http://localhost:${VLLM_PORT}/|g" "$EXISTING_JOB_DIR/config.json"
+    PATCHED_TRIAL_COUNT=$(find "$EXISTING_JOB_DIR" -mindepth 2 -maxdepth 2 -name config.json -print 2>/dev/null | wc -l)
+    if [ "$PATCHED_TRIAL_COUNT" -gt 0 ]; then
+        echo "Patching api_base port in $PATCHED_TRIAL_COUNT per-trial config.json files: -> localhost:${VLLM_PORT}"
+        find "$EXISTING_JOB_DIR" -mindepth 2 -maxdepth 2 -name config.json -print0 2>/dev/null | \
+            xargs -0 -r sed -i.bak-port "s|\"api_base\": \"http://localhost:[0-9]\+/|\"api_base\": \"http://localhost:${VLLM_PORT}/|g"
+    fi
     proxied $HARBOR_BIN jobs resume \
         -p "$EXISTING_JOB_DIR" \
         --filter-error-type EnvironmentStartTimeoutError \

--- a/eval/unified_eval_harbor.sbatch
+++ b/eval/unified_eval_harbor.sbatch
@@ -1308,7 +1308,7 @@ run_dir = os.environ["RUN_DIR"]
 run_tag = os.environ["RUN_TAG"]
 username = os.environ.get("UPLOAD_USERNAME", os.environ.get("USER", "jupiter"))
 error_mode = os.environ.get("UPLOAD_MODE", "skip_on_error")
-hf_repo_id = sanitize_hf_repo_id(f"DCAgent2/{run_tag}")
+hf_repo_id = sanitize_hf_repo_id(f"DCAgent3/{run_tag}")
 hf_token = os.environ["HF_TOKEN"]
 
 print(f"[uploader] upload_eval_results(path={run_dir!r}, username={username!r}, "

--- a/eval/unified_eval_harbor.sbatch
+++ b/eval/unified_eval_harbor.sbatch
@@ -227,9 +227,11 @@ echo "Python: $($PYTHON_BIN --version)"
 harbor --help >/dev/null
 export RAY_DEDUP_LOGS=0
 
-# Set CUDA_HOME for flashinfer JIT compilation (needs nvcc)
-# The CUDA module provides nvcc at this path on Jupiter GH200 nodes.
-_CUDA_HOME="${EVAL_CUDA_HOME:-/e/software/default/stages/2026/software/CUDA/13}"
+# Set CUDA_HOME for flashinfer JIT compilation (needs nvcc).
+# Set EVAL_CUDA_HOME in your dotenv (see hpc/dotenv/example.env) to point
+# at the CUDA module that ships nvcc on your cluster. If unset, we leave
+# CUDA_HOME alone and trust whatever the conda env / system already has.
+_CUDA_HOME="${EVAL_CUDA_HOME:-}"
 if [ -n "${_CUDA_HOME}" ] && [ -d "${_CUDA_HOME}" ]; then
     export CUDA_HOME="${_CUDA_HOME}"
     export PATH="$CUDA_HOME/bin:$PATH"
@@ -242,11 +244,19 @@ fi
 
 NODE_HOST=$(hostname -s)
 TUNNEL_PORT=7003
-LOGIN_NODE="${EVAL_LOGIN_NODE:-jpbl-s01-02}"
+# EVAL_LOGIN_NODE: hostname of the login node that compute nodes can SSH to
+# for outbound connectivity (Daytona, HF). Required for no-internet clusters
+# that go through proxy.enabled=true in the cluster config; ignored otherwise.
+LOGIN_NODE="${EVAL_LOGIN_NODE:-}"
 PROXYCHAINS_BIN="${EVAL_PROXYCHAINS_BIN:-}"
 TUNNEL_PID=""
 
 setup_proxy() {
+    if [ -z "${LOGIN_NODE}" ]; then
+        echo "[proxy] ERROR: EVAL_LOGIN_NODE not set."
+        echo "[proxy] No-internet clusters must export EVAL_LOGIN_NODE in their dotenv."
+        return 1
+    fi
     echo "[proxy] Setting up SSH tunnel to $LOGIN_NODE..."
 
     if [ -z "${SSH_KEY:-}" ]; then
@@ -1194,7 +1204,7 @@ except Exception as e:
             echo "Result file: ${RESULT_FILE}"
             $PYTHON_BIN -c "
 import json
-BENIGN = {'AgentTimeoutError', 'ContextLengthExceededError', 'SummarizationTimeout', 'SummarizationTimeoutError'}
+BENIGN = {'AgentTimeoutError', 'BadRequestError', 'ContextLengthExceededError', 'SummarizationTimeout', 'SummarizationTimeoutError'}
 with open('$RESULT_FILE', 'r') as f:
     data = json.load(f)
 if 'stats' in data and 'evals' in data['stats']:

--- a/eval/unified_eval_listener.py
+++ b/eval/unified_eval_listener.py
@@ -1,0 +1,4127 @@
+#!/usr/bin/env python3
+"""
+Unified Eval Listener v6 - Polls Supabase for models and submits SLURM eval jobs.
+
+Based on v5, with disk-based resume replacing the v5 DB-based DaytonaError resume.
+Scans the eval jobs directory for incomplete/error-heavy jobs and resubmits them
+with the same run_tag so harbor auto-resumes (skips completed trials, retries failed ones).
+
+Key v6 features over v5:
+  - Disk-based resume: scans --jobs-dir for incomplete/errored job dirs
+  - Persistent sliding-window batch_size across iterations
+  - hf_overrides support in baseline model configs
+  - Supabase queries wrapped in try/except for resilience
+Uses unified_eval_harbor.sbatch as the SLURM job template.
+
+
+===============================================================================
+FLAG REFERENCE
+===============================================================================
+
+--- Preset & Dataset Selection ---
+
+--preset, -p {aider,bfcl,medagentbench,gaia,financeagent,swebench,v2,tb2,v1}
+    Load a named preset that bundles dataset, concurrency, error threshold, and
+    other defaults tuned for a specific benchmark. CLI flags override any preset
+    value. Almost all runs should start with a preset.
+
+    Preset details:
+      aider     Dataset: DCAgent2/aider_polyglot.       n_concurrent=32, error_threshold=10, thinking=on, config_yaml=no_override.
+      bfcl      Dataset: DCAgent2/bfcl-parity.          n_concurrent=32, error_threshold=10, thinking=on, vllm_retries=20, config_yaml=no_override.
+      medagentbench  Dataset: DCAgent/medagentbench.   n_concurrent=32, error_threshold=10, thinking=on, vllm_retries=20, config_yaml=no_override.
+      gaia      Dataset: DCAgent/gaia_127.             n_concurrent=32, error_threshold=10, thinking=on, vllm_retries=20, config_yaml=no_override.
+      financeagent  Dataset: DCAgent/financeagent_terminal.  n_concurrent=16 (SEC_EDGAR 10req/s cap; empirical p95 ~6.8 req/s aggregate at n=16, safe margin), error_threshold=10, thinking=on, vllm_retries=20, config_yaml=no_override.
+      swebench  Dataset: DCAgent2/swebench-verified-*.   n_concurrent=32, error_threshold=15, thinking=on, vllm_retries=20,
+                agent_parser=xml, gpu_mem=0.95, config_yaml=no_override. HF existence check on.
+      v2        Dataset: DCAgent/dev_set_v2.             n_concurrent=32, error_threshold=10, thinking=on, vllm_retries=20.
+      tb2       Dataset: DCAgent2/terminal_bench_2.      n_concurrent=32, error_threshold=10, thinking=on,
+                gpu_mem=0.95, slurm_time=48h, config_yaml=no_override.
+      v1        Dataset: DCAgent/dev_set_71_tasks.       n_concurrent=32, error_threshold=10, thinking=on, vllm_retries=20.
+
+    Tuning: Pick the preset matching your benchmark. Override individual params
+    with CLI flags (e.g. --n-concurrent 64 to double concurrency).
+
+--datasets, -d <str>
+    Comma- or space-separated list of HuggingFace dataset repos. Overrides the
+    preset's dataset list. Use this for one-off evals against custom datasets.
+    Example: --datasets "DCAgent/dev_set_v2,DCAgent2/terminal_bench_2"
+
+--sbatch-script, -s <path>
+    Path to the sbatch template. Default: unified_eval_harbor_v4.sbatch (or
+    whatever the preset specifies). Only change this if you have a custom sbatch.
+
+
+--- Model Filtering ---
+
+--priority-file <path>
+    Text file listing HuggingFace model names (org/model), one per line.
+    Lines starting with # are comments; blank lines are ignored.
+    File order = submission priority: earlier lines are submitted first.
+    Hot-reloaded every iteration — edit the file without restarting the listener.
+
+    Env: EVAL_LISTENER_PRIORITY_FILE
+
+--priority-mode {filter_only,priority_first}    [default: filter_only]
+    filter_only   — Only evaluate models IN the priority file. All others skipped.
+    priority_first — Evaluate ALL models, but submit priority models first.
+
+    Tuning: Use filter_only (default) when you have a curated list of models to
+    evaluate. Use priority_first when you want to evaluate everything but ensure
+    specific models get SLURM slots first.
+
+    Env: EVAL_LISTENER_PRIORITY_MODE
+
+--require-priority-list
+    Safety flag. If set and no priority file is loaded (missing file or empty),
+    the listener skips ALL models instead of evaluating everything. Prevents
+    accidental mass submissions when a priority file path is misconfigured.
+
+    Env: EVAL_LISTENER_REQUIRE_PRIORITY_LIST="1"
+
+--blacklist-file <path>                          [v4 NEW]
+    Text file listing models that should NEVER be submitted, same format as
+    --priority-file (one model per line, # comments, blank lines ignored).
+    Blacklist overrides priority: if a model appears in both files, it is blocked.
+    Hot-reloaded every iteration, same as --priority-file.
+
+    Tuning: Use this to permanently exclude known-bad models (e.g. broken
+    checkpoints, models that consistently OOM, duplicates you don't want to
+    re-evaluate). Faster than removing them from the priority file because
+    the blacklist is checked first — no DB queries wasted on blocked models.
+
+    Env: EVAL_LISTENER_BLACKLIST_FILE
+
+--check-hf-exists
+    Before submitting, validate that the model actually exists on HuggingFace Hub.
+    Adds a network round-trip per model but prevents wasted SLURM jobs on typos
+    or deleted models. The swebench preset enables this by default.
+
+    Env: EVAL_LISTENER_CHECK_HF_EXISTS="1"
+
+
+--- Timing & Lifecycle ---
+
+--lookback-days <int>                            [default: 1000]
+    How far back to query the Supabase `models` table (by creation_time).
+    Priority models bypass this window — they are always fetched by name
+    regardless of when they were added.
+
+    Tuning: Keep this large (default 1000) to catch old models. Reduce only if
+    DB queries are slow and you know all target models are recent.
+
+    Env: EVAL_LISTENER_LOOKBACK_DAYS
+
+--check-hours <float>                            [default: 4.0]
+    Hours to sleep between iterations. Each iteration re-queries the DB, hot-
+    reloads priority/blacklist files, and submits any new jobs.
+
+    Tuning: For active development with frequent model uploads, use 1-2h.
+    For stable production runs, 4-12h is fine. Ignored when --once is set.
+
+    Env: EVAL_LISTENER_CHECK_HOURS
+
+--stale-hours <int>                              [default: 24]
+    A job in "Started" status older than this is considered stale and will be
+    resubmitted. Covers cases where the sbatch job crashed without updating
+    the DB to Finished.
+
+    Tuning: Set to at least 1.5x your SLURM time limit. If --slurm-time is
+    24:00:00, keep this at 24 (default). If you use --slurm-time 48:00:00
+    (like tb2), bump to 48-72.
+
+--stale-pending-hours <int>                      [default: 48]
+    A job in "Pending" status older than this is considered stale. The listener
+    will scancel the old SLURM job (if tracked) and resubmit.
+
+    Tuning: Should be >= --stale-hours. Default of 48h gives Pending jobs extra
+    time to get through the SLURM queue before being killed.
+
+
+--- Sbatch / vLLM Parameters (passed to sbatch via env vars) ---
+
+--n-concurrent <int>                             [default: 64, preset overrides]
+    Number of concurrent Harbor evaluation jobs inside the sbatch. Controls how
+    many sandbox tasks run in parallel against the vLLM server.
+
+    Tuning: Depends on model size and GPU memory.
+      - 7-8B models on GH200 (96GB): 32-64 is safe.
+      - 32B models: 8-16 (higher causes vLLM queue buildup → AgentTimeoutError).
+      - 131K context models: 4-8 (KV cache fills fast at high concurrency).
+    If you see many AgentTimeoutErrors, reduce this. If eval is slow and vLLM
+    GPU utilization is low, increase it.
+
+--n-attempts <int>                               [default: 3]
+    Number of retry attempts per Harbor task. If a task fails (e.g. sandbox
+    timeout), Harbor retries it up to this many times.
+
+    Tuning: 3 is good for most benchmarks. Raise to 5 for flaky benchmarks.
+    Lowering to 1 speeds up runs but increases noise from transient failures.
+
+--gpu-memory-util <float>                        [default: 0.9]
+    Fraction of GPU memory allocated to vLLM via --gpu-memory-utilization.
+
+    Tuning:
+      - 0.90 (default): safe for 7-8B models on GH200 (96GB). Leaves headroom
+        for GPU memory variance across nodes.
+      - 0.95: used by swebench/tb2 presets for larger models or when you need
+        maximum KV cache capacity. Risk: some GH200 nodes have slightly less
+        available memory and will OOM at 0.95 (use --exclude in sbatch).
+      - Never go above 0.95. Below 0.85 wastes memory.
+
+--error-threshold <int>                          [default: 3, preset overrides]
+    Maximum number of "invalid" errors allowed before the sbatch script aborts
+    result upload. Invalid = any error type EXCEPT AgentTimeoutError,
+    ContextLengthExceededError, SummarizationTimeout, SummarizationTimeoutError.
+
+    Tuning: Controls quality gating. Low values (3) are strict — a few
+    DaytonaErrors or unexpected crashes abort the upload. Higher values (10-15)
+    are more tolerant, appropriate for benchmarks where some sandbox flakiness
+    is expected.
+      - aider: 3 (strict, small dataset)
+      - v2/tb2: 10 (moderate, larger datasets with occasional flakes)
+      - swebench: 15 (lenient, swebench sandboxes are flakier)
+
+    --daytona-threshold is a backward-compatible alias for this flag.
+
+--vllm-max-retries <int>                         [default: 5, preset overrides]
+    Number of times the sbatch script retries starting the vLLM server.
+    vLLM occasionally fails to start on first attempt (port conflicts,
+    CUDA initialization issues).
+
+    Tuning: 5 is fine for quick detection of real failures. Presets like v2
+    and swebench use 20 for more resilience on busy clusters.
+
+--agent-parser <str>                             [default: "" (none)]
+    Parser type for Harbor agent output. Set to "xml" for swebench (which
+    uses XML-structured agent responses). Leave empty for all other benchmarks.
+
+    Tuning: Only change this if you're adding a new benchmark with a custom
+    agent output format. The swebench preset sets this automatically.
+
+--slurm-time <str>                               [default: "24:00:00"]
+    SLURM wall-clock time limit for the sbatch job. Format: HH:MM:SS.
+
+    Tuning: 24h is enough for most benchmarks. tb2 preset uses 48h because
+    terminal_bench_2 tasks are longer-running. If jobs are hitting the time
+    limit and getting killed, increase this and also bump --stale-hours.
+
+--slurm-partition <str>                          [default: "gh"]
+    SLURM partition to submit jobs to. On TACC, "gh" is the GH200 GPU partition.
+
+--agent-name <str>                               [default: "terminus-2"]
+    Agent name written to DB entries and used by Harbor for evaluation config.
+    This determines which agent implementation Harbor uses to run the eval tasks.
+
+--enable-thinking
+    Enable thinking/reasoning blocks in vLLM model inference. Most presets
+    enable this by default. Only disable if the model doesn't support thinking
+    or you want to test non-thinking mode.
+
+--upload-username <str>                          [default: current OS user]
+    Username recorded in DB entries and result uploads. Auto-detected from
+    the OS user if not specified.
+
+    Env: EVAL_UPLOAD_USERNAME
+
+
+--- v3 Enhancement: Per-Listener SLURM Throttle ---
+
+--max-jobs-submitted <int>                       [default: 20]
+    Maximum number of active SLURM jobs this listener instance is allowed to
+    have running simultaneously. The listener tracks which SLURM job IDs it
+    submitted and checks squeue to count only those still active.
+
+    Tuning: This is PER-LISTENER, not global. Multiple listeners can run in
+    parallel with independent budgets. Set based on your fair-share allocation:
+      - Single listener: 10-20 is typical.
+      - Multiple listeners: split your budget (e.g. v2=10, swebench=5).
+    When the limit is reached, the listener queues submissions by priority
+    order and drops the lowest-priority ones.
+
+    Env: EVAL_LISTENER_MAX_JOBS
+
+
+--- v3 Enhancement: Daytona Resource Pre-flight ---
+
+--check-daytona-resources
+    Enable Daytona API sandbox count check at startup and each iteration.
+    If active sandboxes are at or above the limit, the listener skips that
+    iteration entirely. Requires DAYTONA_API_KEY in environment.
+
+    Tuning: Enable this in production to prevent overwhelming the Daytona
+    sandbox pool. Not needed for small-scale or development runs.
+
+--daytona-sandbox-limit <int>                    [default: 2000]
+    Maximum expected active sandboxes. The listener skips submissions when
+    the active count reaches this number.
+
+--daytona-warning-buffer <float>                 [default: 0.9]
+    Fraction of the sandbox limit at which a warning is logged. At 0.9 with
+    limit=2000, warns when active sandboxes reach 1800.
+
+
+--- v3 Enhancement: Model Retry Tracking ---
+
+--track-model-retries
+    Enable tracking of how many times each model has been started. Models
+    exceeding the retry threshold are deprioritized (moved to end of the
+    submission queue, not blocked entirely).
+
+    Tuning: Enable this for long-running listeners to prevent repeatedly
+    resubmitting models that keep failing. The sbatch script appends to the
+    shared log when transitioning a job from Pending → Started.
+
+--model-retry-threshold <int>                    [default: 5]
+    Number of eval starts before a model is deprioritized. Deprioritized
+    models are still submitted, just last in the queue (and may be dropped
+    if --max-jobs-submitted truncates the list).
+
+    Tuning: 3-5 for strict environments. Higher (10+) if transient failures
+    are common and you want to give models more chances.
+
+--eval-starts-log <path>                         [default: auto-generated]
+    Path to the shared append-only log file where eval starts are recorded.
+    Auto-generated with a benchmark+timestamp suffix if not specified.
+    Multiple listeners using the same log file will share retry counts.
+
+    Tuning: If you run multiple listeners for the same benchmark and want
+    shared retry tracking, point them at the same log file.
+
+
+--- v3 Enhancement: Timeout-Config-Sensitive Dedup ---
+
+--timeout-aware
+    Change job dedup logic to check model + benchmark + agent + timeout_multiplier
+    instead of just model + benchmark. This allows running the same model with
+    different timeout configurations without one blocking the other.
+
+    Tuning: Enable when running A/B experiments with different timeout settings.
+    When disabled (default), two listeners submitting the same model with
+    different --timeout-multiplier values will conflict (one sees the other's
+    job and skips).
+
+--timeout-multiplier <float>                     [default: 1.0]
+    Harbor timeout multiplier, passed to the sbatch job and stored in the DB
+    job config. Values >1.0 give tasks more time; <1.0 makes them stricter.
+
+    Tuning: Use with --timeout-aware for controlled experiments:
+      --timeout-multiplier 0.25   (aggressive timeout, fast failures)
+      --timeout-multiplier 1.0    (default)
+      --timeout-multiplier 2.0    (lenient, for slow models)
+      --timeout-multiplier 4.0    (very lenient, for debugging)
+
+
+--- Execution Mode ---
+
+--dry-run
+    Preview mode: runs one full iteration (DB queries, filtering, status checks)
+    but does NOT submit any sbatch jobs. Logs what WOULD be submitted. Implies
+    --once. Use this to verify your flags before a real run.
+
+    Env: EVAL_LISTENER_DRY_RUN="1"
+
+--once
+    Run a single iteration and exit. Useful for cron-triggered runs or one-shot
+    submissions. Without this, the listener loops forever (sleeping --check-hours
+    between iterations).
+
+--verbose, -v
+    Enable detailed logging: shows every model skipped (with reason), priority
+    list contents, blacklist contents, and per-model DB status checks.
+
+--log-file <path>
+    Explicit log file path. Default: auto-generated in experiments/listener_logs/
+    with a preset+timestamp name.
+
+    Env: EVAL_LISTENER_LOG_DIR (for the directory)
+
+
+===============================================================================
+ENVIRONMENT VARIABLES (all optional, CLI args take precedence)
+===============================================================================
+
+  EVAL_LISTENER_LOOKBACK_DAYS         Days to look back for models (default: 1000)
+  EVAL_LISTENER_CHECK_HOURS           Hours between iterations (default: 4.0)
+  EVAL_LISTENER_SBATCH                SBATCH script to use
+  EVAL_LISTENER_LOG_DIR               Log directory (default: experiments/listener_logs)
+  EVAL_LISTENER_DATASETS              Comma/space/newline list of HF dataset repos
+  EVAL_LISTENER_PRIORITY_FILE         Path to priority models file (hot-reloaded)
+  EVAL_LISTENER_BLACKLIST_FILE        Path to blacklist models file (hot-reloaded) [v4]
+  EVAL_LISTENER_DRY_RUN               "1" or "true" to enable dry run mode
+  EVAL_LISTENER_REQUIRE_PRIORITY_LIST "1" or "true" to require priority list
+  EVAL_LISTENER_PRIORITY_MODE         "filter_only" or "priority_first"
+  EVAL_LISTENER_CHECK_HF_EXISTS       "1" or "true" to validate HF model existence
+  EVAL_LISTENER_MAX_JOBS              Per-listener SLURM job limit (default: 20)
+  EVAL_UPLOAD_USERNAME                Username for DB entries (default: OS user)
+  DAYTONA_API_KEY                     Required for --check-daytona-resources
+
+
+===============================================================================
+QUICK START EXAMPLES
+===============================================================================
+
+  # Most common: evaluate priority models on dev_set_v2
+  python unified_eval_listener_v4.py --preset v2 \\
+    --priority-file v2_priority_models_richard.txt
+
+  # Preview what would be submitted (no actual jobs)
+  python unified_eval_listener_v4.py --preset v2 --dry-run --once \\
+    --priority-file v2_priority_models_richard.txt --verbose
+
+  # Block known-bad models
+  python unified_eval_listener_v4.py --preset v2 \\
+    --priority-file v2_priority_models_richard.txt \\
+    --blacklist-file bad_models.txt
+
+  # Full v3/v4 features enabled
+  python unified_eval_listener_v4.py --preset v2 \\
+    --priority-file v2_priority_models_richard.txt \\
+    --blacklist-file bad_models.txt \\
+    --error-threshold 10 --max-jobs-submitted 15 \\
+    --check-daytona-resources \\
+    --track-model-retries --model-retry-threshold 3 \\
+    --timeout-aware --timeout-multiplier 2.0
+
+  # Two listeners with independent SLURM budgets
+  python unified_eval_listener_v4.py --preset v2 --max-jobs-submitted 10 &
+  python unified_eval_listener_v4.py --preset swebench --max-jobs-submitted 5 &
+
+  # A/B timeout experiment (requires --timeout-aware on both)
+  python unified_eval_listener_v4.py --preset v2 --timeout-aware \\
+    --timeout-multiplier 1.0 --max-jobs-submitted 10 &
+  python unified_eval_listener_v4.py --preset v2 --timeout-aware \\
+    --timeout-multiplier 2.0 --max-jobs-submitted 5 &
+"""
+
+import argparse
+import getpass
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import yaml
+
+# Add leaderboard utilities to path
+# Add project root to path for database.unified_db imports
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+# Ensure ${DCFT} in baseline-yaml extra_args expands at submit time (see
+# _build_env -> EVAL_VLLM_EXTRA_ARGS). load_cluster_config() may override
+# this when paths.project_root is supplied via --cluster-config.
+_DCFT_DEFAULT = os.path.abspath(os.path.join(_SCRIPT_DIR, ".."))
+os.environ.setdefault("DCFT", _DCFT_DEFAULT)
+
+from database.unified_db.utils import get_supabase_client, load_supabase_keys
+
+
+# ---------------------------------------------------------------------------
+# Secrets loading (Jupiter-specific: load ~/secrets.env at import time)
+# ---------------------------------------------------------------------------
+def _load_secrets(path: Optional[str] = None) -> None:
+    """Load secrets from env file, then call unified_db's load_supabase_keys."""
+    path = (
+        path
+        or os.environ.get("DC_AGENT_SECRET_ENV")
+        or os.environ.get("KEYS")
+        or os.path.expanduser("~/secrets.env")
+    )
+    if path and os.path.isfile(os.path.expanduser(path)):
+        with open(os.path.expanduser(path)) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                if line.startswith("export "):
+                    line = line[7:].strip()
+                k, v = line.split("=", 1)
+                os.environ[k.strip()] = v.strip().strip("'\"")
+    # Alias SUPABASE_KEY -> SUPABASE_ANON_KEY if the latter is missing
+    # (some secrets.env files use the shorter name)
+    if os.environ.get("SUPABASE_KEY") and not os.environ.get("SUPABASE_ANON_KEY"):
+        os.environ["SUPABASE_ANON_KEY"] = os.environ["SUPABASE_KEY"]
+    try:
+        load_supabase_keys()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Harbor config parsing -- extract eval config fields for dedup
+# ---------------------------------------------------------------------------
+def parse_harbor_eval_config(path: Optional[str]) -> Dict:
+    """Parse eval-relevant config fields from a Harbor YAML config.
+
+    Returns dict with keys: timeout_multiplier, override_cpus,
+    override_memory_mb, override_storage_mb (only if set).
+    """
+    if not path or not os.path.isfile(path):
+        return {}
+    try:
+        import yaml
+        with open(path) as f:
+            cfg = yaml.safe_load(f) or {}
+    except Exception as e:
+        log(f"WARNING: failed to parse harbor config {path}: {e}")
+        return {}
+    result: Dict = {}
+    if cfg.get("timeout_multiplier") is not None:
+        result["timeout_multiplier"] = float(cfg["timeout_multiplier"])
+    env_cfg = cfg.get("environment") or {}
+    for key in ("override_cpus", "override_memory_mb", "override_storage_mb"):
+        if env_cfg.get(key) is not None:
+            result[key] = int(env_cfg[key])
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Baseline model config mapping -- per-model vLLM overrides
+# ---------------------------------------------------------------------------
+_BASELINE_MODEL_CONFIGS: Optional[Dict[str, Dict]] = None
+_BASELINE_MODEL_PATTERNS: Optional[List[Dict]] = None
+
+
+def load_baseline_model_configs(path: Optional[str]) -> Dict[str, Dict]:
+    """Load baseline model -> vLLM config mapping from YAML file.
+
+    Returns dict mapping HF model name to vLLM serving params.
+    Also loads pattern-based fallback configs (stored in _BASELINE_MODEL_PATTERNS).
+    """
+    global _BASELINE_MODEL_CONFIGS, _BASELINE_MODEL_PATTERNS
+    if _BASELINE_MODEL_CONFIGS is not None:
+        return _BASELINE_MODEL_CONFIGS
+
+    if not path or not os.path.isfile(path):
+        _BASELINE_MODEL_CONFIGS = {}
+        _BASELINE_MODEL_PATTERNS = []
+        return _BASELINE_MODEL_CONFIGS
+
+    try:
+        import yaml
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+
+        # Start with per-model entries
+        per_model = data.get("models", {})
+
+        # Expand groups: each group has a "models" list + shared config fields.
+        # Group config is the base; per-model entries are merged on top (override wins).
+        expanded: Dict[str, Dict] = {}
+        for group in data.get("groups", []):
+            model_names = group.get("models", [])
+            shared_cfg = {k: v for k, v in group.items() if k != "models"}
+            for name in model_names:
+                expanded[name] = dict(shared_cfg)  # copy so mutations are isolated
+
+        # Merge per-model overrides on top of group defaults
+        for name, overrides in per_model.items():
+            if name in expanded:
+                expanded[name].update(overrides)
+            else:
+                expanded[name] = dict(overrides)
+
+        _BASELINE_MODEL_CONFIGS = expanded
+        _BASELINE_MODEL_PATTERNS = data.get("patterns", [])
+        n_groups = len(data.get("groups", []))
+        log(f"Loaded {len(_BASELINE_MODEL_CONFIGS)} baseline model config(s) "
+            f"({n_groups} group(s), {len(per_model)} override(s)) and "
+            f"{len(_BASELINE_MODEL_PATTERNS)} pattern(s) from {path}")
+    except Exception as e:
+        log(f"WARNING: failed to load baseline model configs from {path}: {e}")
+        _BASELINE_MODEL_CONFIGS = {}
+        _BASELINE_MODEL_PATTERNS = []
+
+    return _BASELINE_MODEL_CONFIGS
+
+
+def _match_pattern_config(hf_model: str) -> Optional[Dict]:
+    """Try to match a model name against pattern-based configs.
+
+    Patterns are checked in order; first match wins.
+    Each pattern has a 'match' field (regex or substring) and config fields.
+    """
+    if not _BASELINE_MODEL_PATTERNS:
+        return None
+    for pattern_entry in _BASELINE_MODEL_PATTERNS:
+        pattern = pattern_entry.get("match", "")
+        if not pattern:
+            continue
+        if re.search(pattern, hf_model):
+            return {k: v for k, v in pattern_entry.items() if k != "match"}
+    return None
+
+
+def get_vllm_env_overrides(hf_model: str, configs: Dict[str, Dict]) -> Dict[str, str]:
+    """Get vLLM env var overrides for a model from the baseline config mapping.
+
+    Tries exact model name match first, then falls back to pattern matching.
+    Returns dict of EVAL_VLLM_* env vars to pass to the eval script.
+    """
+    match_source = None
+    cfg = configs.get(hf_model)
+    if cfg:
+        match_source = "exact/group"
+    else:
+        cfg = _match_pattern_config(hf_model)
+        if cfg:
+            match_source = "pattern"
+    if not cfg:
+        return {}
+
+    log(f"  Baseline config [{match_source}] for {hf_model}: {cfg}")
+
+    env: Dict[str, str] = {}
+    if cfg.get("tensor_parallel_size") is not None:
+        env["EVAL_VLLM_TENSOR_PARALLEL_SIZE"] = str(cfg["tensor_parallel_size"])
+    if cfg.get("max_model_len") is not None:
+        env["EVAL_VLLM_MAX_MODEL_LEN"] = str(cfg["max_model_len"])
+    if cfg.get("swap_space") is not None:
+        env["EVAL_VLLM_SWAP_SPACE"] = str(cfg["swap_space"])
+    if cfg.get("trust_remote_code"):
+        env["EVAL_VLLM_TRUST_REMOTE_CODE"] = "1"
+    if cfg.get("tool_call_parser"):
+        env["EVAL_VLLM_TOOL_CALL_PARSER"] = cfg["tool_call_parser"]
+    if cfg.get("reasoning_parser"):
+        env["EVAL_VLLM_REASONING_PARSER"] = cfg["reasoning_parser"]
+    if cfg.get("extra_args"):
+        # Expand ${DCFT}/... etc. so absolute paths flow into the sbatch
+        # (vLLM does not do shell expansion on its own arguments).
+        env["EVAL_VLLM_EXTRA_ARGS"] = os.path.expandvars(cfg["extra_args"])
+    if cfg.get("hf_overrides"):
+        env["EVAL_VLLM_HF_OVERRIDES"] = cfg["hf_overrides"]
+
+    return env
+
+
+def get_conda_env_override(hf_model: str, configs: Dict[str, Dict]) -> Optional[str]:
+    """Get conda_env override for a model from the baseline config mapping.
+
+    Tries exact/group match first, then pattern match. Returns the conda_env
+    string (e.g. "otagent2") or None if no override is configured.
+    """
+    cfg = configs.get(hf_model)
+    if not cfg:
+        cfg = _match_pattern_config(hf_model)
+    if cfg and cfg.get("conda_env"):
+        return cfg["conda_env"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# API model config mapping -- per-model serving config for hosted endpoints
+# (Together AI, OpenAI, Anthropic ...). Models matching this mapping are
+# dispatched to eval/unified_eval_api_harbor.sbatch instead of the regular
+# vLLM sbatch — no GPU allocation, no local vLLM server.
+# ---------------------------------------------------------------------------
+_API_MODEL_CONFIGS: Optional[Dict[str, Any]] = None
+
+
+def load_api_model_configs(path: Optional[str]) -> Dict[str, Any]:
+    """Load per-model API serving config from YAML.
+
+    Returns a dict with keys:
+      - api_models: dict[model_name -> {api_base, api_key_env, agent_kwargs, n_concurrent_cap}]
+      - patterns: list[{regex, api_base, api_key_env, n_concurrent_cap}]
+      - preset_n_concurrent_caps: dict[preset_name -> int]
+
+    If the file is missing or malformed, returns an empty dict (i.e. no
+    models match → no behavior change for existing fires).
+    """
+    global _API_MODEL_CONFIGS
+    if _API_MODEL_CONFIGS is not None:
+        return _API_MODEL_CONFIGS
+
+    if not path or not os.path.isfile(path):
+        _API_MODEL_CONFIGS = {}
+        return _API_MODEL_CONFIGS
+
+    try:
+        import yaml
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        _API_MODEL_CONFIGS = {
+            "api_models": data.get("api_models", {}) or {},
+            "patterns": data.get("patterns", []) or [],
+            "preset_n_concurrent_caps": data.get("preset_n_concurrent_caps", {}) or {},
+        }
+        log(f"Loaded {len(_API_MODEL_CONFIGS['api_models'])} API model entries "
+            f"and {len(_API_MODEL_CONFIGS['patterns'])} pattern(s) from {path}")
+    except Exception as e:
+        log(f"WARNING: failed to load API model configs from {path}: {e}")
+        _API_MODEL_CONFIGS = {}
+    return _API_MODEL_CONFIGS
+
+
+def get_api_config(hf_model: str, configs: Optional[Dict[str, Any]] = None) -> Optional[Dict]:
+    """Resolve the API serving config for a model name, or None if it should
+    use the regular vLLM path.
+
+    Lookup order:
+      1. Exact match in api_models.
+      2. Regex pattern fallback in patterns (first match wins).
+      3. None (model is not API-served).
+
+    Returns dict with keys: api_base, api_key_env, agent_kwargs (dict),
+    n_concurrent_cap (int).
+    """
+    cfg_root = configs if configs is not None else (_API_MODEL_CONFIGS or {})
+    if not cfg_root:
+        return None
+
+    api_models = cfg_root.get("api_models", {})
+    cfg = api_models.get(hf_model)
+    if not cfg:
+        for pat in cfg_root.get("patterns", []):
+            regex = pat.get("regex")
+            if regex and re.search(regex, hf_model):
+                cfg = {k: v for k, v in pat.items() if k != "regex"}
+                break
+    if not cfg:
+        return None
+
+    return {
+        "api_base": cfg.get("api_base"),
+        "api_key_env": cfg.get("api_key_env"),
+        "agent_kwargs": cfg.get("agent_kwargs", {}) or {},
+        "n_concurrent_cap": int(cfg.get("n_concurrent_cap", 32)),
+        # litellm_model is what LiteLLM expects (with provider prefix);
+        # falls back to the lookup key when omitted.
+        "litellm_model": cfg.get("litellm_model") or hf_model,
+    }
+
+
+def _build_api_agent_kwargs_string(agent_kwargs: Dict[str, Any]) -> str:
+    """Serialize a dict of agent kwargs into newline-separated `key=value`
+    pairs for EVAL_API_AGENT_KWARGS. The sbatch splits on newlines and adds
+    each as one --agent-kwarg arg, so JSON values (with quotes/braces/commas)
+    survive without shell quoting hell.
+    """
+    if not agent_kwargs:
+        return ""
+    return "\n".join(f"{k}={v}" for k, v in agent_kwargs.items())
+
+
+# ---------- v6: Disk-Based Resume Scanner ----------
+
+# Infrastructure errors that harbor's resume filters will retry
+INFRA_ERROR_TYPES = {
+    "DaytonaError",
+    "DaytonaAuthenticationError",
+    "DaytonaAuthorizationError",
+    "DaytonaNotFoundError",
+    "EnvironmentStartTimeoutError",
+    "DaytonaRateLimitError",
+    "CancelledError",
+    "SandboxBuildFailedError",
+    "AgentEnvironmentTimeoutError",
+}
+
+
+def _parse_job_dir(job_dir: Path) -> Optional[Dict]:
+    """Parse a harbor job directory, extracting model/dataset/progress info.
+
+    Returns dict with keys: run_tag, hf_model, dataset, n_completed, n_total,
+    finished_at, infra_errors, total_errors, db_job_id, slurm_job_id, resume_count.
+    Returns None if dir is not a valid harbor job dir.
+    """
+    config_path = job_dir / "config.json"
+    if not config_path.exists():
+        return None
+
+    run_tag = job_dir.name
+    info: Dict = {
+        "run_tag": run_tag,
+        "hf_model": None,
+        "dataset": None,
+        "n_completed": 0,
+        "n_total": 0,
+        "finished_at": None,
+        "infra_errors": 0,
+        "total_errors": 0,
+        "db_job_id": None,
+        "slurm_job_id": None,
+        "resume_count": 0,
+    }
+
+    # Parse config.json for model and dataset
+    try:
+        import json as _json
+        config = _json.loads(config_path.read_text())
+        agents = config.get("agents", [])
+        if agents and isinstance(agents, list):
+            model_name = agents[0].get("model_name", "")
+            # Strip "hosted_vllm/" prefix
+            if model_name.startswith("hosted_vllm/"):
+                model_name = model_name[len("hosted_vllm/"):]
+            info["hf_model"] = model_name or None
+        datasets = config.get("datasets", [])
+        if datasets and isinstance(datasets, list):
+            ds_path = datasets[0].get("path", "")
+            if ds_path:
+                # Extract dataset name from path: /e/.../DCAgent_dev_set_v2 → DCAgent/dev_set_v2
+                ds_name = Path(ds_path).name  # e.g., "DCAgent_dev_set_v2"
+                # Convert first underscore to slash (org/name convention)
+                parts = ds_name.split("_", 1)
+                if len(parts) == 2:
+                    info["dataset"] = f"{parts[0]}/{parts[1]}"
+                else:
+                    info["dataset"] = ds_name
+    except Exception:
+        pass
+
+    # Parse meta.env for DB_JOB_ID, SLURM_JOB_ID, RESUME_COUNT
+    meta_path = job_dir / "meta.env"
+    if meta_path.exists():
+        try:
+            for line in meta_path.read_text().splitlines():
+                if line.startswith("DB_JOB_ID="):
+                    info["db_job_id"] = line.split("=", 1)[1].strip() or None
+                elif line.startswith("SLURM_JOB_ID="):
+                    info["slurm_job_id"] = line.split("=", 1)[1].strip() or None
+                elif line.startswith("RESUME_COUNT="):
+                    try:
+                        info["resume_count"] = int(line.split("=", 1)[1].strip())
+                    except ValueError:
+                        pass
+                elif line.startswith("MODEL=") and not info["hf_model"]:
+                    info["hf_model"] = line.split("=", 1)[1].strip() or None
+        except Exception:
+            pass
+
+    # Parse result.json for progress
+    result_path = job_dir / "result.json"
+    if result_path.exists():
+        try:
+            import json as _json
+            result = _json.loads(result_path.read_text())
+            info["n_total"] = result.get("n_total_trials", 0)
+            stats = result.get("stats", {})
+            info["n_completed"] = stats.get("n_trials", 0)
+            info["finished_at"] = result.get("finished_at")
+
+            # Count infrastructure errors
+            infra_count = 0
+            total_err_count = 0
+            for eval_data in stats.get("evals", {}).values():
+                for exc_type, ids in eval_data.get("exception_stats", {}).items():
+                    n = len(ids) if isinstance(ids, list) else 1
+                    total_err_count += n
+                    if exc_type in INFRA_ERROR_TYPES:
+                        infra_count += n
+            info["infra_errors"] = infra_count
+            info["total_errors"] = total_err_count
+        except Exception:
+            pass
+
+    return info
+
+
+def scan_jobs_dir_for_resume(
+    jobs_dir: str,
+    dataset_prefixes: List[str],
+    active_slurm_ids: Set[str],
+    infra_error_threshold: int = 3,
+    max_resume_count: int = 5,
+) -> List[Dict]:
+    """Scan eval jobs directory for jobs that need to be resumed.
+
+    Args:
+        jobs_dir: Path to the eval jobs directory
+        dataset_prefixes: List of dataset name prefixes to filter (e.g., ["dev_set_v2"])
+        active_slurm_ids: Set of SLURM job IDs currently in squeue
+        infra_error_threshold: Min infra errors to trigger resume for PARTIAL jobs
+        max_resume_count: Skip dirs with RESUME_COUNT >= this (prevent infinite loops)
+
+    Returns:
+        List of dicts with keys: hf_model, dataset, run_tag, reason, db_job_id
+    """
+    jobs_path = Path(jobs_dir)
+    if not jobs_path.is_dir():
+        log(f"[v6-resume] Jobs dir not found: {jobs_dir}")
+        return []
+
+    # Build prefix patterns from dataset names
+    # "DCAgent/dev_set_v2" → "dev_set_v2_"
+    # Must normalize hyphens/dots to underscores to match generate_run_tag() output
+    dir_prefixes = []
+    for ds in dataset_prefixes:
+        # Dataset format: "DCAgent/dev_set_v2" or "DCAgent2/terminal_bench_2"
+        ds_short = ds.split("/")[-1] if "/" in ds else ds
+        ds_safe = ds_short.replace("-", "_").replace(".", "_")
+        dir_prefixes.append(f"{ds_safe}_")
+
+    candidates = []
+    scanned = 0
+    skipped_active = 0
+    skipped_done = 0
+    skipped_resume_limit = 0
+
+    for entry in sorted(jobs_path.iterdir()):
+        if not entry.is_dir():
+            continue
+
+        # Filter by dataset prefix
+        if not any(entry.name.startswith(p) for p in dir_prefixes):
+            continue
+
+        info = _parse_job_dir(entry)
+        if info is None:
+            continue
+        scanned += 1
+
+        # Skip if SLURM job still running
+        if info["slurm_job_id"] and info["slurm_job_id"] in active_slurm_ids:
+            skipped_active += 1
+            continue
+
+        # Skip if resume count too high
+        if info["resume_count"] >= max_resume_count:
+            skipped_resume_limit += 1
+            continue
+
+        # Classify job state
+        n_completed = info["n_completed"]
+        n_total = info["n_total"]
+        finished_at = info["finished_at"]
+        infra_errors = info["infra_errors"]
+
+        reason = None
+
+        if n_total == 0 and not (jobs_path / entry.name / "result.json").exists():
+            # EARLY_KILL: killed before any trial completed
+            reason = f"early_kill (no result.json, resume #{info['resume_count']+1})"
+        elif n_completed < n_total and finished_at is None:
+            # INCOMPLETE: SLURM killed mid-run
+            reason = f"incomplete ({n_completed}/{n_total} trials, resume #{info['resume_count']+1})"
+        elif n_completed < n_total and finished_at is not None:
+            # PARTIAL: harbor finished but some trials failed
+            if infra_errors > infra_error_threshold:
+                reason = f"partial ({n_completed}/{n_total}, {infra_errors} infra errors, resume #{info['resume_count']+1})"
+        elif n_completed == n_total:
+            # DONE: all trials completed
+            if infra_errors > infra_error_threshold:
+                reason = f"done_with_errors ({n_completed}/{n_total}, {infra_errors} infra errors, resume #{info['resume_count']+1})"
+            else:
+                skipped_done += 1
+                continue
+        else:
+            continue
+
+        if reason and info["hf_model"]:
+            candidates.append({
+                "hf_model": info["hf_model"],
+                "dataset": info["dataset"],
+                "run_tag": info["run_tag"],
+                "reason": f"v6_resume: {reason}",
+                "db_job_id": info["db_job_id"],
+            })
+
+    log(f"[v6-resume] Scanned {scanned} job dirs: "
+        f"{len(candidates)} resume candidates, "
+        f"{skipped_active} still running, "
+        f"{skipped_done} completed, "
+        f"{skipped_resume_limit} at resume limit")
+
+    return candidates
+
+
+# ---------- Preset Definitions ----------
+# Each preset can configure:
+#   - datasets: list of HF dataset repos
+#   - sbatch_script: sbatch script to use (default: unified_eval_harbor_v4.sbatch)
+#   - log_suffix: suffix for log file
+#   - check_hf_exists: validate model exists on HuggingFace
+#   - n_concurrent: Harbor --n-concurrent (default: 64)
+#   - n_attempts: Harbor --n-attempts (default: 3)
+#   - gpu_memory_util: VLLM --gpu-memory-utilization (default: 0.9)
+#   - error_threshold: Max invalid errors before abort (default: 3)
+#   - vllm_max_retries: VLLM startup retries (default: 5)
+#   - agent_parser: Agent parser type (default: "", use "xml" for swebench)
+#   - slurm_time: SLURM time limit (default: "24:00:00")
+PRESETS: Dict[str, Dict] = {
+    "aider": {
+        "datasets": ["DCAgent2/aider_polyglot"],
+        "log_suffix": "aider",
+        "n_concurrent": 32,
+        "error_threshold": 20,
+        "vllm_max_retries": 10,
+        "enable_thinking": True,
+        "auto_snapshot": True,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+    },
+    "bfcl": {
+        "datasets": ["DCAgent2/bfcl-parity"],
+        "log_suffix": "bfcl",
+        "n_concurrent": 32,
+        "error_threshold": 20,
+        "vllm_max_retries": 20,
+        "enable_thinking": True,
+        "auto_snapshot": True,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+    },
+    "medagentbench": {
+        "datasets": ["DCAgent/medagentbench"],
+        "log_suffix": "medagent",
+        "n_concurrent": 32,
+        "error_threshold": 10,
+        "vllm_max_retries": 20,
+        "enable_thinking": True,
+        "auto_snapshot": True,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+    },
+    "gaia": {
+        "datasets": ["DCAgent/gaia_127"],
+        "log_suffix": "gaia",
+        "n_concurrent": 32,
+        "error_threshold": 10,
+        "vllm_max_retries": 20,
+        "enable_thinking": True,
+        "auto_snapshot": True,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+    },
+    "financeagent": {
+        "datasets": ["DCAgent/financeagent_terminal"],
+        "log_suffix": "finance",
+        "n_concurrent": 16,
+        "error_threshold": 10,
+        "vllm_max_retries": 20,
+        "enable_thinking": True,
+        "auto_snapshot": True,
+        "agent_envs": "SERPAPI_API_KEY,SEC_EDGAR_API_KEY,MODEL_FOR_TOOLS=openai/gpt-5.2,MODEL_API_KEY=OPENAI_API_KEY",
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+    },
+    # NOTE: all OOD presets + swebench/tb2 use dcagent_eval_config_no_override.yaml
+    "swebench": {
+        "datasets": ["DCAgent2/swebench-verified-random-100-folders"],
+        "log_suffix": "swebench",
+        "n_concurrent": 32,
+        "error_threshold": 20,
+        "agent_parser": "xml",
+        "vllm_max_retries": 10,
+        "enable_thinking": True,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+        "auto_snapshot": True,
+    },
+    "swebench_full": {
+        "datasets": ["DCAgent/swebench-verified"],
+        "log_suffix": "swebench_full",
+        "n_concurrent": 32,
+        "error_threshold": 20,
+        "agent_parser": "xml",
+        "vllm_max_retries": 10,
+        "enable_thinking": True,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+        "slurm_time": "48:00:00",
+        "auto_snapshot": True,
+    },
+    "v2": {
+        "datasets": ["DCAgent/dev_set_v2"],
+        "log_suffix": "v2",
+        "n_concurrent": 32,
+        "error_threshold": 10,
+        "vllm_max_retries": 10,
+        "enable_thinking": True,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+        "auto_snapshot": True,
+    },
+    "tb2": {
+        "datasets": ["DCAgent2/terminal_bench_2"],
+        "log_suffix": "tb2",
+        "n_concurrent": 32,
+        "error_threshold": 10,
+        "enable_thinking": True,
+        "vllm_max_retries": 10,
+        "config_yaml": "dcagent_eval_config_no_override.yaml",
+        "auto_snapshot": True,
+    },
+    "v1": {
+        "datasets": ["DCAgent/dev_set_71_tasks"],
+        "log_suffix": "v1",
+        "n_concurrent": 32,
+        "error_threshold": 10,
+        "vllm_max_retries": 10,
+        "enable_thinking": True,
+    },
+}
+
+# ---------- Cluster Config ----------
+_CLUSTER_CONFIG_REQUIRED_KEYS = ["cluster_name", "slurm_partition", "paths"]
+_CLUSTER_CONFIG_REQUIRED_PATHS = ["eval_jobs_dir", "sbatch_script"]
+
+# Global cluster config (set by --cluster-config, None = use hardcoded defaults)
+_CLUSTER_CONFIG: Optional[Dict[str, Any]] = None
+
+
+def load_cluster_config(path: str) -> Dict[str, Any]:
+    """Load and validate a cluster config YAML.
+
+    Returns the parsed config dict.  Raises SystemExit on validation failure.
+    """
+    path = os.path.expanduser(path)
+    if not os.path.isfile(path):
+        print(f"ERROR: Cluster config not found: {path}")
+        sys.exit(2)
+
+    with open(path) as f:
+        cfg = yaml.safe_load(f)
+
+    if not isinstance(cfg, dict):
+        print(f"ERROR: Cluster config must be a YAML mapping, got {type(cfg).__name__}")
+        sys.exit(2)
+
+    # Expand $USER / ${USER} and ~ in all string values (paths, conda env dirs, etc.)
+    def _expand(obj):
+        if isinstance(obj, str):
+            return os.path.expandvars(os.path.expanduser(obj))
+        elif isinstance(obj, dict):
+            return {k: _expand(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [_expand(v) for v in obj]
+        return obj
+    cfg = _expand(cfg)
+
+    for key in _CLUSTER_CONFIG_REQUIRED_KEYS:
+        if key not in cfg:
+            print(f"ERROR: Cluster config missing required key: {key}")
+            sys.exit(2)
+
+    paths = cfg.get("paths", {})
+    for key in _CLUSTER_CONFIG_REQUIRED_PATHS:
+        if key not in paths:
+            print(f"ERROR: Cluster config paths.{key} is required")
+            sys.exit(2)
+
+    # Cluster config wins over the script-relative DCFT default so that
+    # baseline-yaml extra_args ('${DCFT}/eval/configs/...') expand to the
+    # cluster's checkout root, not whatever directory the listener was
+    # launched from.
+    if paths.get("project_root"):
+        os.environ["DCFT"] = paths["project_root"]
+
+    return cfg
+
+
+def _cc_get(key: str, default: Any = None) -> Any:
+    """Get a top-level key from the cluster config, or *default* if not loaded."""
+    if _CLUSTER_CONFIG is None:
+        return default
+    return _CLUSTER_CONFIG.get(key, default)
+
+
+def _cc_path(key: str, default: Any = None) -> Any:
+    """Get a paths.* key from the cluster config, or *default*."""
+    if _CLUSTER_CONFIG is None:
+        return default
+    return _CLUSTER_CONFIG.get("paths", {}).get(key, default)
+
+
+# ---------- Constants ----------
+HF_URL_RE = re.compile(r'https?://(?:www\.)?huggingface\.co/([^/\s]+)/([^/\s#?]+)')
+JOB_STATUS_PENDING = "Pending"
+JOB_STATUS_STARTED = "Started"
+JOB_STATUS_FINISHED = "Finished"
+JOB_STATUS_FAILED = "Failed"
+DEFAULT_STALE_JOB_HOURS = 24
+DEFAULT_STALE_PENDING_HOURS = 48
+DEFAULT_LOOKBACK_DAYS = 1000
+DEFAULT_CHECK_HOURS = 4.0
+DEFAULT_LOG_DIR = "experiments/listener_logs"
+
+# Sbatch parameter defaults
+DEFAULT_N_CONCURRENT = 64
+DEFAULT_N_ATTEMPTS = 3
+DEFAULT_GPU_MEMORY_UTIL = 0.9
+DEFAULT_ERROR_THRESHOLD = 10
+DEFAULT_VLLM_MAX_RETRIES = 10
+DEFAULT_AGENT_PARSER = ""
+DEFAULT_SLURM_TIME = "12:00:00"
+DEFAULT_AGENT_NAME = "terminus-2"
+DEFAULT_SLURM_PARTITION = "booster"
+DEFAULT_SLURM_ACCOUNT = ""  # empty = use sbatch header default
+DEFAULT_ENABLE_THINKING = False
+DEFAULT_TP_SIZE = 1
+DEFAULT_SBATCH_SCRIPT = "eval/unified_eval_harbor.sbatch"
+
+# Fallback defaults (used when no --cluster-config is provided).
+# Empty strings force explicit cluster config — no implicit Jupiter defaults.
+_FALLBACK_EVAL_JOBS_DIR = ""
+_FALLBACK_HF_CACHE = ""
+_FALLBACK_EVAL_LOGS_DIR = "eval/logs"
+
+# Conda env paths: env name → prefix directory (passed as OTAGENT_DIR to sbatch)
+# Overridden by cluster_config["conda_envs"] when --cluster-config is used.
+CONDA_ENV_PATHS: Dict[str, str] = {}
+
+# Dataset repo name → short benchmark tag for SLURM job names (squeue readability)
+_BENCH_SHORT: Dict[str, str] = {
+    "dev_set_v2": "v2",
+    "swebench-verified-random-100-folders": "swe",
+    "terminal_bench_2": "tb2",
+    "swebench-verified": "swefull",
+    "aider_polyglot": "aider",
+    "bfcl-parity": "bfcl",
+    "medagentbench": "medagent",
+    "gaia_127": "gaia",
+    "financeagent_terminal": "finance",
+    "dev_set_71_tasks": "v1",
+}
+
+# Enhancement 2: SLURM job submission throttle
+DEFAULT_MAX_JOBS_SUBMITTED = 20
+
+# Enhancement 3: Daytona resource pre-flight check
+DEFAULT_DAYTONA_SANDBOX_LIMIT = 2000
+DEFAULT_DAYTONA_WARNING_BUFFER = 0.9
+
+# Enhancement 5: Timeout-config-sensitive dedup
+DEFAULT_TIMEOUT_MULTIPLIER = 1.0
+
+
+# ---------- Configuration ----------
+@dataclass
+class ListenerConfig:
+    """Configuration for the eval listener.
+
+    Core fields:
+        datasets             HF dataset repos to evaluate against.
+        sbatch_script        Path to the sbatch script to submit.
+        priority_models      Ordered list of HF model names from the priority file.
+                             File order = submission priority (first = highest).
+        priority_file        Path to the priority file (hot-reloaded each iteration).
+
+    Sbatch parameters (forwarded to sbatch via env vars):
+        n_concurrent         Harbor --n-concurrent.
+        n_attempts           Harbor --n-attempts.
+        gpu_memory_util      VLLM --gpu-memory-utilization.
+        error_threshold      Max invalid errors before aborting upload (v3 Enhancement 1).
+                             Replaces v2's daytona_threshold. Env var kept as
+                             EVAL_DAYTONA_THRESHOLD for sbatch backward compat.
+        agent_name           Agent name for harbor and DB entries.
+        timeout_multiplier   Harbor timeout multiplier (v3 Enhancement 5).
+
+    v3 enhancement fields:
+        max_jobs_submitted       Per-listener SLURM job limit (Enhancement 2).
+                                 Each listener tracks its own submitted job IDs and
+                                 only counts those still active in squeue.
+        check_daytona_resources  Enable Daytona API pre-flight check (Enhancement 3).
+        daytona_sandbox_limit    Max expected active sandboxes for pre-flight check.
+        daytona_warning_buffer   Fraction of limit to trigger warning (e.g. 0.95).
+        timeout_aware            Enable config-sensitive job dedup (Enhancement 5).
+    """
+    datasets: List[str]
+    sbatch_script: str
+    log_file: Optional[Path]
+    lookback_days: int
+    check_interval_hours: float
+    stale_job_hours: int
+    stale_pending_hours: int
+    priority_file: Optional[str]
+    require_priority_list: bool
+    priority_models: List[str]
+    check_hf_exists: bool
+    dry_run: bool
+    run_once: bool
+    verbose: bool
+    # Priority mode: "filter_only" (skip non-priority) or "priority_first" (all models, priority first)
+    priority_mode: str = "filter_only"
+    # Sbatch parameters (passed to sbatch via env vars)
+    n_concurrent: int = DEFAULT_N_CONCURRENT
+    n_attempts: int = DEFAULT_N_ATTEMPTS
+    gpu_memory_util: float = DEFAULT_GPU_MEMORY_UTIL
+    error_threshold: int = DEFAULT_ERROR_THRESHOLD
+    vllm_max_retries: int = DEFAULT_VLLM_MAX_RETRIES
+    agent_parser: str = DEFAULT_AGENT_PARSER
+    slurm_time: str = DEFAULT_SLURM_TIME
+    enable_thinking: bool = DEFAULT_ENABLE_THINKING
+    agent_name: str = DEFAULT_AGENT_NAME
+    slurm_partition: str = DEFAULT_SLURM_PARTITION
+    slurm_account: str = DEFAULT_SLURM_ACCOUNT
+    tp_size: int = DEFAULT_TP_SIZE
+    dp_size: int = 1  # vLLM native data-parallel replicas (total GPUs = tp_size * dp_size)
+    upload_username: str = ""
+    log_prefix: str = "[unified-eval-listener-v6]"
+    # v3 Enhancement 2: Per-listener SLURM throttle
+    max_jobs_submitted: int = DEFAULT_MAX_JOBS_SUBMITTED
+    # v3 Enhancement 3: Daytona pre-flight
+    check_daytona_resources: bool = False
+    daytona_sandbox_limit: int = DEFAULT_DAYTONA_SANDBOX_LIMIT
+    daytona_warning_buffer: float = DEFAULT_DAYTONA_WARNING_BUFFER
+    # v3 Enhancement 5: Timeout-config-sensitive dedup
+    timeout_multiplier: float = DEFAULT_TIMEOUT_MULTIPLIER
+    timeout_aware: bool = False
+    # Config YAML for harbor (overrides vs no-overrides)
+    config_yaml: str = "dcagent_eval_config.yaml"
+    # Max output tokens override (None = use sbatch default 16384)
+    max_output_tokens: Optional[int] = None
+    # Model blacklist
+    blacklist_file: Optional[str] = None
+    blacklisted_models: Set[str] = field(default_factory=set)
+    # Daytona auto_snapshot: None = use YAML config default, True/False = override
+    auto_snapshot: Optional[bool] = None
+    # Comma-separated KEY=VALUE pairs forwarded into the Daytona sandbox via --ae
+    agent_envs: Optional[str] = None
+    # Pinggy tunnel config (for installed agents that run in Daytona sandbox)
+    pinggy_url: Optional[str] = None
+    pinggy_token: Optional[str] = None
+    # Per-model vLLM overrides (baseline model configs)
+    baseline_model_configs: Optional[str] = None
+    # Per-model API serving config (Together AI / OpenAI / Anthropic)
+    api_model_config: Optional[str] = None
+    # API sbatch script (used when get_api_config() matches a model)
+    api_sbatch_script: str = "eval/unified_eval_api_harbor.sbatch"
+    # Harbor config path
+    harbor_config: Optional[str] = None
+    # Parsed eval config from harbor YAML (for config-aware dedup)
+    eval_config: Dict = field(default_factory=dict)
+    # Pre-download model weights before submitting jobs
+    pre_download: bool = False
+    # Sliding-window batch dependencies
+    batch_size: Optional[int] = None
+    # Conda env selector (otagent / otagent2)
+    conda_env: str = "otagent"
+    # v6: Disk-based resume
+    jobs_dirs: List[str] = field(default_factory=list)  # Set from CLI or EVAL_JOBS_DIR env var
+    enable_disk_resume: bool = True
+    resume_infra_error_threshold: int = 10
+    max_resume_count: int = 5
+    force_reeval: bool = False  # Bypass DB status check (submit even if Finished/Started)
+    resume_only: bool = False  # Only submit resume jobs, skip fresh submissions
+    submission_delay: float = 1.0  # Seconds to sleep between sbatch submissions
+    stagger_delay: int = 0  # Minutes between job starts via SLURM after: dependency chain (0 = disabled)
+    chain_batch_size: int = 1  # Jobs per stagger batch (1 = every job waits, 10 = fire 10 then wait)
+    pack_jobs: bool = False  # Pack multiple jobs onto same node via --nodelist
+    # DP: data-parallel multi-node eval
+    dp_nodes: int = 0  # 0 = single-node (default), >0 = use DP sbatch with N nodes
+    dp_sbatch_script: str = "eval/unified_eval_harbor_dp.sbatch"
+    # Inherit: seed _submitted_jobs from previous listener logs
+    inherit_log: Optional[List[str]] = None
+    # Cluster config (loaded from --cluster-config YAML)
+    cluster_config: Optional[Dict[str, Any]] = None
+
+    @property
+    def check_interval_seconds(self) -> int:
+        return int(self.check_interval_hours * 60 * 60)
+
+
+# ---------- Logging ----------
+_LOG_FILE: Optional[Path] = None
+_VERBOSE: bool = False
+
+
+def set_log_file(path: Optional[Path]) -> None:
+    global _LOG_FILE
+    _LOG_FILE = path
+
+
+def log(msg: str, prefix: str = "[unified-eval-listener-v6]", verbose_only: bool = False) -> None:
+    """Log a message to stdout and optionally to file.
+
+    If verbose_only=True, the message is only emitted when _VERBOSE is set.
+    """
+    if verbose_only and not _VERBOSE:
+        return
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    line = f"{prefix} {ts}  {msg}"
+    print(line, flush=True)
+    if _LOG_FILE:
+        try:
+            with _LOG_FILE.open("a") as f:
+                f.write(line + "\n")
+        except Exception:
+            pass
+
+
+# ---------- Priority Models Loading ----------
+def load_priority_models(filepath: Optional[str]) -> List[str]:
+    """
+    Load priority models from a text file, preserving file order as rank.
+
+    File order determines submission priority: models listed earlier are
+    submitted first. When the per-listener SLURM job limit truncates the
+    submission list, higher-priority (earlier) models are kept.
+
+    File format:
+      - One model per line (HuggingFace format: org/model)
+      - Lines starting with # are comments
+      - Blank lines are ignored
+
+    Returns:
+        Ordered list of model names (duplicates removed, order preserved).
+        Empty list if file is missing or empty.
+    """
+    if not filepath:
+        return []
+
+    path = Path(filepath)
+    if not path.exists():
+        log(f"Priority file not found: {filepath}")
+        return []
+
+    models: List[str] = []
+    seen: Set[str] = set()
+    try:
+        with path.open("r") as f:
+            for line in f:
+                line = line.strip()
+                # Skip empty lines and comments
+                if not line or line.startswith("#"):
+                    continue
+                if line not in seen:
+                    seen.add(line)
+                    models.append(line)
+        log(f"Loaded {len(models)} model(s) from priority file: {filepath}")
+        return models
+    except Exception as e:
+        log(f"ERROR reading priority file {filepath}: {e}")
+        return []
+
+
+# ---------- Model Blacklist Loading ----------
+def load_blacklist(filepath: Optional[str]) -> Set[str]:
+    """Load blacklisted models from a text file. Same format as priority file."""
+    return set(load_priority_models(filepath))
+
+
+# ---------- HuggingFace Utilities ----------
+def check_hf_model_exists(model_name: str) -> bool:
+    """
+    Check if a model exists on HuggingFace Hub.
+
+    Args:
+        model_name: HF model name (e.g., "org/model-name")
+
+    Returns:
+        True if model exists and is accessible, False otherwise
+    """
+    if not model_name or not isinstance(model_name, str):
+        return False
+
+    try:
+        from huggingface_hub import model_info
+        model_info(model_name)
+        return True
+    except Exception as e:
+        log(f"HF check failed for {model_name}: {e}")
+        return False
+
+
+def _parse_hf_from_str(val: Optional[str]) -> Optional[str]:
+    """Parse HuggingFace model name from a string (URL or org/repo)."""
+    if not isinstance(val, str):
+        return None
+    m = HF_URL_RE.search(val)
+    if m:
+        return f"{m.group(1)}/{m.group(2)}"
+    return None
+
+
+def resolve_hf_model_name(model_row: Dict) -> Optional[str]:
+    """
+    Resolve HF model name from a database model row.
+
+    Checks multiple fields in order of priority.
+    """
+    # Check name field first
+    v = model_row.get("name")
+    if isinstance(v, str) and "/" in v and not v.startswith("hosted_vllm/"):
+        return v
+
+    # Check other URL fields
+    for field in ("weights_location", "training_parameters", "url", "hf_url"):
+        vv = model_row.get(field)
+        if isinstance(vv, str):
+            name = _parse_hf_from_str(vv)
+            if name:
+                return name
+
+    # Check training_parameters as JSON
+    vv = model_row.get("training_parameters")
+    if isinstance(vv, str):
+        try:
+            obj = json.loads(vv)
+        except Exception:
+            obj = None
+    else:
+        obj = vv
+
+    if isinstance(obj, dict):
+        for sval in obj.values():
+            if isinstance(sval, str):
+                name = _parse_hf_from_str(sval)
+                if name:
+                    return name
+
+    return None
+
+
+# ---------- Dataset Parsing ----------
+def parse_datasets(s: str) -> List[str]:
+    """
+    Parse dataset list from string.
+
+    Supports comma, space, or newline separated values.
+    Normalizes HF URLs to org/repo format.
+    """
+    parts = [p.strip() for p in re.split(r"[,\s]+", s) if p.strip()]
+    out = []
+    for p in parts:
+        m = HF_URL_RE.search(p)
+        out.append(f"{m.group(1)}/{m.group(2)}" if m else p)
+
+    # Dedup while preserving order
+    seen: Set[str] = set()
+    uniq: List[str] = []
+    for d in out:
+        if d not in seen:
+            seen.add(d)
+            uniq.append(d)
+    return uniq
+
+
+def dataset_repo_name(dataset_hf: str) -> str:
+    """Convert 'org/repo' or HF URL to 'repo' (just the repo name)."""
+    if not dataset_hf:
+        return dataset_hf
+    m = HF_URL_RE.search(dataset_hf)
+    if m:
+        return m.group(2)
+    if "/" in dataset_hf:
+        return dataset_hf.rsplit("/", 1)[-1]
+    return dataset_hf
+
+
+# ---------- Database Operations ----------
+_BENCH_CACHE: Dict[str, Optional[str]] = {}
+
+
+def _iso(dt: datetime) -> str:
+    """Convert datetime to ISO format string."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _time_filters(q, since_iso: str):
+    """Apply time filter to Supabase query (handles both column names)."""
+    try:
+        return q.gte('creation_time', since_iso)
+    except Exception:
+        return q.gte('created_at', since_iso)
+
+
+def fetch_recent_models(days: int) -> List[Dict]:
+    """Fetch recent models from Supabase within the lookback window.
+
+    Filters out:
+      - Models with created_by == "precomputed_hf"
+      - Models with a non-empty "duplicate_of" field (v3: prevents duplicate
+        eval submissions when the same HF model appears under multiple DB rows)
+    """
+    client = get_supabase_client()
+    since = _iso(datetime.now(timezone.utc) - timedelta(days=days))
+    try:
+        resp = _time_filters(client.table('models').select('*'), since).execute()
+        rows = list(resp.data or [])
+    except Exception as e:
+        log(f"ERROR: failed querying models by time: {e}")
+        return []
+
+    # Filter out precomputed models and duplicates
+    out: List[Dict] = []
+    skipped_dupes = 0
+    for r in rows:
+        if r.get("created_by") == "precomputed_hf":
+            continue
+        if r.get("duplicate_of"):
+            skipped_dupes += 1
+            continue
+        out.append(r)
+    if skipped_dupes:
+        log(f"Filtered out {skipped_dupes} duplicate model(s) (duplicate_of set)")
+    return out
+
+
+def fetch_priority_models(priority_names: List[str]) -> List[Dict]:
+    """Fetch models by name from Supabase, bypassing the lookback window.
+
+    This ensures priority models are always evaluated even if they were
+    registered long ago (outside the lookback window).
+
+    Filters out:
+      - Models with created_by == "precomputed_hf"
+      - Models with a non-empty "duplicate_of" field
+    """
+    if not priority_names:
+        return []
+
+    client = get_supabase_client()
+    try:
+        resp = (
+            client.table('models')
+            .select('*')
+            .in_('name', priority_names)
+            .execute()
+        )
+        rows = list(resp.data or [])
+    except Exception as e:
+        log(f"ERROR: failed querying priority models by name: {e}")
+        return []
+
+    out: List[Dict] = []
+    for r in rows:
+        if r.get("created_by") == "precomputed_hf":
+            continue
+        if r.get("duplicate_of"):
+            continue
+        out.append(r)
+    return out
+
+
+def resolve_benchmark_id(dataset_hf: str) -> Optional[str]:
+    """
+    Look up benchmark ID from database for a given dataset.
+
+    Caches results for performance.
+    """
+    repo_name = dataset_repo_name(dataset_hf)
+    if repo_name in _BENCH_CACHE:
+        return _BENCH_CACHE[repo_name]
+
+    try:
+        client = get_supabase_client()
+        resp = (
+            client.table('benchmarks')
+            .select('id,name')
+            .eq('name', repo_name)
+            .limit(1)
+            .execute()
+        )
+        rows = resp.data or []
+        bench_id = rows[0]['id'] if rows else None
+        _BENCH_CACHE[repo_name] = bench_id
+        if not bench_id:
+            log(f"No benchmark row found for dataset '{dataset_hf}' (wanted name='{repo_name}').")
+        return bench_id
+    except Exception as e:
+        log(f"ERROR resolving benchmark id for dataset '{dataset_hf}': {e}")
+        return None
+
+
+def check_job_status(
+    model_id: str, benchmark_id: Optional[str]
+) -> Tuple[bool, Optional[str], Optional[datetime], Optional[datetime], Optional[str]]:
+    """Check if a job exists for (model_id, benchmark_id) and its status.
+
+    Delegates to check_job_status_v3 (single-ID, non-timeout-aware path).
+    Kept as a thin wrapper for backward compatibility with callers that don't
+    need timeout-aware or duplicate-group queries.
+    """
+    return check_job_status_v3(model_id, benchmark_id)
+
+
+# ---------- Cross-Duplicate Aggregation ----------
+_DUP_GROUP_CACHE: Dict[str, List[str]] = {}
+
+
+def get_duplicate_group_ids(table: str, entity_id: str) -> List[str]:
+    """Get all IDs in the duplicate group for a model or benchmark.
+
+    Given an entity_id, finds the canonical ID and all its duplicates.
+    - If entity has duplicate_of set, canonical = duplicate_of
+    - Otherwise canonical = entity_id
+    - Then finds all rows WHERE duplicate_of = canonical_id
+    - Returns [canonical_id] + [all duplicate IDs]
+
+    Results are cached per (table, entity_id).
+    """
+    cache_key = f"{table}:{entity_id}"
+    if cache_key in _DUP_GROUP_CACHE:
+        return _DUP_GROUP_CACHE[cache_key]
+
+    try:
+        client = get_supabase_client()
+
+        # Step 1: Find the canonical ID
+        resp = client.table(table).select('id,duplicate_of').eq('id', entity_id).limit(1).execute()
+        rows = resp.data or []
+        if not rows:
+            _DUP_GROUP_CACHE[cache_key] = [entity_id]
+            return [entity_id]
+
+        canonical_id = rows[0].get('duplicate_of') or entity_id
+
+        # Step 2: Find all duplicates of the canonical
+        resp2 = client.table(table).select('id').eq('duplicate_of', canonical_id).execute()
+        dup_ids = [r['id'] for r in (resp2.data or [])]
+
+        group = list(set([canonical_id] + dup_ids))
+        # Cache for all members of the group
+        for gid in group:
+            _DUP_GROUP_CACHE[f"{table}:{gid}"] = group
+        return group
+
+    except Exception as e:
+        log(f"WARNING: Failed to get duplicate group for {table}/{entity_id}: {e}")
+        _DUP_GROUP_CACHE[cache_key] = [entity_id]
+        return [entity_id]
+
+
+# ---------- v3 Enhancement 5: Timeout-Config-Sensitive Job Dedup ----------
+def check_job_status_v3(
+    model_id: str,
+    benchmark_id: Optional[str],
+    timeout_aware: bool = False,
+    agent_name: str = DEFAULT_AGENT_NAME,
+    timeout_multiplier: float = DEFAULT_TIMEOUT_MULTIPLIER,
+    duplicate_model_ids: Optional[List[str]] = None,
+    duplicate_benchmark_ids: Optional[List[str]] = None,
+) -> Tuple[bool, Optional[str], Optional[datetime], Optional[datetime], Optional[str]]:
+    """
+    Check if a job exists for (model_id, benchmark_id) and its status.
+
+    When timeout_aware=True, filters to only match jobs with the same
+    agent_name and timeout_multiplier in their config.
+
+    When duplicate_model_ids/duplicate_benchmark_ids are provided, queries
+    across the entire duplicate group using .in_() instead of .eq().
+
+    Returns:
+        (job_exists, job_status, started_at, submitted_at, slurm_job_id)
+    """
+    if not benchmark_id:
+        return (False, None, None, None, None)
+
+    # Determine which IDs to query
+    model_ids = duplicate_model_ids if duplicate_model_ids else [model_id]
+    bench_ids = duplicate_benchmark_ids if duplicate_benchmark_ids else [benchmark_id]
+
+    try:
+        client = get_supabase_client()
+        q = client.table('sandbox_jobs').select(
+            'id,job_status,started_at,submitted_at,slurm_job_id,config'
+        )
+
+        # Use .in_() for duplicate groups, .eq() for singles
+        if len(model_ids) == 1:
+            q = q.eq('model_id', model_ids[0])
+        else:
+            q = q.in_('model_id', model_ids)
+
+        if len(bench_ids) == 1:
+            q = q.eq('benchmark_id', bench_ids[0])
+        else:
+            q = q.in_('benchmark_id', bench_ids)
+
+        q = q.order('created_at', desc=True).limit(50)
+        data = (q.execute().data) or []
+
+        if not data:
+            return (False, None, None, None, None)
+
+        # Filter to matching config if timeout_aware
+        for job in data:
+            if timeout_aware:
+                config = job.get('config')
+                if isinstance(config, str):
+                    try:
+                        config = json.loads(config)
+                    except Exception:
+                        config = {}
+                if not isinstance(config, dict):
+                    config = {}
+
+                job_agent = config.get('agent', DEFAULT_AGENT_NAME)
+                job_tm = config.get('timeout_multiplier', DEFAULT_TIMEOUT_MULTIPLIER)
+
+                # Skip if agent_name or timeout_multiplier don't match
+                if job_agent != agent_name or float(job_tm) != float(timeout_multiplier):
+                    continue
+
+            job_status = job.get('job_status')
+            started_at_str = job.get('started_at')
+            submitted_at_str = job.get('submitted_at')
+            slurm_job_id = job.get('slurm_job_id')
+
+            started_at = None
+            if started_at_str:
+                try:
+                    started_at = datetime.fromisoformat(started_at_str.replace('Z', '+00:00'))
+                except Exception:
+                    pass
+
+            submitted_at = None
+            if submitted_at_str:
+                try:
+                    submitted_at = datetime.fromisoformat(submitted_at_str.replace('Z', '+00:00'))
+                except Exception:
+                    pass
+
+            return (True, job_status, started_at, submitted_at, slurm_job_id)
+
+        # No matching job found
+        return (False, None, None, None, None)
+
+    except Exception as e:
+        log(f"WARNING: sandbox_jobs v3 check failed for model_id={model_id}, benchmark_id={benchmark_id}: {e}")
+        return (False, None, None, None, None)  # fail-open
+
+
+def is_job_stale(started_at: Optional[datetime], hours: int = DEFAULT_STALE_JOB_HOURS) -> bool:
+    """Check if a job started more than the specified hours ago."""
+    if not started_at:
+        # If started_at is null but job exists with status='Started', treat as stale
+        return True
+    now = datetime.now(timezone.utc)
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=timezone.utc)
+    age = now - started_at
+    return age > timedelta(hours=hours)
+
+
+def _config_matches_eval(job_config: Optional[Dict], eval_config: Dict) -> bool:
+    """Check if a DB job's config JSONB matches the current eval config fields.
+
+    Compares: timeout_multiplier, override_cpus, override_memory_mb, override_storage_mb.
+    A job with no config is treated as defaults (timeout=1.0, no overrides).
+    If eval_config is empty (no harbor config), any job config matches (backwards compat).
+    """
+    if not eval_config:
+        return True  # no config constraints -- any existing job counts
+
+    job_cfg = job_config or {}
+    job_env = job_cfg.get("environment") or {}
+
+    # timeout_multiplier: top-level in config JSONB
+    if "timeout_multiplier" in eval_config:
+        job_tm = job_cfg.get("timeout_multiplier")
+        # Treat None/missing as 1.0
+        job_tm = float(job_tm) if job_tm is not None else 1.0
+        if float(eval_config["timeout_multiplier"]) != job_tm:
+            return False
+
+    # Environment overrides: nested under config.environment
+    for key in ("override_cpus", "override_memory_mb", "override_storage_mb"):
+        if key in eval_config:
+            job_val = job_env.get(key)
+            # Treat None/missing as the default (None means no override)
+            job_val = int(job_val) if job_val is not None else None
+            eval_val = int(eval_config[key])
+            if job_val != eval_val:
+                return False
+
+    return True
+
+
+def should_start_job(
+    model_id: str,
+    benchmark_id: Optional[str],
+    stale_hours: int = DEFAULT_STALE_JOB_HOURS,
+    stale_pending_hours: int = DEFAULT_STALE_PENDING_HOURS,
+    timeout_aware: bool = False,
+    agent_name: str = DEFAULT_AGENT_NAME,
+    timeout_multiplier: float = DEFAULT_TIMEOUT_MULTIPLIER,
+    duplicate_model_ids: Optional[List[str]] = None,
+    duplicate_benchmark_ids: Optional[List[str]] = None,
+    eval_config: Optional[Dict] = None,
+) -> Tuple[bool, str, Optional[str]]:
+    """
+    Determine if a job should be started based on DB status.
+
+    When timeout_aware=True (v3 Enhancement 5), uses check_job_status_v3()
+    which filters jobs by agent_name and timeout_multiplier in config. This
+    allows running the same model with different configs without one blocking
+    the other.
+
+    When duplicate_model_ids/duplicate_benchmark_ids are provided, checks
+    across the entire duplicate group for existing jobs.
+
+    When eval_config is provided (from harbor YAML), performs config-aware
+    dedup: checks that existing jobs match the current resource overrides
+    (timeout_multiplier, override_cpus, override_memory_mb, override_storage_mb).
+
+    Returns:
+        (should_start, reason, slurm_job_id)
+        slurm_job_id is provided so the caller can scancel stale jobs.
+    """
+    job_exists, job_status, started_at, submitted_at, slurm_job_id = check_job_status_v3(
+        model_id, benchmark_id,
+        timeout_aware=timeout_aware,
+        agent_name=agent_name,
+        timeout_multiplier=timeout_multiplier,
+        duplicate_model_ids=duplicate_model_ids,
+        duplicate_benchmark_ids=duplicate_benchmark_ids,
+    )
+
+    if not job_exists:
+        return (True, "no existing job", None)
+
+    ec = eval_config or {}
+
+    if job_status == JOB_STATUS_FINISHED:
+        if ec:
+            # Check if any Finished job matches our eval config
+            try:
+                client = get_supabase_client()
+                q = (
+                    client.table("sandbox_jobs")
+                    .select("config, metrics")
+                    .eq("model_id", model_id)
+                    .eq("benchmark_id", benchmark_id)
+                    .eq("job_status", "Finished")
+                    .order("created_at", desc=True)
+                    .limit(10)
+                )
+                rows = (q.execute().data) or []
+                matching = [r for r in rows if _config_matches_eval(r.get("config"), ec)]
+                if not matching:
+                    return (True, "no finished job with matching config", slurm_job_id)
+                if matching[0] and not matching[0].get("metrics"):
+                    return (True, "finished with matching config but metrics cleared", slurm_job_id)
+            except Exception as e:
+                log(f"WARNING: config-aware check failed: {e}")
+        # v6: DaytonaError resume is now handled by disk-based scanning in
+        # scan_jobs_dir_for_resume(), not here. This avoids the circular dependency
+        # where DB stats only exist after upload, but upload is skipped on error.
+
+        return (False, "job finished", slurm_job_id)
+
+    if job_status == JOB_STATUS_PENDING:
+        if ec:
+            try:
+                client = get_supabase_client()
+                q = (
+                    client.table("sandbox_jobs")
+                    .select("config, slurm_job_id, created_at")
+                    .eq("model_id", model_id)
+                    .eq("benchmark_id", benchmark_id)
+                    .eq("job_status", "Pending")
+                    .order("created_at", desc=True)
+                    .limit(5)
+                )
+                rows = (q.execute().data) or []
+                matching = [r for r in rows if _config_matches_eval(r.get("config"), ec)]
+                if not matching:
+                    return (True, "no pending job with matching config", slurm_job_id)
+            except Exception as e:
+                log(f"WARNING: config-aware check failed: {e}")
+        # Job submitted but not yet running - check if stale using separate pending threshold
+        if is_job_stale(submitted_at, stale_pending_hours):
+            submitted_str = submitted_at.isoformat() if submitted_at else "null"
+            return (True, f"stale pending job (submitted_at={submitted_str})", slurm_job_id)
+        else:
+            submitted_str = submitted_at.isoformat() if submitted_at else "null"
+            return (False, f"job pending in SLURM queue (submitted_at={submitted_str})", slurm_job_id)
+
+    if job_status == JOB_STATUS_STARTED:
+        if ec:
+            try:
+                client = get_supabase_client()
+                q = (
+                    client.table("sandbox_jobs")
+                    .select("config, started_at")
+                    .eq("model_id", model_id)
+                    .eq("benchmark_id", benchmark_id)
+                    .eq("job_status", "Started")
+                    .order("created_at", desc=True)
+                    .limit(5)
+                )
+                rows = (q.execute().data) or []
+                matching = [r for r in rows if _config_matches_eval(r.get("config"), ec)]
+                if not matching:
+                    return (True, "no in-progress job with matching config", slurm_job_id)
+            except Exception as e:
+                log(f"WARNING: config-aware check failed: {e}")
+        if is_job_stale(started_at, stale_hours):
+            started_str = started_at.isoformat() if started_at else "null"
+            return (True, f"stale job (started_at={started_str})", slurm_job_id)
+        else:
+            started_str = started_at.isoformat() if started_at else "null"
+            return (False, f"job in progress (started_at={started_str})", slurm_job_id)
+
+    # Unknown status - start job to be safe
+    return (True, f"unknown job status: {job_status}", slurm_job_id)
+
+
+# ---------- v3 Enhancement 2: Per-Listener SLURM Job Throttle ----------
+def get_active_slurm_job_ids() -> Set[str]:
+    """Return set of SLURM job IDs currently queued/running for this user.
+
+    Used by EvalListener to determine which of its submitted jobs are still
+    active. The listener intersects this with its internal _submitted_jobs
+    set to get a per-listener active count.
+    """
+    try:
+        user = getpass.getuser()
+        code, out = _run(["squeue", "-u", user, "--noheader", "-h", "-o", "%i"])
+        if code != 0:
+            log(f"WARNING: squeue failed (exit {code}), returning empty set")
+            return set()
+        return {line.strip() for line in out.strip().split('\n') if line.strip()}
+    except Exception as e:
+        log(f"WARNING: Failed to query squeue: {e}")
+        return set()
+
+
+def get_active_model_dataset_pairs(
+    log_dir: str = "eval/logs",
+) -> Tuple[Set[str], Set[Tuple[str, str]], Dict[str, str]]:
+    """Return (active_models, active_model_dataset_pairs, active_run_tags) for all active SLURM eval jobs.
+
+    Queries squeue for all active jobs (RUNNING/PENDING/COMPLETING), then parses
+    each job's eval log file to extract the model name, dataset, and run_tag.
+
+    Args:
+        log_dir: Directory containing eval log files ({job_name}_{slurm_id}.out).
+
+    Returns:
+        active_models: Set of HF model names currently running/queued.
+        active_pairs: Set of (hf_model, dataset_hf) tuples currently running/queued.
+        active_run_tags: Dict mapping run_tag → slurm_job_id for active jobs.
+    """
+    active_models: Set[str] = set()
+    active_pairs: Set[Tuple[str, str]] = set()
+    active_run_tags: Dict[str, str] = {}
+
+    try:
+        user = getpass.getuser()
+        code, out = _run(["squeue", "-u", user, "--noheader", "-o", "%i %j"])
+        if code != 0:
+            log(f"WARNING: squeue failed (exit {code}), returning empty active sets")
+            return active_models, active_pairs, active_run_tags
+    except Exception as e:
+        log(f"WARNING: Failed to query squeue: {e}")
+        return active_models, active_pairs, active_run_tags
+
+    log_path = Path(log_dir)
+    for line in out.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) < 2:
+            continue
+        job_id, job_name = parts[0], parts[1]
+
+        # Try to parse the eval log file for this job
+        log_file = log_path / f"{job_name}_{job_id}.out"
+        if not log_file.exists():
+            continue
+
+        model = dataset = run_tag = None
+        try:
+            with open(log_file, "r") as f:
+                for i, fline in enumerate(f):
+                    if i > 200:  # Only scan first 200 lines
+                        break
+                    if fline.startswith("Model: "):
+                        model = fline.strip()[7:]
+                    elif fline.startswith("Dataset: "):
+                        dataset = fline.strip()[9:]
+                    elif fline.startswith("Run tag: "):
+                        run_tag = fline.strip()[9:]
+                    if model and dataset and run_tag:
+                        break
+        except (OSError, IOError):
+            continue
+
+        if model:
+            active_models.add(model)
+        if model and dataset:
+            # Normalize dataset: local path → HF name (e.g. /e/.../DCAgent_dev_set_v2 → DCAgent/dev_set_v2)
+            ds_normalized = dataset
+            if "/" in dataset and not dataset.startswith("/"):
+                # Already HF format like DCAgent/dev_set_v2 or DCAgent2/terminal_bench_2
+                ds_normalized = dataset
+            active_pairs.add((model, ds_normalized))
+        if run_tag:
+            active_run_tags[run_tag] = job_id
+
+    return active_models, active_pairs, active_run_tags
+
+
+def _parse_job_ids_from_single_log(log_path: str) -> Set[str]:
+    """Parse SLURM job IDs from a single listener log file.
+
+    Matches two patterns:
+      1. "-> Submitted as SLURM job 293324 (job_name=...)"   — direct submissions
+      2. "[inherit-log] Inherited jobs: 293324,293325,..."    — inherited from previous log
+    """
+    job_ids: Set[str] = set()
+    try:
+        with open(log_path, "r") as f:
+            for line in f:
+                if "Submitted as SLURM job" in line:
+                    parts = line.split("Submitted as SLURM job ")
+                    if len(parts) >= 2:
+                        jid = parts[1].split()[0].strip()
+                        if jid.isdigit():
+                            job_ids.add(jid)
+                elif "[inherit-log] Inherited jobs:" in line:
+                    # Parse comma-separated job IDs
+                    parts = line.split("Inherited jobs:")
+                    if len(parts) >= 2:
+                        for jid in parts[1].strip().split(","):
+                            jid = jid.strip()
+                            if jid.isdigit():
+                                job_ids.add(jid)
+    except (OSError, IOError) as e:
+        log(f"WARNING: Failed to read log {log_path}: {e}")
+    return job_ids
+
+
+def parse_submitted_jobs_from_logs(log_paths: List[str]) -> Set[str]:
+    """Parse SLURM job IDs from one or more listener logs.
+
+    Aggregates across all logs, then filters to jobs still active in squeue.
+    """
+    all_job_ids: Set[str] = set()
+    for lp in log_paths:
+        ids = _parse_job_ids_from_single_log(lp)
+        log(f"[inherit-log] Parsed {len(ids)} job(s) from {lp}")
+        all_job_ids |= ids
+
+    active_ids = get_active_slurm_job_ids()
+    still_active = all_job_ids & active_ids
+    log(f"[inherit-log] Total: {len(all_job_ids)} job(s) across {len(log_paths)} log(s), "
+        f"{len(still_active)} still active in squeue")
+    return still_active
+
+
+# ---------- v3 Enhancement 3: Daytona Resource Pre-flight Check ----------
+def check_daytona_resources(sandbox_limit: int, warning_buffer: float) -> bool:
+    """
+    Check Daytona resource usage via API.
+
+    Called at listener startup and optionally each iteration when
+    --check-daytona-resources is enabled. Requires DAYTONA_API_KEY in env.
+
+    Returns True if OK to proceed, False if active sandboxes >= sandbox_limit.
+    Logs a warning when active sandboxes >= sandbox_limit * warning_buffer.
+    """
+    try:
+        from daytona_api_client import ApiClient, Configuration, SandboxApi
+    except ImportError:
+        log("WARNING: daytona_api_client not installed, skipping resource check")
+        return True
+
+    api_key = os.environ.get("DAYTONA_API_KEY")
+    api_url = os.environ.get("DAYTONA_API_URL", "https://app.daytona.io/api")
+    if not api_key:
+        log("WARNING: DAYTONA_API_KEY not set, skipping resource check")
+        return True
+
+    try:
+        config = Configuration(host=api_url)
+        client = ApiClient(config)
+        client.default_headers["Authorization"] = f"Bearer {api_key}"
+        api = SandboxApi(client)
+
+        result = api.list_sandboxes_paginated(states=["started"], limit=1, page=1)
+        active_count = result.total
+
+        threshold = int(sandbox_limit * warning_buffer)
+        if active_count >= sandbox_limit:
+            log(f"ERROR: Daytona resources at limit: {active_count}/{sandbox_limit} active sandboxes "
+                f"({active_count/sandbox_limit:.1%})")
+            return False
+        elif active_count >= threshold:
+            log(f"WARNING: Daytona resources at {active_count}/{sandbox_limit} active sandboxes "
+                f"({active_count/sandbox_limit:.1%}) - approaching limit!")
+            return True
+        else:
+            log(f"Daytona resources OK: {active_count}/{sandbox_limit} active sandboxes "
+                f"({active_count/sandbox_limit:.1%})")
+            return True
+    except Exception as e:
+        log(f"WARNING: Daytona resource check failed: {e}")
+        return True  # fail-open
+
+
+# ---------- Job Submission ----------
+def _resolve_agent_name_from_config_yaml(config_yaml: str) -> Optional[str]:
+    """Return agents[0].name from a harbor eval config YAML, or None if not resolvable.
+
+    Mirrors the sbatch's own yaml resolution (eval/configs/, eval/<cluster>/, eval/MBZ/)
+    so the listener and sbatch always agree on the runtime agent name.
+    """
+    if not config_yaml:
+        return None
+    candidates = []
+    if os.path.isabs(config_yaml):
+        candidates.append(config_yaml)
+    else:
+        cluster_name = (_CLUSTER_CONFIG or {}).get("cluster_name")
+        for base in ("eval/configs", f"eval/{cluster_name}" if cluster_name else None, "eval/MBZ"):
+            if base:
+                candidates.append(os.path.join(base, config_yaml))
+    for path in candidates:
+        try:
+            if os.path.isfile(path):
+                with open(path) as f:
+                    cfg = yaml.safe_load(f) or {}
+                agents = cfg.get("agents") or []
+                if agents and isinstance(agents, list):
+                    name = agents[0].get("name")
+                    if name:
+                        return name
+                return None
+        except Exception:
+            continue
+    return None
+
+
+@dataclass
+class SbatchParams:
+    """Parameters passed to the sbatch script via environment variables.
+
+    The listener converts these to EVAL_* env vars via to_env(), which the
+    sbatch script reads at startup.
+
+    v3 additions:
+        error_threshold   Mapped to EVAL_DAYTONA_THRESHOLD (name kept for compat).
+                          Controls the unified invalid error threshold.
+        timeout_multiplier  Mapped to EVAL_TIMEOUT_MULTIPLIER. Passed to harbor
+                            --timeout-multiplier and stored in DB job config.
+
+    Cluster config additions (v6):
+        When a cluster config YAML is loaded (--cluster-config), to_env() also
+        exports EVAL_PROJECT_ROOT, EVAL_HF_CACHE, EVAL_HARBOR_SRC,
+        EVAL_DATASETS_DIRS, EVAL_PROXY_ENABLED, EVAL_LOGIN_NODE,
+        EVAL_PROXYCHAINS_BIN, EVAL_CUDA_HOME, EVAL_ARCH, EVAL_GPUS_PER_NODE,
+        and EVAL_LOGS_DIR so sbatch scripts can be cluster-agnostic.
+    """
+    n_concurrent: int = DEFAULT_N_CONCURRENT
+    n_attempts: int = DEFAULT_N_ATTEMPTS
+    gpu_memory_util: float = DEFAULT_GPU_MEMORY_UTIL
+    error_threshold: int = DEFAULT_ERROR_THRESHOLD
+    vllm_max_retries: int = DEFAULT_VLLM_MAX_RETRIES
+    agent_parser: str = DEFAULT_AGENT_PARSER
+    slurm_time: str = DEFAULT_SLURM_TIME
+    enable_thinking: bool = DEFAULT_ENABLE_THINKING
+    agent_name: str = DEFAULT_AGENT_NAME
+    slurm_partition: str = DEFAULT_SLURM_PARTITION
+    slurm_account: str = DEFAULT_SLURM_ACCOUNT
+    tp_size: int = DEFAULT_TP_SIZE
+    dp_size: int = 1  # vLLM native data-parallel replicas (total GPUs = tp_size * dp_size)
+    upload_username: str = ""
+    timeout_multiplier: float = DEFAULT_TIMEOUT_MULTIPLIER  # v3 Enhancement 5
+    config_yaml: str = "dcagent_eval_config.yaml"
+    max_output_tokens: Optional[int] = None  # None = use sbatch default (16384)
+    auto_snapshot: Optional[bool] = None  # None = use YAML default
+    agent_envs: Optional[str] = None  # Comma-separated KEY=VALUE pairs for --ae
+    pinggy_url: Optional[str] = None  # Pinggy persistent URL (e.g., xxx.a.pinggy.link)
+    pinggy_token: Optional[str] = None  # Pinggy auth token
+
+    def get_effective_agent_name(self) -> str:
+        """Resolve the runtime agent name, preferring the config_yaml's agents[0].name.
+
+        The harbor config YAML is the ground truth for which agent actually runs
+        (the sbatch reads it too). The listener's `--agent-name` CLI flag is only
+        used as a fallback when the yaml is missing or lacks an agents block.
+        Without this resolution, the DB Pending entry ends up with the wrong
+        agent_id for installed-agent runs (aider / openhands / mini-swe-agent /
+        swe-agent), because --agent-name defaults to terminus-2.
+        """
+        yaml_name = _resolve_agent_name_from_config_yaml(self.config_yaml)
+        return yaml_name or self.agent_name
+
+    def to_env(self) -> Dict[str, str]:
+        """Convert to environment variables for sbatch."""
+        env = {
+            "EVAL_N_CONCURRENT": str(self.n_concurrent),
+            "EVAL_N_ATTEMPTS": str(self.n_attempts),
+            "EVAL_GPU_MEMORY_UTIL": str(self.gpu_memory_util),
+            "EVAL_DAYTONA_THRESHOLD": str(self.error_threshold),
+            "EVAL_VLLM_MAX_RETRIES": str(self.vllm_max_retries),
+            "EVAL_AGENT_PARSER": self.agent_parser,
+            "EVAL_SLURM_TIME": self.slurm_time,
+            "EVAL_ENABLE_THINKING": "true" if self.enable_thinking else "false",
+            "EVAL_AGENT_NAME": self.get_effective_agent_name(),
+        }
+        # Always send tp_size so build_vllm_cmd.sh doesn't fall back to its own default
+        env["EVAL_VLLM_TENSOR_PARALLEL_SIZE"] = str(self.tp_size)
+        if self.dp_size > 1:
+            env["EVAL_VLLM_DATA_PARALLEL_SIZE"] = str(self.dp_size)
+        if self.upload_username:
+            env["EVAL_UPLOAD_USERNAME"] = self.upload_username
+        # Enhancement 5: Pass timeout multiplier
+        if self.timeout_multiplier != DEFAULT_TIMEOUT_MULTIPLIER:
+            env["EVAL_TIMEOUT_MULTIPLIER"] = str(self.timeout_multiplier)
+        # Pass config YAML (no-override for tb2/swebench)
+        if self.config_yaml and self.config_yaml != "dcagent_eval_config.yaml":
+            env["EVAL_CONFIG_YAML"] = self.config_yaml
+        # Max output tokens override
+        if self.max_output_tokens is not None:
+            env["EVAL_MAX_OUTPUT_TOKENS"] = str(self.max_output_tokens)
+        # Daytona auto_snapshot override (None = use YAML default)
+        if self.auto_snapshot is not None:
+            env["EVAL_AUTO_SNAPSHOT"] = "true" if self.auto_snapshot else "false"
+        # Agent env vars forwarded into sandbox via --ae
+        if self.agent_envs:
+            env["EVAL_AGENT_ENVS"] = self.agent_envs
+        # Pinggy tunnel config (for installed agents)
+        if self.pinggy_url:
+            env["EVAL_PINGGY_URL"] = self.pinggy_url
+        if self.pinggy_token:
+            env["EVAL_PINGGY_TOKEN"] = self.pinggy_token
+        # Forward EVAL_JOBS_DIR to sbatch (default to user-writable location)
+        fallback_jobs_dir = _cc_path("eval_jobs_dir", _FALLBACK_EVAL_JOBS_DIR)
+        env["EVAL_JOBS_DIR"] = os.environ.get("EVAL_JOBS_DIR", fallback_jobs_dir)
+
+        # --- Cluster config env vars (for sbatch parameterization) ---
+        cc = _CLUSTER_CONFIG
+        if cc:
+            paths = cc.get("paths", {})
+            proxy = cc.get("proxy", {})
+            hw = cc.get("hardware", {})
+
+            if cc.get("cluster_name"):
+                env["EVAL_CLUSTER_NAME"] = cc["cluster_name"]
+            if paths.get("project_root"):
+                env["EVAL_PROJECT_ROOT"] = paths["project_root"]
+            if paths.get("hf_cache"):
+                env["EVAL_HF_CACHE"] = paths["hf_cache"]
+            if paths.get("harbor_src"):
+                env["EVAL_HARBOR_SRC"] = paths["harbor_src"]
+            if paths.get("datasets_dirs"):
+                env["EVAL_DATASETS_DIRS"] = ":".join(paths["datasets_dirs"])
+            if paths.get("eval_logs_dir"):
+                env["EVAL_LOGS_DIR"] = paths["eval_logs_dir"]
+
+            env["EVAL_PROXY_ENABLED"] = "true" if proxy.get("enabled") else "false"
+            if proxy.get("login_node"):
+                env["EVAL_LOGIN_NODE"] = proxy["login_node"]
+            if proxy.get("proxychains_bin"):
+                env["EVAL_PROXYCHAINS_BIN"] = proxy["proxychains_bin"]
+
+            if hw.get("cuda_home"):
+                env["EVAL_CUDA_HOME"] = hw["cuda_home"]
+            if hw.get("arch"):
+                env["EVAL_ARCH"] = hw["arch"]
+            if hw.get("gpus_per_node"):
+                env["EVAL_GPUS_PER_NODE"] = str(hw["gpus_per_node"])
+            if hw.get("cpus_per_node"):
+                env["EVAL_CPUS_PER_NODE"] = str(hw["cpus_per_node"])
+
+        return env
+
+    def __str__(self) -> str:
+        """String representation for logging."""
+        parts = [
+            f"n_concurrent={self.n_concurrent}",
+            f"n_attempts={self.n_attempts}",
+            f"gpu_memory_util={self.gpu_memory_util}",
+            f"error_threshold={self.error_threshold}",
+            f"vllm_max_retries={self.vllm_max_retries}",
+        ]
+        if self.agent_parser:
+            parts.append(f"agent_parser={self.agent_parser}")
+        if self.slurm_time != DEFAULT_SLURM_TIME:
+            parts.append(f"slurm_time={self.slurm_time}")
+        if self.tp_size != DEFAULT_TP_SIZE:
+            parts.append(f"tp_size={self.tp_size}")
+        if self.dp_size > 1:
+            parts.append(f"dp_size={self.dp_size}")
+        if self.enable_thinking:
+            parts.append("enable_thinking=True")
+        if self.agent_name != DEFAULT_AGENT_NAME:
+            parts.append(f"agent_name={self.agent_name}")
+        if self.slurm_partition != DEFAULT_SLURM_PARTITION:
+            parts.append(f"slurm_partition={self.slurm_partition}")
+        if self.upload_username:
+            parts.append(f"upload_username={self.upload_username}")
+        if self.timeout_multiplier != DEFAULT_TIMEOUT_MULTIPLIER:
+            parts.append(f"timeout_multiplier={self.timeout_multiplier}")
+        return ", ".join(parts)
+
+
+def _run(cmd: List[str], env: Optional[Dict[str, str]] = None) -> Tuple[int, str]:
+    """Run a command and return exit code and output."""
+    # Merge with current environment if extra env vars provided
+    run_env = None
+    if env:
+        run_env = os.environ.copy()
+        run_env.update(env)
+
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=run_env
+    )
+    out_lines = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        out_lines.append(line.rstrip())
+    code = proc.wait()
+    return code, "\n".join(out_lines)
+
+
+def get_idle_nodes(partition: str) -> List[str]:
+    """Get list of idle nodes on a SLURM partition."""
+    code, out = _run(["sinfo", "-p", partition, "-N", "--format=%N %t", "--noheader"])
+    if code != 0:
+        return []
+    nodes = []
+    for line in out.strip().split("\n"):
+        parts = line.split()
+        if len(parts) >= 2 and parts[1].strip() == "idle":
+            nodes.append(parts[0].strip())
+    return nodes
+
+
+def generate_run_tag(dataset_hf: str, model_hf: str) -> str:
+    """
+    Generate a unique RUN_TAG for the job.
+
+    Format: {safe_repo}_{safe_model}_{timestamp}
+    """
+    safe_repo = dataset_repo_name(dataset_hf).replace("-", "_").replace(".", "_")
+    safe_model = model_hf.split("/")[-1].replace("-", "_").replace(".", "_")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return f"{safe_repo}_{safe_model}_{timestamp}"
+
+
+def cancel_slurm_job(slurm_job_id: str, dry_run: bool = False) -> bool:
+    """Cancel a SLURM job via scancel. Returns True if successful."""
+    if dry_run:
+        log(f"[DRY RUN] Would cancel SLURM job {slurm_job_id}")
+        return True
+    code, out = _run(["scancel", slurm_job_id])
+    if code == 0:
+        log(f"Cancelled SLURM job {slurm_job_id}")
+        return True
+    else:
+        log(f"WARNING: scancel failed for job {slurm_job_id}: {out}")
+        return False
+
+
+def update_pending_job_slurm_id(db_job_id: str, slurm_job_id: str) -> None:
+    """Update the Pending job entry with the SLURM job ID after successful sbatch."""
+    try:
+        client = get_supabase_client()
+        client.table("sandbox_jobs").update(
+            {"slurm_job_id": slurm_job_id}
+        ).eq("id", db_job_id).execute()
+        log(f"Updated job {db_job_id} with slurm_job_id={slurm_job_id}", verbose_only=True)
+    except Exception as e:
+        log(f"WARNING: failed to update job {db_job_id} with slurm_job_id: {e}")
+
+
+def submit_eval(
+    hf_model_name: str,
+    dataset_hf: str,
+    benchmark_id: Optional[str],
+    sbatch_script: str,
+    sbatch_params: Optional[SbatchParams] = None,
+    dry_run: bool = False,
+    upload_username: str = "",
+    timeout_multiplier: float = DEFAULT_TIMEOUT_MULTIPLIER,
+    vllm_overrides: Optional[Dict[str, str]] = None,
+    dependency: Optional[str] = None,
+    eval_config: Optional[Dict] = None,
+    conda_env: str = "otagent",
+    run_tag_override: Optional[str] = None,
+    dp_nodes: int = 0,
+    nodelist: Optional[str] = None,
+    extra_env: Optional[Dict[str, str]] = None,
+    skip_gpu_request: bool = False,
+    sbatch_model_override: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Create a Pending DB entry, then submit sbatch job and update with SLURM ID.
+
+    sbatch positional args:
+      $1 = model HF name
+      $2 = dataset HF repo (org/repo)
+      $3 = benchmark_id (uuid)  [optional]
+      $4 = job_name (RUN_TAG)
+
+    Environment variables (from SbatchParams.to_env()):
+      EVAL_N_CONCURRENT, EVAL_N_ATTEMPTS, EVAL_GPU_MEMORY_UTIL,
+      EVAL_DAYTONA_THRESHOLD, EVAL_VLLM_MAX_RETRIES, EVAL_AGENT_PARSER,
+      EVAL_SLURM_TIME, EVAL_ENABLE_THINKING, EVAL_AGENT_NAME,
+      EVAL_STARTS_LOG (v3), EVAL_TIMEOUT_MULTIPLIER (v3)
+
+    The Pending DB entry includes timeout_multiplier in its config dict
+    so that timeout-aware dedup (Enhancement 5) can match on it.
+
+    Args:
+        vllm_overrides: Optional dict of EVAL_VLLM_* env vars from baseline
+                        model config. Merged into sbatch env vars.
+        dependency: Optional SLURM dependency string (e.g. 'afterany:12345').
+        eval_config: Optional harbor eval config dict for DB job config.
+        run_tag_override: v5 - reuse original run_tag for resume (triggers sbatch auto-resume).
+
+    Returns:
+        (slurm_job_id, job_name) if successful, ("DRY_RUN", job_name) if dry run, (None, None) on failure
+    """
+    # Generate unique job name, or reuse for resume
+    if run_tag_override:
+        job_name = run_tag_override
+        log(f"  [v5] Reusing run_tag for resume: {job_name}")
+    else:
+        job_name = generate_run_tag(dataset_hf, hf_model_name)
+
+    # Early return for dry-run — no DB writes, no sbatch
+    if dry_run:
+        log(f"[DRY RUN] Would submit: model={hf_model_name} dataset={dataset_hf} job={job_name}")
+        if sbatch_params:
+            log(f"[DRY RUN] With params: {sbatch_params}")
+        if vllm_overrides:
+            log(f"[DRY RUN] vLLM overrides: {list(vllm_overrides.keys())}", verbose_only=True)
+        return ("DRY_RUN", job_name)
+
+    # Step 1: Create or reuse DB entry BEFORE sbatch submission.
+    # Use the effective agent name (derived from config_yaml when available) so
+    # installed-agent runs don't get terminus-2's agent_id stamped on their row.
+    agent = sbatch_params.get_effective_agent_name() if sbatch_params else DEFAULT_AGENT_NAME
+    tm = sbatch_params.timeout_multiplier if sbatch_params else timeout_multiplier
+    config: Dict = {"agent": agent, "env": "daytona", "timeout_multiplier": tm, "run_tag": job_name}
+    # Include harbor eval config fields in DB entry for config-aware dedup
+    if eval_config:
+        if "timeout_multiplier" in eval_config:
+            config["timeout_multiplier"] = eval_config["timeout_multiplier"]
+        env_overrides = {}
+        for key in ("override_cpus", "override_memory_mb", "override_storage_mb"):
+            if key in eval_config:
+                env_overrides[key] = eval_config[key]
+        if env_overrides:
+            config["environment"] = env_overrides
+
+    db_job_id: Optional[str] = None
+    try:
+        from database.unified_db.utils import (
+            create_job_entry_pending, get_supabase_client,
+            get_model_by_name, get_benchmark_by_name,
+            get_job_by_model_benchmark, update_sandbox_job,
+        )
+
+        if run_tag_override:
+            # v6 resume: find existing DB entry and update its job_name to match
+            # the resume run_tag, so sbatch's update_job_status_to_started() can
+            # find it by name. Also reset status to Pending for clean state.
+            model_row = get_model_by_name(hf_model_name)
+            bench_name = dataset_hf.split("/")[-1] if "/" in dataset_hf else dataset_hf
+            bench_row = get_benchmark_by_name(bench_name)
+            if model_row and bench_row:
+                existing = get_job_by_model_benchmark(model_row['id'], bench_row['id'])
+                if existing:
+                    old_name = existing.get('job_name', '?')
+                    old_status = existing.get('job_status', '?')
+                    db_job_id = str(existing['id'])
+                    # Update the existing entry: reset to Pending with new job_name
+                    update_sandbox_job(db_job_id, {
+                        "job_name": job_name,
+                        "job_status": "Pending",
+                        "slurm_job_id": "pending",
+                        "config": config,
+                        "submitted_at": datetime.now().isoformat(),
+                        "started_at": None,
+                    })
+                    log(f"  [v6] Reused DB entry {db_job_id}: {old_status} '{old_name}' → Pending '{job_name}'",
+                        verbose_only=True)
+
+        if not db_job_id:
+            # Normal path: create new Pending entry
+            result = create_job_entry_pending(
+                job_name=job_name,
+                model_hf=hf_model_name,
+                benchmark_hf=dataset_hf,
+                agent_name=agent,
+                slurm_job_id="pending",
+                username=upload_username or "listener",
+                config=config,
+            )
+            if result.get("success") and result.get("job"):
+                db_job_id = str(result["job"].get("id"))
+                log(f"Created Pending DB entry: {db_job_id}", verbose_only=True)
+            else:
+                log(f"WARNING: Failed to create Pending DB entry: {result.get('error')}")
+    except Exception as e:
+        log(f"WARNING: Exception creating Pending DB entry: {e}")
+
+    # Step 2: Build sbatch command
+    cmd = ["sbatch"]
+    if sbatch_params:
+        cmd.extend(["--time", sbatch_params.slurm_time])
+        cmd.extend(["--partition", sbatch_params.slurm_partition])
+        if sbatch_params.slurm_account:
+            cmd.extend(["--account", sbatch_params.slurm_account])
+        if skip_gpu_request:
+            # API mode: no GPU, modest CPU/mem (sbatch header sets sane defaults).
+            cmd.extend(["--cpus-per-task", "8"])
+            cmd.extend(["--mem", "16G"])
+        else:
+            # Request GPUs, CPUs, and memory proportional to total GPU count (TP × DP).
+            # Per-model baseline config can override TP (e.g. 32B models need TP=4).
+            effective_tp = sbatch_params.tp_size
+            if vllm_overrides and "EVAL_VLLM_TENSOR_PARALLEL_SIZE" in vllm_overrides:
+                effective_tp = int(vllm_overrides["EVAL_VLLM_TENSOR_PARALLEL_SIZE"])
+            effective_dp = sbatch_params.dp_size
+            total_gpus = effective_tp * effective_dp
+            cmd.extend(["--gres", f"gpu:{total_gpus}"])
+            cc = _CLUSTER_CONFIG or {}
+            hw = cc.get("hardware", {})
+            gpus_per_node = int(hw.get("gpus_per_node", 8))
+            cpus_per_node = int(hw.get("cpus_per_node", 96))
+            mem_per_node_mb = int(hw.get("mem_per_node_mb", 1860000))
+            cpus_needed = (cpus_per_node * total_gpus) // gpus_per_node
+            mem_needed = (mem_per_node_mb * total_gpus) // gpus_per_node
+            cmd.extend(["--cpus-per-task", str(cpus_needed)])
+            cmd.extend(["--mem", f"{mem_needed}M"])
+    # Override sbatch --output to use cluster-configured log dir
+    cc_logs = (_CLUSTER_CONFIG or {}).get("paths", {}).get("eval_logs_dir", _FALLBACK_EVAL_LOGS_DIR)
+    cmd.extend(["--output", f"{cc_logs}/%x_%j.out"])
+    if nodelist:
+        cmd.extend(["--nodelist", nodelist])
+    if dependency:
+        cmd.append(f"--dependency={dependency}")
+    # DP: request multiple nodes
+    if dp_nodes > 0:
+        cmd.extend(["--nodes", str(dp_nodes)])
+    # Benchmark-aware SLURM job name for squeue readability
+    repo_name = dataset_repo_name(dataset_hf)
+    bench_tag = _BENCH_SHORT.get(repo_name, repo_name[:12])
+    if run_tag_override:
+        job_prefix = "res_dp_" if dp_nodes > 0 else "res_"
+    else:
+        job_prefix = "eval_dp_" if dp_nodes > 0 else "eval_"
+    slurm_job_name = os.environ.get("EVAL_SLURM_JOB_NAME", "data")
+    cmd.extend(["--job-name", slurm_job_name])
+    cmd.append(sbatch_script)
+    # For API mode the sbatch arg is the LiteLLM-prefixed name (e.g.
+    # together_ai/moonshotai/Kimi-K2.5) while the DB row keeps the unprefixed
+    # registered name. For vLLM mode they're the same.
+    sbatch_model_arg = sbatch_model_override or hf_model_name
+    cmd.extend([sbatch_model_arg, dataset_hf])
+    # $3 = benchmark_id (or empty placeholder), $4 = run_tag override
+    cmd.append(str(benchmark_id) if benchmark_id else "")
+    cmd.append(job_name)  # 4th arg: job_name (RUN_TAG)
+
+    # Get env vars from params and merge vllm overrides + harbor config env vars
+    env_vars = sbatch_params.to_env() if sbatch_params else {}
+    # Pass-through whitelist for agent-specific host env overrides (e.g. custom
+    # swe-agent config URL). Listed here rather than forwarding full environ to
+    # avoid leaking unrelated vars into the SLURM job.
+    for _passthru in ("SWEAGENT_CONFIG", "EVAL_USE_GLM5_PROXY"):
+        if _passthru in os.environ:
+            env_vars[_passthru] = os.environ[_passthru]
+    if db_job_id:
+        env_vars["EVAL_DB_JOB_ID"] = db_job_id
+    if vllm_overrides:
+        env_vars.update(vllm_overrides)
+    # Pass harbor eval config fields as sbatch env vars
+    if eval_config:
+        if eval_config.get("timeout_multiplier") is not None:
+            env_vars["EVAL_TIMEOUT_MULTIPLIER"] = str(eval_config["timeout_multiplier"])
+        if eval_config.get("override_memory_mb") is not None:
+            env_vars["EVAL_OVERRIDE_MEMORY_MB"] = str(eval_config["override_memory_mb"])
+
+    # Pass conda env path so sbatch uses the right Python/vLLM installation
+    otagent_dir = CONDA_ENV_PATHS.get(conda_env)
+    if otagent_dir:
+        env_vars["OTAGENT_DIR"] = otagent_dir
+    # Merge extra env vars (e.g. EVAL_VLLM_PORT from pack-jobs port planner)
+    if extra_env:
+        env_vars.update(extra_env)
+    # DP: let sbatch compute NUM_SHARDS from GPUS_PER_NODE / TP_SIZE * nodes
+    # Do NOT pass EVAL_NUM_SHARDS — it would override the per-node shard calculation
+
+    # Step 3: Run sbatch
+    code, out = _run(cmd, env=env_vars)
+    log(f"sbatch: {' '.join(cmd)}\n{out}")
+
+    if code != 0:
+        # sbatch failed; pending entry remains (will be detected as stale later)
+        return (None, None)
+
+    m = re.search(r"Submitted batch job (\d+)", out)
+    slurm_job_id = m.group(1) if m else None
+
+    if not slurm_job_id:
+        log("ERROR: Could not parse SLURM job ID from sbatch output")
+        return (None, None)
+
+    # Step 4: Update pending entry with actual SLURM job ID
+    if db_job_id:
+        update_pending_job_slurm_id(db_job_id, slurm_job_id)
+
+    return (slurm_job_id, job_name)
+
+
+# ---------- Main Listener Class ----------
+class EvalListener:
+    """Unified eval listener v3 that handles all benchmark configurations.
+
+    Lifecycle:
+      1. run() logs config, runs Daytona pre-flight (if enabled), enters main loop
+      2. Each iteration: hot-reload priority file, fetch models, filter, build
+         submissions list, sort by priority rank, apply retry deprioritization,
+         throttle to per-listener SLURM limit, submit
+      3. Sleep for check_interval_hours, then repeat
+
+    Per-listener SLURM tracking:
+      _submitted_jobs tracks SLURM job IDs submitted by THIS listener instance.
+      Each iteration, completed jobs are pruned via squeue intersection. This
+      allows multiple listeners to run in parallel with independent job budgets.
+    """
+
+    def __init__(self, config: ListenerConfig):
+        self.config = config
+        self._submitted_jobs: Set[str] = set()  # SLURM job IDs submitted by THIS listener
+        self._dep_chain: List[str] = []  # Persistent sliding-window dependency chain across iterations
+        self._resume_run_tags: Dict[str, str] = {}  # v6: hf_model → run_tag for disk resume
+        set_log_file(config.log_file)
+        # Seed _submitted_jobs from previous listener logs (--inherit-log)
+        if config.inherit_log:
+            inherited = parse_submitted_jobs_from_logs(config.inherit_log)
+            self._submitted_jobs = inherited
+            if inherited:
+                # Log the inherited IDs so future --inherit-log on THIS log picks them up
+                log(f"[inherit-log] Inherited {len(inherited)} active job(s)")
+                log(f"[inherit-log] Inherited jobs: {','.join(sorted(inherited))}")
+
+    def run_iteration(self) -> int:
+        """
+        Run one check iteration.
+
+        Returns:
+            Number of jobs submitted (or would submit in dry-run mode)
+        """
+        # Hot-reload priority models from file (enables editing during long runs)
+        if self.config.priority_file:
+            new_priority = load_priority_models(self.config.priority_file)
+            if new_priority != self.config.priority_models:
+                log(f"Priority list reloaded: {len(new_priority)} model(s)")
+                self.config.priority_models = new_priority
+
+        # Hot-reload blacklist from file
+        if self.config.blacklist_file:
+            new_blacklist = load_blacklist(self.config.blacklist_file)
+            if new_blacklist != self.config.blacklisted_models:
+                log(f"Blacklist reloaded: {len(new_blacklist)} model(s)")
+                self.config.blacklisted_models = new_blacklist
+
+        # v6: Clear per-iteration resume state
+        self._resume_run_tags = {}
+
+        log("Checking for new models...")
+
+        # Optimization: in filter_only mode with a priority file, skip the
+        # expensive fetch_recent_models() (which returns ALL models in the
+        # lookback window) and only fetch priority models by name.
+        if (self.config.priority_mode == "filter_only"
+                and self.config.priority_models):
+            models = fetch_priority_models(self.config.priority_models)
+            log(f"Fetched {len(models)} priority model(s) directly (filter_only mode, skipped full scan).")
+        else:
+            models = fetch_recent_models(self.config.lookback_days)
+            log(f"Found {len(models)} model(s) in lookback window.")
+
+            # Priority models bypass lookback window.
+            # Fetch priority models by name regardless of creation_time, then merge.
+            if self.config.priority_models:
+                priority_models_from_db = fetch_priority_models(self.config.priority_models)
+                seen_ids = {str(m.get("id")) for m in models}
+                added = 0
+                for pm in priority_models_from_db:
+                    if str(pm.get("id")) not in seen_ids:
+                        models.append(pm)
+                        seen_ids.add(str(pm.get("id")))
+                        added += 1
+                if added:
+                    log(f"Added {added} priority model(s) outside lookback window.")
+
+        log(f"Total {len(models)} model(s) to check. Filtering...")
+
+        # Check if we should skip all models due to require_priority_list
+        if not self.config.priority_models and self.config.require_priority_list:
+            log("No priority list configured and --require-priority-list is set. Skipping all models.")
+            return 0
+
+        submissions: List[Tuple[str, str, str, Optional[str], str, Optional[str]]] = []
+        # (model_id, hf_model_name, dataset_hf, benchmark_id, reason, slurm_job_id)
+        finished_in_db: Set[str] = set()  # v6: models DB considers done (skip for resume)
+
+        # v6: Build set of (model, dataset) pairs currently running in squeue (by parsing eval logs).
+        # Used to prevent both resume and fresh submissions for already-running models.
+        active_models, active_pairs, active_run_tags = get_active_model_dataset_pairs(
+            log_dir=_cc_path("eval_logs_dir", _FALLBACK_EVAL_LOGS_DIR),
+        )
+        if active_pairs:
+            log(f"[v6-active] Found {len(active_pairs)} (model, dataset) pair(s) currently active in squeue")
+            if self.config.verbose:
+                for m, d in sorted(active_pairs):
+                    log(f"  [v6-active] {m} on {d}")
+
+        # Track stats
+        skipped_not_in_priority = 0
+        skipped_hf_not_exists = 0
+
+        # Resolve all benchmarks up front (once per loop)
+        dataset_to_bench: Dict[str, Optional[str]] = {
+            ds: resolve_benchmark_id(ds) for ds in self.config.datasets
+        }
+
+        # Precompute benchmark duplicate groups for cross-duplicate aggregation
+        bench_dup_groups: Dict[str, List[str]] = {}
+        for ds, bench_id in dataset_to_bench.items():
+            if bench_id:
+                bench_dup_groups[bench_id] = get_duplicate_group_ids('benchmarks', bench_id)
+
+        for m in models:
+            model_id = str(m.get("id"))
+            if not model_id:
+                continue
+
+            hf_model = resolve_hf_model_name(m)
+            if not hf_model:
+                if self.config.verbose:
+                    log(f"Skip: cannot resolve HF model for id={model_id}, name={m.get('name')}")
+                continue
+
+            # Blacklist check (overrides priority)
+            if hf_model in self.config.blacklisted_models:
+                if self.config.verbose:
+                    log(f"Skip: model={hf_model} is blacklisted")
+                continue
+
+            # Priority handling depends on mode
+            is_priority = bool(self.config.priority_models and hf_model in self.config.priority_models)
+
+            if self.config.priority_mode == "filter_only":
+                # Only evaluate models in the priority list
+                if self.config.priority_models and not is_priority:
+                    skipped_not_in_priority += 1
+                    continue
+            # priority_first: don't skip, just track is_priority for sorting
+
+            # HuggingFace existence check
+            if self.config.check_hf_exists:
+                if not check_hf_model_exists(hf_model):
+                    log(f"Skip: model not found on HuggingFace: {hf_model} (model_id={model_id})")
+                    skipped_hf_not_exists += 1
+                    continue
+
+            # Compute model duplicate group for cross-duplicate aggregation
+            model_dup_ids = get_duplicate_group_ids('models', model_id)
+
+            for dataset_hf in self.config.datasets:
+                bench_id = dataset_to_bench.get(dataset_hf)
+
+                # Get benchmark duplicate group (precomputed above)
+                bench_dup_ids = bench_dup_groups.get(bench_id) if bench_id else None
+
+                # Check DB status to decide if we should start
+                # (Enhancement 5: timeout-aware, cross-duplicate aggregation, config-aware dedup)
+                if self.config.force_reeval:
+                    should_start, reason, old_slurm_job_id = True, "force-reeval", None
+                else:
+                    should_start, reason, old_slurm_job_id = should_start_job(
+                        model_id, bench_id, self.config.stale_job_hours,
+                        stale_pending_hours=self.config.stale_pending_hours,
+                        timeout_aware=self.config.timeout_aware,
+                        agent_name=self.config.agent_name,
+                        timeout_multiplier=self.config.timeout_multiplier,
+                        duplicate_model_ids=model_dup_ids,
+                        duplicate_benchmark_ids=bench_dup_ids,
+                        eval_config=self.config.eval_config if self.config.eval_config else None,
+                    )
+
+                if should_start:
+                    # v6: Skip if (model, dataset) already running in squeue (even if DB says "no existing job",
+                    # e.g. when DB entry was deleted but SLURM job is still active)
+                    # Bypass this check in force-reeval mode.
+                    if not self.config.force_reeval and (hf_model, dataset_hf) in active_pairs:
+                        if self.config.verbose:
+                            log(f"Skip: model={hf_model}, dataset={dataset_hf}, reason=currently running in squeue")
+                        continue
+                    submissions.append((model_id, hf_model, dataset_hf, bench_id, reason, old_slurm_job_id))
+                else:
+                    # Track models the DB considers done (for v6 resume filtering)
+                    if "finished" in reason:
+                        finished_in_db.add(hf_model)
+                    if self.config.verbose:
+                        log(f"Skip: model={hf_model}, dataset={dataset_hf}, reason={reason}")
+
+        # Log filtering stats
+        if self.config.priority_mode == "filter_only" and self.config.priority_models and skipped_not_in_priority > 0:
+            log(f"Skipped {skipped_not_in_priority} model(s) not in priority list")
+        if self.config.check_hf_exists and skipped_hf_not_exists > 0:
+            log(f"Skipped {skipped_hf_not_exists} model(s) not found on HuggingFace")
+
+        # v6: Disk-based resume — scan jobs dir for incomplete/errored jobs
+        resume_submissions = []
+        if self.config.enable_disk_resume and self.config.jobs_dirs:
+            # Always query squeue (even in dry-run) for accurate filtering
+            active_slurm = get_active_slurm_job_ids()
+            # Build dataset prefixes from config
+            ds_prefixes = []
+            for ds in self.config.datasets:
+                ds_short = ds.split("/")[-1] if "/" in ds else ds
+                ds_prefixes.append(ds_short)
+            # Scan all configured jobs directories
+            resume_candidates = []
+            for jdir in self.config.jobs_dirs:
+                resume_candidates.extend(scan_jobs_dir_for_resume(
+                    jobs_dir=jdir,
+                    dataset_prefixes=ds_prefixes,
+                    active_slurm_ids=active_slurm,
+                    infra_error_threshold=self.config.resume_infra_error_threshold,
+                    max_resume_count=self.config.max_resume_count,
+                ))
+            # Filter resume candidates through blacklist and priority (same as normal models)
+            if self.config.blacklisted_models:
+                before = len(resume_candidates)
+                resume_candidates = [rc for rc in resume_candidates
+                                     if rc["hf_model"] not in self.config.blacklisted_models]
+                skipped_bl = before - len(resume_candidates)
+                if skipped_bl:
+                    log(f"[v6-resume] Filtered out {skipped_bl} blacklisted resume candidate(s)")
+            if self.config.priority_mode == "filter_only" and self.config.priority_models:
+                before = len(resume_candidates)
+                resume_candidates = [rc for rc in resume_candidates
+                                     if rc["hf_model"] in self.config.priority_models]
+                skipped_prio = before - len(resume_candidates)
+                if skipped_prio:
+                    log(f"[v6-resume] Filtered out {skipped_prio} non-priority resume candidate(s)")
+
+            # v6: Filter out (model, dataset) pairs currently running in squeue.
+            # This prevents resuming old dirs when a job for the same model+dataset is active.
+            if active_pairs:
+                before = len(resume_candidates)
+                resume_candidates = [rc for rc in resume_candidates
+                                     if (rc["hf_model"], rc.get("dataset", "")) not in active_pairs]
+                skipped_active = before - len(resume_candidates)
+                if skipped_active:
+                    log(f"[v6-resume] Filtered out {skipped_active} currently-running resume candidate(s)")
+
+            # Filter out models that DB already considers finished (stale disk dirs
+            # from older runs that have been superseded by a successful resubmission)
+            if finished_in_db:
+                before = len(resume_candidates)
+                resume_candidates = [rc for rc in resume_candidates
+                                     if rc["hf_model"] not in finished_in_db]
+                skipped_fin = before - len(resume_candidates)
+                if skipped_fin:
+                    log(f"[v6-resume] Filtered out {skipped_fin} already-finished-in-DB resume candidate(s)")
+
+            # Dedup: pick the most recent dir per model (reverse so latest timestamp wins).
+            seen_resume_models: Set[str] = set()
+            for rc in reversed(resume_candidates):
+                if rc["hf_model"] not in seen_resume_models:
+                    seen_resume_models.add(rc["hf_model"])
+                    # Use a sentinel model_id since we don't have it from DB
+                    resume_submissions.append(
+                        ("__resume__", rc["hf_model"], rc["dataset"] or "",
+                         None, rc["reason"], None)
+                    )
+                    # Store run_tag mapping for submit_eval
+                    self._resume_run_tags[rc["hf_model"]] = rc["run_tag"]
+            if resume_submissions:
+                log(f"[v6-resume] Adding {len(resume_submissions)} resume job(s) (priority over new models)")
+
+        # v6: Resume takes priority — remove normal submissions for models
+        # that already have a resume candidate (avoid duplicate fresh + resume).
+        resume_model_set = {s[1] for s in resume_submissions}  # s[1] = hf_model
+        if resume_model_set:
+            before = len(submissions)
+            submissions = [s for s in submissions if s[1] not in resume_model_set]
+            skipped_dup = before - len(submissions)
+            if skipped_dup:
+                log(f"[v6-resume] Suppressed {skipped_dup} fresh submission(s) in favor of resume")
+
+        # --resume-only: drop all fresh submissions, keep only resume jobs
+        if self.config.resume_only:
+            if submissions:
+                log(f"[v6-resume] --resume-only: dropping {len(submissions)} fresh submission(s)")
+                submissions = []
+
+        if not submissions and not resume_submissions:
+            log("No eligible (model, dataset) pairs to submit.")
+            return 0
+
+        # Prepend resume submissions (higher priority than new models)
+        submissions = resume_submissions + submissions
+
+        # Sort submissions by priority file order (earlier in file = higher priority).
+        # Models not in the priority list get lowest rank (submitted last).
+        if self.config.priority_models:
+            priority_rank = {m: i for i, m in enumerate(self.config.priority_models)}
+            fallback_rank = len(self.config.priority_models)
+            submissions.sort(key=lambda s: priority_rank.get(s[1], fallback_rank))
+            if self.config.priority_mode == "priority_first":
+                n_priority = sum(1 for s in submissions if s[1] in priority_rank)
+                n_non_priority = len(submissions) - n_priority
+                log(f"Priority-first ordering: {n_priority} priority + {n_non_priority} non-priority submissions")
+
+        prefix = "[DRY RUN] Would submit" if self.config.dry_run else "Submitting"
+        log(f"{prefix} {len(submissions)} eval(s)...")
+
+        # Enhancement 2: Per-listener SLURM job submission throttle.
+        # Track which SLURM job IDs this listener submitted. Prune finished ones
+        # via squeue, then cap new submissions at remaining slots.
+        if not self.config.dry_run:
+            active_ids = get_active_slurm_job_ids()
+            # Prune jobs that are no longer in squeue (finished/failed/cancelled)
+            still_active = self._submitted_jobs & active_ids
+            finished = len(self._submitted_jobs) - len(still_active)
+            self._submitted_jobs = still_active
+            active_count = len(self._submitted_jobs)
+            remaining_slots = self.config.max_jobs_submitted - active_count
+            log(f"Listener SLURM jobs: {active_count} active "
+                f"({finished} finished since last check), "
+                f"{remaining_slots} slots available (max {self.config.max_jobs_submitted})")
+            if remaining_slots <= 0:
+                log(f"WARNING: At per-listener job limit "
+                    f"({active_count}/{self.config.max_jobs_submitted}), "
+                    f"skipping all submissions this iteration")
+                return 0
+            if len(submissions) > remaining_slots:
+                log(f"Capping submissions from {len(submissions)} to {remaining_slots} "
+                    f"(per-listener limit: {self.config.max_jobs_submitted})")
+                submissions = submissions[:remaining_slots]
+
+        # Create sbatch params from config
+        sbatch_params = SbatchParams(
+            n_concurrent=self.config.n_concurrent,
+            n_attempts=self.config.n_attempts,
+            gpu_memory_util=self.config.gpu_memory_util,
+            error_threshold=self.config.error_threshold,
+            vllm_max_retries=self.config.vllm_max_retries,
+            agent_parser=self.config.agent_parser,
+            slurm_time=self.config.slurm_time,
+            enable_thinking=self.config.enable_thinking,
+            agent_name=self.config.agent_name,
+            slurm_partition=self.config.slurm_partition,
+            slurm_account=self.config.slurm_account,
+            tp_size=self.config.tp_size,
+            dp_size=self.config.dp_size,
+            upload_username=self.config.upload_username,
+            timeout_multiplier=self.config.timeout_multiplier,
+            config_yaml=self.config.config_yaml,
+            max_output_tokens=self.config.max_output_tokens,
+            auto_snapshot=self.config.auto_snapshot,
+            agent_envs=self.config.agent_envs,
+            pinggy_url=self.config.pinggy_url,
+            pinggy_token=self.config.pinggy_token,
+        )
+
+        # Load baseline model configs for per-model vLLM overrides
+        baseline_configs = load_baseline_model_configs(self.config.baseline_model_configs)
+
+        # Load per-model API serving configs (no-op if file missing — get_api_config returns None)
+        api_configs = load_api_model_configs(self.config.api_model_config)
+
+        # Add harbor config env vars to sbatch params
+        if self.config.harbor_config:
+            # Will be merged in submit_eval via eval_config, but also pass path
+            pass  # harbor config fields are passed via eval_config to submit_eval
+
+        # Pre-download setup (for no-internet compute nodes)
+        if self.config.pre_download:
+            from huggingface_hub import snapshot_download
+            downloaded_models: set = set()
+
+        # Sliding-window dependency tracking (persistent across iterations)
+        # self._dep_chain carries job IDs from previous iterations so new jobs
+        # respect the concurrency limit even across sleep cycles.
+        batch_size = self.config.batch_size
+        if batch_size and batch_size > 0:
+            if not self.config.dry_run:
+                active_ids = get_active_slurm_job_ids()
+            else:
+                active_ids = set()
+            active_in_chain = sum(1 for jid in self._dep_chain if jid in active_ids)
+            log(f"Sliding-window batch-size={batch_size}: "
+                f"{active_in_chain} active jobs in dependency chain from previous iterations")
+
+        # Node packing: query idle nodes and track GPU + port slots per node
+        pack_node_list: List[str] = []
+        pack_gpus_per_node = 8
+        pack_node_gpu_used: Dict[int, int] = {}  # node_idx -> GPUs used so far
+        pack_node_port_next: Dict[int, int] = {}  # node_idx -> next available port offset
+        pack_node_idx = 0
+        if self.config.pack_jobs:
+            cc = self.config.cluster_config or {}
+            hw = cc.get("hardware", {})
+            pack_gpus_per_node = int(hw.get("gpus_per_node", 8))
+            pack_node_list = get_idle_nodes(self.config.slurm_partition)
+            if pack_node_list:
+                log(f"Pack mode: {len(pack_node_list)} idle nodes, {pack_gpus_per_node} GPUs/node")
+            else:
+                log("Pack mode: no idle nodes found, falling back to default scheduling")
+
+        submitted = 0
+        for idx, (mid, hf_model, dataset_hf, bench_id, reason, old_slurm_job_id) in enumerate(submissions):
+
+            # Pre-download this model before submitting (download-then-submit per model)
+            # Uses the shared HF cache so compute nodes (no internet) find it via HF_HUB_OFFLINE=1
+            if self.config.pre_download and hf_model not in downloaded_models:
+                hf_cache = os.environ.get("HF_HUB_CACHE", _cc_path("hf_cache", _FALLBACK_HF_CACHE))
+                log(f"  Pre-downloading model {hf_model} to {hf_cache}...")
+                try:
+                    # Run snapshot_download in a subprocess thread with timeout
+                    # to avoid indefinite hangs on network issues
+                    import concurrent.futures
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                        future = executor.submit(
+                            snapshot_download, repo_id=hf_model, repo_type="model", cache_dir=hf_cache
+                        )
+                        path = future.result(timeout=300)  # 5 minute timeout
+                    log(f"  Cached at {path}")
+                except concurrent.futures.TimeoutError:
+                    log(f"  WARNING: Pre-download of {hf_model} timed out after 300s, skipping (will retry next iteration)")
+                except Exception as e:
+                    log(f"  WARNING: Failed to download {hf_model}: {e}")
+                downloaded_models.add(hf_model)
+
+            dry_prefix = "[DRY RUN] " if self.config.dry_run else ""
+            prio_tag = " [PRIORITY]" if (self.config.priority_mode == "priority_first"
+                                         and self.config.priority_models
+                                         and hf_model in self.config.priority_models) else ""
+            # v6: Pretty-print resume reason
+            display_reason = reason
+            log(f"{dry_prefix}Submitting [{idx+1}/{len(submissions)}]: model={hf_model}, dataset={dataset_hf}, reason={display_reason}{prio_tag}")
+
+            # Cancel stale Pending SLURM job before resubmission
+            if reason.startswith("stale pending") and old_slurm_job_id:
+                cancel_slurm_job(old_slurm_job_id, dry_run=self.config.dry_run)
+
+            # Per-model vLLM overrides from baseline config mapping
+            vllm_overrides = get_vllm_env_overrides(hf_model, baseline_configs)
+            if vllm_overrides:
+                log(f"  Applying baseline model vLLM overrides: {list(vllm_overrides.keys())}", verbose_only=True)
+
+            # Per-model conda env override (e.g. otagent2 for Qwen3.5)
+            model_conda_env = get_conda_env_override(hf_model, baseline_configs) or self.config.conda_env
+            if model_conda_env != self.config.conda_env:
+                log(f"  Using conda env '{model_conda_env}' for {hf_model}")
+
+            # Build sliding-window dependency using persistent chain.
+            # Look back batch_size positions in self._dep_chain. If that job is
+            # still active (running/pending in squeue), depend on it. If it already
+            # finished, the concurrency slot is free — no dependency needed.
+            job_dependency: Optional[str] = None
+            if batch_size and batch_size > 0:
+                chain_pos = len(self._dep_chain)  # where this job will be appended
+                if chain_pos >= batch_size:
+                    dep_candidate = self._dep_chain[chain_pos - batch_size]
+                    if not self.config.dry_run and dep_candidate in active_ids:
+                        job_dependency = f"afterany:{dep_candidate}"
+                        log(f"  Depends on job {dep_candidate} (chain pos {chain_pos - batch_size})", verbose_only=True)
+
+            # Stagger chain: jobs wait N minutes after the previous batch STARTS.
+            # Uses SLURM "after:jobid+minutes" so jobs start sequentially even when
+            # many nodes are idle (prevents Daytona sandbox creation burst).
+            # With chain_batch_size=K, K jobs fire together, then the next K wait
+            # for the first job of the previous batch to have started + delay.
+            if self.config.stagger_delay > 0 and self._dep_chain:
+                cbs = max(self.config.chain_batch_size, 1)
+                chain_len = len(self._dep_chain)
+                # Determine which batch this job belongs to
+                current_batch = chain_len // cbs
+                if current_batch > 0:
+                    # Depend on the first job of the previous batch
+                    prev_batch_first = (current_batch - 1) * cbs
+                    prev_job = self._dep_chain[prev_batch_first]
+                    if not prev_job.startswith(("DRY_", "FAILED_")):
+                        stagger_dep = f"after:{prev_job}+{self.config.stagger_delay}"
+                        if job_dependency:
+                            job_dependency = f"{job_dependency},{stagger_dep}"
+                        else:
+                            job_dependency = stagger_dep
+                        if chain_len % cbs == 0:
+                            log(f"  Stagger: batch {current_batch} boundary, wait {self.config.stagger_delay}m after job {prev_job} starts")
+                        else:
+                            log(f"  Stagger: batch {current_batch} (pos {chain_len % cbs}/{cbs}), wait {self.config.stagger_delay}m after job {prev_job} starts", verbose_only=True)
+
+            # v6: Extract run_tag_override for disk-based resume
+            resume_run_tag = self._resume_run_tags.get(hf_model)
+
+            # DP: use DP sbatch when dp_nodes > 0
+            actual_sbatch = self.config.dp_sbatch_script if self.config.dp_nodes > 0 else self.config.sbatch_script
+
+            # API mode: dispatch hosted-endpoint models to the API sbatch
+            # (no GPU, no vLLM). Vllm-served models hit the else branch
+            # below with byte-identical behavior to the pre-API listener.
+            api_cfg = get_api_config(hf_model, api_configs)
+            is_api_mode = api_cfg is not None
+            target_node = None
+            pack_port = None
+            extra_env: Dict[str, str] = {}
+            sbatch_model_override: Optional[str] = None
+            if is_api_mode:
+                actual_sbatch = self.config.api_sbatch_script
+                sbatch_model_override = api_cfg["litellm_model"]
+                # Resolve preset → cap (honor n_concurrent_cap from yaml + per-preset cap)
+                preset_for_dataset = next(
+                    (name for name, p in PRESETS.items()
+                     if dataset_hf in p.get("datasets", [])),
+                    None,
+                )
+                preset_caps = (api_configs or {}).get("preset_n_concurrent_caps", {}) or {}
+                model_cap = api_cfg.get("n_concurrent_cap", self.config.n_concurrent)
+                preset_cap = preset_caps.get(preset_for_dataset, model_cap)
+                n_eff = min(self.config.n_concurrent, model_cap, preset_cap)
+                ak_string = _build_api_agent_kwargs_string(api_cfg.get("agent_kwargs", {}))
+                extra_env.update({
+                    "EVAL_API_BASE": api_cfg["api_base"] or "",
+                    "EVAL_API_KEY_ENV": api_cfg["api_key_env"] or "",
+                    "EVAL_API_AGENT_KWARGS": ak_string,
+                    "EVAL_N_CONCURRENT": str(n_eff),
+                })
+                log(f"  [API] {hf_model} → {sbatch_model_override} "
+                    f"(api_base={api_cfg['api_base']}, key_env={api_cfg['api_key_env']}, "
+                    f"n_concurrent={n_eff}; caps: model={model_cap}, preset={preset_cap}/{preset_for_dataset})")
+            elif pack_node_list:
+                # Node packing: assign a target node and port based on GPU slots
+                effective_tp = self.config.tp_size
+                if vllm_overrides and "EVAL_VLLM_TENSOR_PARALLEL_SIZE" in vllm_overrides:
+                    effective_tp = int(vllm_overrides["EVAL_VLLM_TENSOR_PARALLEL_SIZE"])
+                effective_dp = self.config.dp_size
+                total_gpus = effective_tp * effective_dp
+                # Find a node with enough free GPU slots
+                while pack_node_idx < len(pack_node_list):
+                    used = pack_node_gpu_used.get(pack_node_idx, 0)
+                    if used + total_gpus <= pack_gpus_per_node:
+                        target_node = pack_node_list[pack_node_idx]
+                        pack_node_gpu_used[pack_node_idx] = used + total_gpus
+                        # Assign a non-overlapping port for this job
+                        port_offset = pack_node_port_next.get(pack_node_idx, 0)
+                        pack_port = 10000 + port_offset
+                        pack_node_port_next[pack_node_idx] = port_offset + max(effective_dp, 1)
+                        break
+                    pack_node_idx += 1
+                if target_node:
+                    log(f"  Pack: {target_node} (GPUs {pack_node_gpu_used[pack_node_idx]}/{pack_gpus_per_node}, port {pack_port})", verbose_only=True)
+
+            # Pass listener-assigned port to sbatch when packing (vLLM mode only)
+            if pack_port is not None:
+                extra_env["EVAL_VLLM_PORT"] = str(pack_port)
+
+            slurm_job_id, job_name = submit_eval(
+                hf_model,
+                dataset_hf,
+                bench_id,
+                actual_sbatch,
+                sbatch_params=sbatch_params,
+                dry_run=self.config.dry_run,
+                upload_username=self.config.upload_username,
+                timeout_multiplier=self.config.timeout_multiplier,
+                vllm_overrides=vllm_overrides if (vllm_overrides and not is_api_mode) else None,
+                dependency=job_dependency,
+                eval_config=self.config.eval_config if self.config.eval_config else None,
+                conda_env=model_conda_env,
+                run_tag_override=resume_run_tag,
+                dp_nodes=0 if is_api_mode else self.config.dp_nodes,
+                nodelist=target_node,
+                extra_env=extra_env,
+                skip_gpu_request=is_api_mode,
+                sbatch_model_override=sbatch_model_override,
+            )
+
+            if slurm_job_id:
+                if self.config.dry_run:
+                    node_str = f" on {target_node}" if target_node else ""
+                    log(f"  -> Would submit as SLURM job (job_name={job_name}){node_str}")
+                    self._dep_chain.append(f"DRY_{idx}")
+                else:
+                    log(f"  -> Submitted as SLURM job {slurm_job_id} (job_name={job_name})")
+                    self._submitted_jobs.add(slurm_job_id)
+                    self._dep_chain.append(slurm_job_id)
+                submitted += 1
+            else:
+                log(f"  -> Submission failed")
+                self._dep_chain.append(f"FAILED_{idx}")
+
+            if not self.config.dry_run and self.config.submission_delay > 0:
+                time.sleep(self.config.submission_delay)
+
+        return submitted
+
+    def run(self) -> None:
+        """Main event loop."""
+        # Log configuration
+        hdr = (
+            f"lookback={self.config.lookback_days}d, "
+            f"every {self.config.check_interval_hours}h, "
+            f"sbatch={self.config.sbatch_script}"
+        )
+        log(f"Starting listener v3 for datasets={self.config.datasets}: {hdr}")
+        log(
+            f"Job logic: restart if 'Started' and started_at > {self.config.stale_job_hours}h ago, "
+            f"restart+scancel if 'Pending' and submitted_at > {self.config.stale_pending_hours}h ago, "
+            f"skip if 'Finished'"
+        )
+        log(f"Dry run mode: {self.config.dry_run}")
+        log(f"Run once mode: {self.config.run_once}")
+        if self.config.force_reeval:
+            log("WARNING: --force-reeval is ON — bypassing DB status checks, will re-submit even if Finished")
+        log(f"Check HF exists: {self.config.check_hf_exists}")
+        log(f"Require priority list: {self.config.require_priority_list}")
+
+        if self.config.priority_models:
+            mode_desc = "filter_only (skip non-priority)" if self.config.priority_mode == "filter_only" else "priority_first (all models, priority first)"
+            log(f"Priority mode: {mode_desc}, {len(self.config.priority_models)} model(s) in list")
+            if self.config.priority_file:
+                log(f"Priority file: {self.config.priority_file} (hot-reloaded each iteration)")
+            if self.config.verbose:
+                for m in sorted(self.config.priority_models):
+                    log(f"  - {m}")
+        else:
+            log("Priority: disabled (no priority file or empty)")
+
+        if self.config.blacklisted_models:
+            log(f"Blacklist: {len(self.config.blacklisted_models)} model(s) from {self.config.blacklist_file}")
+            if self.config.verbose:
+                for m in sorted(self.config.blacklisted_models):
+                    log(f"  - {m}")
+        else:
+            log("Blacklist: disabled (no blacklist file or empty)")
+
+        # Log sbatch parameters
+        sbatch_params = SbatchParams(
+            n_concurrent=self.config.n_concurrent,
+            n_attempts=self.config.n_attempts,
+            gpu_memory_util=self.config.gpu_memory_util,
+            error_threshold=self.config.error_threshold,
+            vllm_max_retries=self.config.vllm_max_retries,
+            agent_parser=self.config.agent_parser,
+            slurm_time=self.config.slurm_time,
+            enable_thinking=self.config.enable_thinking,
+            agent_name=self.config.agent_name,
+            slurm_partition=self.config.slurm_partition,
+            slurm_account=self.config.slurm_account,
+            tp_size=self.config.tp_size,
+            dp_size=self.config.dp_size,
+            timeout_multiplier=self.config.timeout_multiplier,
+            config_yaml=self.config.config_yaml,
+            max_output_tokens=self.config.max_output_tokens,
+            auto_snapshot=self.config.auto_snapshot,
+            agent_envs=self.config.agent_envs,
+            pinggy_url=self.config.pinggy_url,
+            pinggy_token=self.config.pinggy_token,
+        )
+        log(f"Sbatch params: {sbatch_params}")
+
+        # Log v3 enhancement status
+        log(f"[v3] Max SLURM jobs per listener: {self.config.max_jobs_submitted}")
+        log(f"[v3] Daytona resource check: {'enabled' if self.config.check_daytona_resources else 'disabled'}")
+        log(f"[v3] Timeout-aware dedup: {'enabled' if self.config.timeout_aware else 'disabled'}")
+        if self.config.timeout_multiplier != DEFAULT_TIMEOUT_MULTIPLIER:
+            log(f"[v3] Timeout multiplier: {self.config.timeout_multiplier}")
+        if self.config.stagger_delay > 0:
+            log(f"[v6] Stagger delay: {self.config.stagger_delay}m between batches of {self.config.chain_batch_size} jobs (SLURM after: chain)")
+
+        # Enhancement 3: Daytona resource pre-flight check at startup
+        if self.config.check_daytona_resources:
+            ok = check_daytona_resources(
+                self.config.daytona_sandbox_limit,
+                self.config.daytona_warning_buffer,
+            )
+            if not ok:
+                log("ERROR: Daytona resources at limit. Exiting.")
+                sys.exit(1)
+
+        while True:
+            try:
+                # Enhancement 3: Optional per-iteration Daytona resource check
+                if self.config.check_daytona_resources:
+                    ok = check_daytona_resources(
+                        self.config.daytona_sandbox_limit,
+                        self.config.daytona_warning_buffer,
+                    )
+                    if not ok:
+                        log("WARNING: Daytona resources at limit, skipping this iteration")
+                        if self.config.run_once or self.config.dry_run:
+                            break
+                        hours = self.config.check_interval_hours
+                        log(f"Sleeping for {hours} hours...\n")
+                        time.sleep(self.config.check_interval_seconds)
+                        continue
+
+                self.run_iteration()
+
+                # Exit after one iteration if requested
+                if self.config.run_once or self.config.dry_run:
+                    mode = "DRY RUN" if self.config.dry_run else "ONCE"
+                    log(f"[{mode}] Complete. Exiting after one iteration.")
+                    break
+
+                hours = self.config.check_interval_hours
+                log(f"Sleeping for {hours} hours...\n")
+                time.sleep(self.config.check_interval_seconds)
+
+            except KeyboardInterrupt:
+                log("Interrupted by user. Exiting.")
+                sys.exit(0)
+            except Exception as e:
+                log(f"ERROR in main loop: {e}. Backing off 30s.")
+                time.sleep(30)
+
+
+# ---------- CLI Argument Parsing ----------
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Unified Eval Listener v4 - Run models on benchmark datasets",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+See the module docstring (top of file) for detailed flag reference with tuning
+guidance. Quick summary below.
+
+Presets: aider, bfcl, medagentbench, gaia, financeagent, swebench, v2, tb2, v1
+
+v4 new:  --blacklist-file PATH   Block models from eval (overrides priority list)
+v3 opt-in enhancements (all backward compatible):
+  --error-threshold N             Unified invalid error threshold
+  --max-jobs-submitted N          Per-listener SLURM job limit
+  --check-daytona-resources       Daytona sandbox pre-flight check
+  --track-model-retries           Deprioritize repeatedly-started models
+  --timeout-aware                 Dedup by model+benchmark+timeout_multiplier
+
+Examples:
+  python unified_eval_listener_v4.py --preset v2 \\
+    --priority-file priority_models.txt
+
+  python unified_eval_listener_v4.py --preset v2 \\
+    --priority-file priority_models.txt \\
+    --blacklist-file bad_models.txt
+
+  python unified_eval_listener_v4.py --preset v2 --dry-run --once --verbose
+        """,
+    )
+
+    # Preset configuration
+    parser.add_argument(
+        "--preset", "-p",
+        choices=list(PRESETS.keys()),
+        help="Use a preset configuration (aider, bfcl, medagentbench, gaia, financeagent, swebench, v2, tb2, v1)",
+    )
+
+    # Dataset configuration
+    parser.add_argument(
+        "--datasets", "-d",
+        help="Comma/space separated HF dataset repos (overrides preset)",
+    )
+    parser.add_argument(
+        "--sbatch-script", "-s",
+        help="SBATCH script to use (overrides preset)",
+    )
+    parser.add_argument(
+        "--log-file",
+        help="Log file path (default: auto-generated based on preset)",
+    )
+    parser.add_argument(
+        "--log-dir",
+        help=f"Directory for listener logs (default: {DEFAULT_LOG_DIR}, env: EVAL_LISTENER_LOG_DIR)",
+    )
+
+    # Cluster configuration
+    parser.add_argument(
+        "--cluster-config",
+        help="Path to cluster config YAML (e.g. eval/clusters/jupiter.yaml). "
+             "Provides cluster-specific defaults for SLURM, paths, proxy, and hardware. "
+             "CLI flags still override cluster config values.",
+    )
+
+    # Timing configuration
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        help=f"Days to look back for models (default: {DEFAULT_LOOKBACK_DAYS})",
+    )
+    parser.add_argument(
+        "--check-hours",
+        type=float,
+        help=f"Hours between iterations (default: {DEFAULT_CHECK_HOURS})",
+    )
+    parser.add_argument(
+        "--stale-hours",
+        type=int,
+        help=f"Hours before 'Started' job is stale (default: {DEFAULT_STALE_JOB_HOURS})",
+    )
+    parser.add_argument(
+        "--stale-pending-hours",
+        type=int,
+        help=f"Hours before 'Pending' job is stale (default: {DEFAULT_STALE_PENDING_HOURS})",
+    )
+
+    # Priority filtering
+    parser.add_argument(
+        "--priority-file",
+        help="Path to priority models file (one model per line)",
+    )
+    parser.add_argument(
+        "--require-priority-list",
+        action="store_true",
+        help="Skip all models when priority list is empty/missing",
+    )
+    parser.add_argument(
+        "--blacklist-file",
+        help="Path to blacklisted models file (one model per line). "
+             "Models in this file are never submitted. Overrides priority list.",
+    )
+    parser.add_argument(
+        "--priority-mode",
+        choices=["filter_only", "priority_first"],
+        help='Priority mode: "filter_only" (default) only evaluates priority models; '
+             '"priority_first" evaluates all models but submits priority ones first',
+    )
+
+    # Validation options
+    parser.add_argument(
+        "--check-hf-exists",
+        action="store_true",
+        help="Validate model exists on HuggingFace before submit",
+    )
+
+    # Eval parameters (passed to sbatch via env vars)
+    parser.add_argument(
+        "--n-concurrent",
+        type=int,
+        help=f"Harbor concurrent jobs (default: {DEFAULT_N_CONCURRENT}, preset overrides)",
+    )
+    parser.add_argument(
+        "--n-attempts",
+        type=int,
+        help=f"Retry attempts per task (default: {DEFAULT_N_ATTEMPTS})",
+    )
+    parser.add_argument(
+        "--gpu-memory-util",
+        type=float,
+        help=f"VLLM GPU memory fraction (default: {DEFAULT_GPU_MEMORY_UTIL})",
+    )
+    # Enhancement 1: Unified error threshold (with backward-compat alias)
+    parser.add_argument(
+        "--error-threshold",
+        type=int,
+        dest="error_threshold",
+        help=f"Max invalid errors before abort upload (default: {DEFAULT_ERROR_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--daytona-threshold",
+        type=int,
+        dest="error_threshold_compat",
+        help=f"Alias for --error-threshold (backward compat, default: {DEFAULT_ERROR_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--vllm-max-retries",
+        type=int,
+        help=f"VLLM startup retries (default: {DEFAULT_VLLM_MAX_RETRIES})",
+    )
+    parser.add_argument(
+        "--agent-parser",
+        help=f"Agent parser type (default: \"{DEFAULT_AGENT_PARSER}\", use \"xml\" for swebench)",
+    )
+    parser.add_argument(
+        "--slurm-time",
+        help=f"SLURM time limit (default: \"{DEFAULT_SLURM_TIME}\")",
+    )
+    parser.add_argument(
+        "--agent-name",
+        help=f"Agent name for harbor and DB entries (default: \"{DEFAULT_AGENT_NAME}\")",
+    )
+    parser.add_argument(
+        "--slurm-partition",
+        help=f"SLURM partition (default: \"{DEFAULT_SLURM_PARTITION}\")",
+    )
+    parser.add_argument(
+        "--slurm-account",
+        help="SLURM account for job submission (e.g. 'reformo'). "
+             "Overrides the #SBATCH --account in the sbatch script.",
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        choices=[1, 2, 4],
+        help=f"vLLM tensor parallel size — number of GPUs per model "
+             f"(default: {DEFAULT_TP_SIZE})",
+    )
+    parser.add_argument(
+        "--dp-size",
+        type=int,
+        default=1,
+        choices=[1, 2, 4, 8],
+        help="vLLM native data-parallel size — number of model replicas. "
+             "Total GPUs = tp_size × dp_size. vLLM load-balances requests "
+             "across replicas internally. (default: 1)",
+    )
+    parser.add_argument(
+        "--enable-thinking",
+        action="store_true",
+        help="Enable thinking blocks for model inference (default: False)",
+    )
+    parser.add_argument(
+        "--upload-username",
+        help="Username for DB entries and result uploads (default: current OS user)",
+    )
+
+    # v3 Enhancement 2: Per-listener SLURM job throttle
+    parser.add_argument(
+        "--max-jobs-submitted",
+        type=int,
+        help=f"Per-listener SLURM job limit. Each listener tracks its own "
+             f"submitted jobs independently (default: {DEFAULT_MAX_JOBS_SUBMITTED})",
+    )
+
+    # v3 Enhancement 3: Daytona resource pre-flight check
+    parser.add_argument(
+        "--check-daytona-resources",
+        action="store_true",
+        help="Query Daytona API for active sandbox count; skip if at limit. "
+             "Requires DAYTONA_API_KEY in env",
+    )
+    parser.add_argument(
+        "--daytona-sandbox-limit",
+        type=int,
+        help=f"Max expected active sandboxes (default: {DEFAULT_DAYTONA_SANDBOX_LIMIT})",
+    )
+    parser.add_argument(
+        "--daytona-warning-buffer",
+        type=float,
+        help=f"Warn when active sandboxes reach this fraction of limit "
+             f"(default: {DEFAULT_DAYTONA_WARNING_BUFFER})",
+    )
+
+    # v3 Enhancement 5: Timeout-config-sensitive dedup
+    parser.add_argument(
+        "--timeout-multiplier",
+        type=float,
+        help=f"Harbor timeout multiplier, stored in DB job config "
+             f"(default: {DEFAULT_TIMEOUT_MULTIPLIER})",
+    )
+    parser.add_argument(
+        "--timeout-aware",
+        action="store_true",
+        help="Dedup jobs by model+benchmark+agent+timeout_multiplier instead "
+             "of just model+benchmark. Allows same model with different configs",
+    )
+
+    # Baseline model configs (per-model vLLM overrides)
+    parser.add_argument(
+        "--baseline-model-configs",
+        help="Path to YAML mapping baseline models to vLLM serving params "
+             "(e.g., eval/baseline_model_configs.yaml)",
+    )
+
+    # API model config (per-model serving config for Together / OpenAI / Anthropic)
+    parser.add_argument(
+        "--api-model-config",
+        default="eval/configs/api_model_configs.yaml",
+        help="Path to YAML mapping API-served models (together_ai/, openai/, "
+             "anthropic/...) to api_base + key env + agent kwargs. Models that "
+             "match are dispatched to eval/unified_eval_api_harbor.sbatch (no GPU). "
+             "Missing file is OK — listener falls back to vLLM path for all models.",
+    )
+
+    # Harbor config
+    parser.add_argument(
+        "--harbor-config",
+        help="Path to Harbor YAML config (parsed for timeout_multiplier, "
+             "resource overrides; passed as EVAL_HARBOR_CONFIG to sbatch)",
+    )
+    parser.add_argument(
+        "--config-yaml",
+        help="Override Harbor eval config YAML filename (e.g. 'ablation_interleaved_true_16k.yaml'). "
+             "Overrides preset default. Resolved from eval/configs/ on the compute node.",
+    )
+    parser.add_argument(
+        "--max-output-tokens",
+        type=int,
+        default=None,
+        help="Override max output tokens for LLM calls (default: 16384). "
+             "Sets both max_tokens and model_info.max_output_tokens in the agent.",
+    )
+
+    # Pre-download model weights
+    parser.add_argument(
+        "--pre-download",
+        action="store_true",
+        help="Pre-download all model weights on login node before submitting jobs. "
+             "Essential for no-internet compute nodes (Leonardo, Jupiter).",
+    )
+
+    # Sliding-window batch dependencies
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        help="Max concurrent jobs via sliding-window SLURM dependencies. "
+             "Job N depends on job N-batch_size finishing (afterany), "
+             "so at most batch-size jobs run at once.",
+    )
+
+    # Conda environment selector
+    parser.add_argument(
+        "--conda-env",
+        default="otagent",
+        help="Conda environment to use for eval jobs. 'otagent2' has vLLM 0.17+ "
+             "for Qwen3.5 and newer architectures. Available envs are defined in "
+             "the cluster config YAML. (default: otagent)",
+    )
+
+    # v6: Disk-based resume
+    parser.add_argument(
+        "--jobs-dir",
+        nargs="+",
+        default=None,  # resolved in build_config from cluster config / env / fallback
+        help="Path(s) to eval jobs directories for disk-based resume scanning. "
+             "Can specify multiple dirs. (default: $EVAL_JOBS_DIR or cluster config paths.eval_jobs_dir)",
+    )
+    parser.add_argument(
+        "--no-disk-resume",
+        action="store_true",
+        help="Disable v6 disk-based resume scanning.",
+    )
+    parser.add_argument(
+        "--resume-only",
+        action="store_true",
+        help="Only submit resume jobs from disk scan, skip all fresh submissions.",
+    )
+    parser.add_argument(
+        "--force-reeval",
+        action="store_true",
+        help="Force re-evaluation: bypass DB status check (submit even if Finished/Started). "
+             "Use with --priority-file to re-run specific models.",
+    )
+    parser.add_argument(
+        "--dp-nodes",
+        type=int,
+        default=0,
+        help="Use DP (data-parallel) eval with N SLURM nodes. "
+             "0 = single-node (default). Each node runs shards_per_node vLLM replicas (4/TP).",
+    )
+    parser.add_argument(
+        "--inherit-log",
+        nargs="+",
+        default=None,
+        help="Path(s) to previous listener log file(s). Seeds _submitted_jobs with SLURM IDs "
+             "still active in squeue. Supports multiple logs for chained takeovers. "
+             "Future --inherit-log on THIS listener's log will also pick up inherited IDs.",
+    )
+    parser.add_argument(
+        "--submission-delay",
+        type=float,
+        default=1.0,
+        help="Seconds to sleep between sbatch submissions (default: 1.0). "
+             "Increase to avoid Daytona rate limits (e.g. 30 for 600 sandboxes/min).",
+    )
+    parser.add_argument(
+        "--stagger-delay",
+        type=int,
+        default=0,
+        help="Minutes between job starts via SLURM 'after:' dependency chain (default: 0 = disabled). "
+             "Each batch of --chain-batch-size jobs waits N minutes after the previous batch STARTS. "
+             "Prevents Daytona sandbox burst when many pending jobs start simultaneously. "
+             "Minimum 1 (SLURM after: granularity is minutes).",
+    )
+    parser.add_argument(
+        "--chain-batch-size",
+        type=int,
+        default=1,
+        help="Jobs per stagger batch (default: 1). With --stagger-delay=1 --chain-batch-size=10, "
+             "10 jobs fire immediately, then the next 10 wait 1 minute after the first batch starts. "
+             "Only meaningful when --stagger-delay > 0.",
+    )
+    parser.add_argument(
+        "--pack-jobs",
+        action="store_true",
+        help="Pack multiple jobs onto the same node. Queries idle nodes and assigns "
+             "jobs round-robin so that GPUs_PER_NODE / TP_SIZE jobs share one node.",
+    )
+    parser.add_argument(
+        "--resume-error-threshold",
+        type=int,
+        default=10,
+        help="Min infrastructure errors to trigger resume for completed jobs. "
+             "(default: 3)",
+    )
+    parser.add_argument(
+        "--max-resume-count",
+        type=int,
+        default=5,
+        help="Max times to resume a job dir before giving up. "
+             "(default: 5)",
+    )
+
+    # Execution mode
+    snapshot_group = parser.add_mutually_exclusive_group()
+    snapshot_group.add_argument(
+        "--auto-snapshot",
+        action="store_true",
+        default=None,
+        dest="auto_snapshot",
+        help="Enable Daytona auto_snapshot (overrides YAML config)",
+    )
+    snapshot_group.add_argument(
+        "--no-auto-snapshot",
+        action="store_false",
+        dest="auto_snapshot",
+        help="Disable Daytona auto_snapshot (overrides YAML config)",
+    )
+    parser.add_argument(
+        "--pinggy-url",
+        type=str,
+        default=None,
+        help="Pinggy persistent URL for tunnel (e.g., dadccqeqqf.a.pinggy.link). Used by installed agents.",
+    )
+    parser.add_argument(
+        "--pinggy-token",
+        type=str,
+        default=None,
+        help="Pinggy auth token for SSH tunnel.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview mode, no actual submission (implies --once)",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run single iteration and exit",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    return parser.parse_args()
+
+
+def _env_bool(name: str) -> bool:
+    """Get boolean from environment variable."""
+    return os.getenv(name, "").lower() in ("1", "true", "yes")
+
+
+def build_config(args: argparse.Namespace) -> ListenerConfig:
+    """Build configuration from args, env vars, cluster config, and preset defaults.
+
+    Resolution order for most fields:
+        CLI flag > Preset > Cluster config > Hardcoded default
+    """
+    global _CLUSTER_CONFIG, CONDA_ENV_PATHS
+
+    # --- Load cluster config (if provided) ---
+    cluster_config: Optional[Dict[str, Any]] = None
+    if args.cluster_config:
+        cluster_config = load_cluster_config(args.cluster_config)
+        _CLUSTER_CONFIG = cluster_config
+        # Override CONDA_ENV_PATHS from cluster config
+        if cluster_config.get("conda_envs"):
+            CONDA_ENV_PATHS = cluster_config["conda_envs"]
+
+    # Helper: get cluster config value
+    def _cc(key: str, default: Any = None) -> Any:
+        if cluster_config is None:
+            return default
+        return cluster_config.get(key, default)
+
+    def _cc_p(key: str, default: Any = None) -> Any:
+        if cluster_config is None:
+            return default
+        return cluster_config.get("paths", {}).get(key, default)
+
+    # Start with preset if specified
+    preset_config: Dict = {}
+    if args.preset:
+        preset_config = PRESETS.get(args.preset, {})
+
+    # Resolve datasets: CLI > ENV > Preset
+    datasets_str = args.datasets or os.getenv("EVAL_LISTENER_DATASETS") or ""
+    if datasets_str:
+        datasets = parse_datasets(datasets_str)
+    else:
+        datasets = preset_config.get("datasets", [])
+
+    if not datasets:
+        print("ERROR: No datasets specified. Use --datasets, EVAL_LISTENER_DATASETS, or --preset")
+        sys.exit(2)
+
+    # Resolve sbatch script: CLI > ENV > Preset > Cluster config > Default
+    sbatch_script = (
+        args.sbatch_script
+        or os.getenv("EVAL_LISTENER_SBATCH")
+        or preset_config.get("sbatch_script")
+        or _cc_p("sbatch_script", DEFAULT_SBATCH_SCRIPT)
+    )
+
+    # Resolve timing: CLI > ENV > Default
+    lookback_days = (
+        args.lookback_days
+        if args.lookback_days is not None
+        else int(os.getenv("EVAL_LISTENER_LOOKBACK_DAYS", str(DEFAULT_LOOKBACK_DAYS)))
+    )
+    check_hours = (
+        args.check_hours
+        if args.check_hours is not None
+        else float(os.getenv("EVAL_LISTENER_CHECK_HOURS", str(DEFAULT_CHECK_HOURS)))
+    )
+    stale_hours = args.stale_hours if args.stale_hours is not None else DEFAULT_STALE_JOB_HOURS
+    stale_pending_hours = args.stale_pending_hours if args.stale_pending_hours is not None else DEFAULT_STALE_PENDING_HOURS
+
+    # Resolve log file (CLI --log-dir > ENV > Cluster config > default)
+    log_dir = Path(
+        args.log_dir
+        or os.getenv("EVAL_LISTENER_LOG_DIR")
+        or _cc_p("listener_logs_dir", DEFAULT_LOG_DIR)
+    )
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    suffix = preset_config.get("log_suffix", "unified")
+    current_time = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    resume_tag = "_resume" if args.resume_only else ""
+    dryrun_tag = "_dryrun" if args.dry_run else ""
+
+    if args.log_file:
+        log_file = Path(args.log_file)
+    else:
+        log_file = log_dir / f"{suffix}_eval_listener_v6{resume_tag}{dryrun_tag}_{current_time}.log"
+
+    # Resolve priority file: CLI > ENV
+    priority_file = args.priority_file or os.getenv("EVAL_LISTENER_PRIORITY_FILE")
+    priority_models = load_priority_models(priority_file)
+
+    # Resolve blacklist file: CLI > ENV
+    blacklist_file = args.blacklist_file or os.getenv("EVAL_LISTENER_BLACKLIST_FILE")
+    blacklisted_models = load_blacklist(blacklist_file)
+
+    # Resolve priority mode: CLI > ENV > default
+    priority_mode = (
+        args.priority_mode
+        or os.getenv("EVAL_LISTENER_PRIORITY_MODE")
+        or "filter_only"
+    )
+
+    # Resolve boolean flags: CLI > ENV > Preset
+    require_priority = args.require_priority_list or _env_bool("EVAL_LISTENER_REQUIRE_PRIORITY_LIST")
+    dry_run = args.dry_run or _env_bool("EVAL_LISTENER_DRY_RUN")
+    check_hf_exists = (
+        args.check_hf_exists
+        or _env_bool("EVAL_LISTENER_CHECK_HF_EXISTS")
+        or preset_config.get("check_hf_exists", False)
+    )
+
+    # Resolve sbatch parameters: CLI > Preset > Cluster config > Default
+    def _resolve(cli_val, preset_key: str, default):
+        if cli_val is not None:
+            return cli_val
+        return preset_config.get(preset_key, default)
+
+    n_concurrent = _resolve(args.n_concurrent, "n_concurrent", DEFAULT_N_CONCURRENT)
+    n_attempts = _resolve(args.n_attempts, "n_attempts", DEFAULT_N_ATTEMPTS)
+    gpu_memory_util = _resolve(args.gpu_memory_util, "gpu_memory_util", DEFAULT_GPU_MEMORY_UTIL)
+
+    # Enhancement 1: Resolve error_threshold with backward compat
+    error_threshold_cli = args.error_threshold
+    if error_threshold_cli is None:
+        error_threshold_cli = getattr(args, 'error_threshold_compat', None)
+    error_threshold = _resolve(error_threshold_cli, "error_threshold", DEFAULT_ERROR_THRESHOLD)
+
+    vllm_max_retries = _resolve(args.vllm_max_retries, "vllm_max_retries", DEFAULT_VLLM_MAX_RETRIES)
+    agent_parser = _resolve(args.agent_parser, "agent_parser", DEFAULT_AGENT_PARSER)
+    slurm_time = _resolve(args.slurm_time, "slurm_time", _cc("slurm_time", DEFAULT_SLURM_TIME))
+    agent_name = _resolve(args.agent_name, "agent_name", DEFAULT_AGENT_NAME)
+    slurm_partition = _resolve(args.slurm_partition, "slurm_partition", _cc("slurm_partition", DEFAULT_SLURM_PARTITION))
+    slurm_account = _resolve(args.slurm_account, "slurm_account", _cc("slurm_account", DEFAULT_SLURM_ACCOUNT))
+    tp_size = _resolve(args.tp_size, "tp_size", DEFAULT_TP_SIZE)
+    dp_size = args.dp_size if args.dp_size else 1
+    enable_thinking = args.enable_thinking or preset_config.get("enable_thinking", DEFAULT_ENABLE_THINKING)
+
+    # Resolve upload_username: CLI > ENV > current OS user
+    upload_username = (
+        args.upload_username
+        or os.getenv("EVAL_UPLOAD_USERNAME")
+        or getpass.getuser()
+    )
+
+    # Enhancement 2: SLURM throttle
+    max_jobs_submitted = (
+        args.max_jobs_submitted
+        if args.max_jobs_submitted is not None
+        else int(os.getenv("EVAL_LISTENER_MAX_JOBS", str(DEFAULT_MAX_JOBS_SUBMITTED)))
+    )
+
+    # Enhancement 3: Daytona resource check
+    check_daytona = args.check_daytona_resources
+    daytona_sandbox_limit = (
+        args.daytona_sandbox_limit
+        if args.daytona_sandbox_limit is not None
+        else DEFAULT_DAYTONA_SANDBOX_LIMIT
+    )
+    daytona_warning_buffer = (
+        args.daytona_warning_buffer
+        if args.daytona_warning_buffer is not None
+        else DEFAULT_DAYTONA_WARNING_BUFFER
+    )
+
+    # Enhancement 5: Timeout-config-sensitive dedup
+    timeout_multiplier = (
+        args.timeout_multiplier
+        if args.timeout_multiplier is not None
+        else DEFAULT_TIMEOUT_MULTIPLIER
+    )
+    timeout_aware = args.timeout_aware
+
+    # auto_snapshot: CLI > Preset > None (use YAML default)
+    auto_snapshot = args.auto_snapshot
+    if auto_snapshot is None:
+        auto_snapshot = preset_config.get("auto_snapshot")
+
+    # Config YAML: CLI > Preset > Default
+    config_yaml = args.config_yaml or preset_config.get("config_yaml", "dcagent_eval_config.yaml")
+
+    # Harbor config (parse eval-relevant fields for config-aware dedup)
+    harbor_config = args.harbor_config or preset_config.get("harbor_config")
+    eval_config = parse_harbor_eval_config(harbor_config)
+
+    # Baseline model configs for per-model vLLM overrides
+    baseline_model_configs_path = args.baseline_model_configs
+
+    # API model configs for per-model API serving (no-op if file missing)
+    api_model_config_path = args.api_model_config
+
+    # Pre-download model weights
+    pre_download = args.pre_download
+
+    # Sliding-window batch dependencies
+    batch_size = args.batch_size
+
+    # Conda env selector
+    conda_env = args.conda_env
+
+    # Resolve jobs_dirs: CLI > ENV > Cluster config > Fallback
+    fallback_jobs_dir = _cc_p("eval_jobs_dir", _FALLBACK_EVAL_JOBS_DIR)
+    jobs_dirs = args.jobs_dir or [os.environ.get("EVAL_JOBS_DIR", fallback_jobs_dir)]
+
+    # Resolve DP sbatch script: Cluster config > Default
+    dp_sbatch_script = _cc_p("dp_sbatch_script", "eval/unified_eval_harbor_dp.sbatch")
+
+    # agent_envs: resolve from preset. Format: "KEY_NAME,KEY_NAME=ENVVAR,KEY=literal"
+    # - "SERPAPI_API_KEY" → reads os.environ["SERPAPI_API_KEY"], passes as SERPAPI_API_KEY=<value>
+    # - "MODEL_API_KEY=OPENAI_API_KEY" → reads os.environ["OPENAI_API_KEY"], passes as MODEL_API_KEY=<value>
+    # - "MODEL_FOR_TOOLS=openai/gpt-5.2" → literal value, passes as-is
+    raw_agent_envs = preset_config.get("agent_envs", "")
+    resolved_agent_envs = None
+    if raw_agent_envs:
+        resolved_pairs = []
+        for item in raw_agent_envs.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            if "=" in item:
+                key, val = item.split("=", 1)
+                env_val = os.environ.get(val)
+                if env_val is not None:
+                    resolved_pairs.append(f"{key}={env_val}")
+                else:
+                    resolved_pairs.append(f"{key}={val}")
+            else:
+                env_val = os.environ.get(item, "")
+                if env_val:
+                    resolved_pairs.append(f"{item}={env_val}")
+                else:
+                    log(f"WARNING: agent_envs: env var {item} not set, skipping")
+        resolved_agent_envs = ",".join(resolved_pairs) if resolved_pairs else None
+
+    return ListenerConfig(
+        datasets=datasets,
+        sbatch_script=sbatch_script,
+        log_file=log_file,
+        lookback_days=lookback_days,
+        check_interval_hours=check_hours,
+        stale_job_hours=stale_hours,
+        stale_pending_hours=stale_pending_hours,
+        priority_file=priority_file,
+        require_priority_list=require_priority,
+        priority_models=priority_models,
+        priority_mode=priority_mode,
+        check_hf_exists=check_hf_exists,
+        dry_run=dry_run,
+        run_once=args.once,
+        verbose=args.verbose,
+        # Sbatch parameters
+        n_concurrent=n_concurrent,
+        n_attempts=n_attempts,
+        gpu_memory_util=gpu_memory_util,
+        error_threshold=error_threshold,
+        vllm_max_retries=vllm_max_retries,
+        agent_parser=agent_parser,
+        slurm_time=slurm_time,
+        enable_thinking=enable_thinking,
+        agent_name=agent_name,
+        slurm_partition=slurm_partition,
+        slurm_account=slurm_account,
+        tp_size=tp_size,
+        dp_size=dp_size,
+        upload_username=upload_username,
+        # Enhancement 2
+        max_jobs_submitted=max_jobs_submitted,
+        # Enhancement 3
+        check_daytona_resources=check_daytona,
+        daytona_sandbox_limit=daytona_sandbox_limit,
+        daytona_warning_buffer=daytona_warning_buffer,
+        # Enhancement 5
+        timeout_multiplier=timeout_multiplier,
+        timeout_aware=timeout_aware,
+        config_yaml=config_yaml,
+        max_output_tokens=args.max_output_tokens,
+        auto_snapshot=auto_snapshot,
+        blacklist_file=blacklist_file,
+        blacklisted_models=blacklisted_models,
+        # New features
+        baseline_model_configs=baseline_model_configs_path,
+        api_model_config=api_model_config_path,
+        harbor_config=harbor_config,
+        eval_config=eval_config,
+        pre_download=pre_download,
+        batch_size=batch_size,
+        conda_env=conda_env,
+        # v6: Disk-based resume
+        jobs_dirs=jobs_dirs,
+        enable_disk_resume=not args.no_disk_resume,
+        resume_infra_error_threshold=args.resume_error_threshold,
+        max_resume_count=args.max_resume_count,
+        force_reeval=args.force_reeval,
+        resume_only=args.resume_only,
+        submission_delay=args.submission_delay,
+        stagger_delay=max(args.stagger_delay, 0),
+        chain_batch_size=max(args.chain_batch_size, 1),
+        pack_jobs=args.pack_jobs,
+        dp_nodes=args.dp_nodes,
+        dp_sbatch_script=dp_sbatch_script,
+        inherit_log=args.inherit_log,
+        # Cluster config
+        cluster_config=cluster_config,
+        agent_envs=resolved_agent_envs,
+        pinggy_url=args.pinggy_url,
+        pinggy_token=args.pinggy_token,
+    )
+
+
+# ---------- Main ----------
+def main() -> None:
+    global _VERBOSE
+    _load_secrets()
+    args = parse_args()
+    config = build_config(args)
+    _VERBOSE = config.verbose
+    if config.cluster_config:
+        log(f"[v6] Cluster config: {config.cluster_config.get('cluster_name', '?')}")
+    listener = EvalListener(config)
+    listener.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/hpc/dotenv/example.env
+++ b/hpc/dotenv/example.env
@@ -1,0 +1,47 @@
+# Example dotenv for the eval listener.
+#
+#   source hpc/dotenv/example.env       # or: source hpc/dotenv/<your-cluster>.env
+#
+# Copy this file to hpc/dotenv/<your-cluster>.env and fill in every TODO.
+# These exports are read by the listener and the sbatch; missing values
+# either crash the fire (HF_TOKEN, SUPABASE_*) or silently disable upload
+# (HF only) / DB upload (SUPABASE_* only).
+
+# --- Repo location ---------------------------------------------------------
+# Source-of-truth checkout that ${DCFT} resolves to inside the sbatch.
+export DCFT="<path-to-OpenThoughts-Agent-checkout>"  # TODO: set me
+
+# --- HuggingFace -----------------------------------------------------------
+# Required for: HF model snapshot_download + HF dataset pull + post-eval
+# trace upload (DCAgent2/<run_tag>-traces).
+export HF_TOKEN=""                                   # TODO: set me
+export HF_HUB_CACHE="<path-to-hf-hub-cache>"         # TODO: set me, e.g. ~/.cache/huggingface/hub
+export HF_HOME="$HF_HUB_CACHE"
+
+# --- Supabase / unified DB -------------------------------------------------
+# Required for: per-trial DB upserts and the listener's "already-evaluated"
+# skip filter. SUPABASE_ANON_KEY and SUPABASE_KEY are aliases the legacy
+# code reads — set both.
+export SUPABASE_URL=""                               # TODO: set me
+export SUPABASE_ANON_KEY=""                          # TODO: set me
+export SUPABASE_KEY="$SUPABASE_ANON_KEY"
+export SUPABASE_SERVICE_ROLE_KEY=""                  # TODO: set me (only needed for query_unevaled_models.py)
+
+# --- Daytona ---------------------------------------------------------------
+# Required for: Pattern A/B/C/D agents that build sandboxes via Daytona.
+# Add fallback keys for failover under load (the sbatch will rotate).
+export DAYTONA_API_KEY=""                            # TODO: set me (primary)
+# export DAYTONA_API_KEY_FALLBACK_1=""               # optional secondary key
+# export DAYTONA_API_KEY_FALLBACK_2=""               # optional tertiary key
+
+# --- Pinggy (installed-agent preferred-harness reproductions) -------------
+# Required for: PHR fires where the agent runtime needs an inbound URL the
+# Daytona sandbox can reach (openhands/swe-agent regular, etc.). Allocate
+# pairs offline and load the pre-baked URL/token here, OR pass on the CLI:
+#   --pinggy-url <url> --pinggy-token <token>
+# export EVAL_PINGGY_URL=""
+# export EVAL_PINGGY_TOKEN=""
+
+# --- Optional: proxychains (no-internet clusters) -------------------------
+# export PROXYCHAINS_BIN="<path-to-proxychains4>"
+# export PROXYCHAINS_LOGIN_NODE="<login-host>"

--- a/hpc/dotenv/example.env
+++ b/hpc/dotenv/example.env
@@ -42,6 +42,15 @@ export DAYTONA_API_KEY=""                            # TODO: set me (primary)
 # export EVAL_PINGGY_URL=""
 # export EVAL_PINGGY_TOKEN=""
 
+# --- Optional: CUDA toolkit override ---------------------------------------
+# Set this if your conda env doesn't bundle nvcc and flashinfer's JIT
+# compiler can't find it on PATH. Leave unset to trust the conda/system
+# default.
+# export EVAL_CUDA_HOME="<path-to-CUDA>"           # e.g. /usr/local/cuda-12.8
+
 # --- Optional: proxychains (no-internet clusters) -------------------------
-# export PROXYCHAINS_BIN="<path-to-proxychains4>"
-# export PROXYCHAINS_LOGIN_NODE="<login-host>"
+# Required if your cluster config sets proxy.enabled=true. The sbatch
+# opens an SSH tunnel to EVAL_LOGIN_NODE and routes Daytona / HF traffic
+# through it via EVAL_PROXYCHAINS_BIN.
+# export EVAL_LOGIN_NODE="<login-host>"            # hostname compute nodes can SSH to
+# export EVAL_PROXYCHAINS_BIN="<path-to-proxychains4>"

--- a/hpc/dotenv/jupiter_eval.env.example
+++ b/hpc/dotenv/jupiter_eval.env.example
@@ -1,0 +1,86 @@
+# Jupiter (JSC GH200) — eval-listener dotenv (eval org / default).
+#
+# Copy this to hpc/dotenv/jupiter_eval.env and edit the per-operator paths
+# below. Your real .env is gitignored.
+#
+#   cp hpc/dotenv/jupiter_eval.env.example hpc/dotenv/jupiter_eval.env
+#   $EDITOR hpc/dotenv/jupiter_eval.env
+#   source hpc/dotenv/jupiter_eval.env
+#
+# This is the eval-listener dotenv, distinct from hpc/dotenv/jupiter.env
+# (the SFT/RL launcher dotenv). It points DCFT at the eval-listener checkout
+# (PR #27).
+#
+# Sources (paths you must provide):
+#   secrets       <your eval-org secrets.env>   (Daytona, HF, Supabase, W&B tokens)
+#   pinggy pairs  <your pinggy_pairs.env>       (optional; 10 PINGGY_URL_N / TOKEN_N — Cat 3 fires only)
+#
+# For the data-org Daytona key, use hpc/dotenv/jupiter_eval_data_org.env.
+
+# --- Per-operator paths (EDIT THESE) ---------------------------------------
+# Your scratch dir. On JSC Jupiter, scratch lives at /e/scratch/<group>/<user>.
+# Override the group with EVAL_GROUP=<your-group> before sourcing.
+SCRATCH_DIR="/e/scratch/${EVAL_GROUP:-jureap59}/${USER}"
+# Where you cloned this repo (PR #27 checkout).
+export DCFT="${SCRATCH_DIR}/OpenThoughts-Agent-Latest"
+# Path to your eval-org secrets.env (Daytona, HF, Supabase, W&B tokens).
+EVAL_SECRETS_FILE="${SCRATCH_DIR}/secrets.env"
+# Path to your pinggy pairs file (optional; only needed for Cat 3 fires).
+PINGGY_PAIRS_FILE="${SCRATCH_DIR}/pinggy_pairs.env"
+# Path to a proxychains4 binary built for aarch64 (compute nodes have no internet).
+EVAL_PROXYCHAINS_BIN_DEFAULT="${SCRATCH_DIR}/proxychains-ng-aarch64/bin/proxychains4"
+
+# --- Repo location ---------------------------------------------------------
+# Listener imports database.unified_db.* — needs project root on path.
+export PYTHONPATH="$DCFT${PYTHONPATH:+:$PYTHONPATH}"
+
+# --- HuggingFace -----------------------------------------------------------
+export HF_HUB_CACHE="/e/data1/datasets/playground/ot/hf_hub"
+export HF_HOME="$HF_HUB_CACHE"
+
+# --- Compile caches (off $HOME — exa_home has tight quota ~21GB hard) ------
+# vLLM populates ~5-10GB of compile artifacts per Qwen3-32B variant during
+# torch.compile warmup. Pin to scratch so concurrent fires don't race the
+# $HOME quota. Default $HOME caches caused OSError [Errno 122] Disk quota
+# exceeded on 2026-05-07 (16 jobs failed at vLLM startup).
+export VLLM_CACHE_ROOT="${SCRATCH_DIR}/vllm_cache"
+export TORCHINDUCTOR_CACHE_DIR="${SCRATCH_DIR}/torch_inductor_cache"
+mkdir -p "$VLLM_CACHE_ROOT" "$TORCHINDUCTOR_CACHE_DIR" 2>/dev/null || true
+
+# --- Secrets (eval org) ----------------------------------------------------
+if [ -f "$EVAL_SECRETS_FILE" ]; then
+    set -a
+    . "$EVAL_SECRETS_FILE"
+    set +a
+    export DC_AGENT_SECRET_ENV="$EVAL_SECRETS_FILE"
+fi
+export SUPABASE_KEY="${SUPABASE_KEY:-${SUPABASE_ANON_KEY:-}}"
+
+# --- Pinggy pairs (installed-agent fires) ---------------------------------
+# 10 pairs: PINGGY_URL_1..10, PINGGY_TOKEN_1..10. Bare assignments → set -a.
+if [ -f "$PINGGY_PAIRS_FILE" ]; then
+    set -a
+    . "$PINGGY_PAIRS_FILE"
+    set +a
+fi
+
+# --- Proxychains (no-internet compute nodes) ------------------------------
+export EVAL_LOGIN_NODE="jpbl-s01-02"
+export EVAL_PROXYCHAINS_BIN="${EVAL_PROXYCHAINS_BIN:-$EVAL_PROXYCHAINS_BIN_DEFAULT}"
+# Compute-side ssh tunnel back to login node (proxychains target).
+# Required by sbatch proxy block. Set to a private key the SLURM job can read.
+export SSH_KEY="$HOME/.ssh/id_ed25519"
+
+# --- vLLM AOT-compile crash workaround (failure mode #32) -----------------
+# vLLM 0.17.1 + torch 2.10.0+cu128 default-enables AOT compile, which dies
+# in profile_run on @support_torch_compile models (e.g. GLM-4.7-FP8). Falls
+# through to regular torch.compile + CUDA graphs (faster than --enforce-eager).
+# Required for any otagent2-fix fire.
+export VLLM_USE_AOT_COMPILE=0
+
+# --- SLURM reservation (optional) -----------------------------------------
+# If you have a reservation, export it here. SBATCH_RESERVATION is a standard
+# SLURM env var that sbatch picks up as a default for every submission — no
+# listener flag needed. Unset/empty for no reservation.
+# Example (remove or change after expiry):
+#   export SBATCH_RESERVATION="reformo"

--- a/hpc/dotenv/jupiter_eval_data_org.env.example
+++ b/hpc/dotenv/jupiter_eval_data_org.env.example
@@ -1,0 +1,60 @@
+# Jupiter (JSC GH200) — eval-listener dotenv (data org).
+#
+# Copy this to hpc/dotenv/jupiter_eval_data_org.env and edit the per-operator
+# paths below. Your real .env is gitignored.
+#
+#   cp hpc/dotenv/jupiter_eval_data_org.env.example hpc/dotenv/jupiter_eval_data_org.env
+#   $EDITOR hpc/dotenv/jupiter_eval_data_org.env
+#   source hpc/dotenv/jupiter_eval_data_org.env
+#
+# Same as jupiter_eval.env but points DC_AGENT_SECRET_ENV at the data-org
+# secrets file (different DAYTONA_API_KEY). Use when extra Daytona capacity
+# is needed, or when explicitly firing against the data org.
+
+# --- Per-operator paths (EDIT THESE) ---------------------------------------
+SCRATCH_DIR="/e/scratch/${EVAL_GROUP:-jureap59}/${USER}"
+export DCFT="${SCRATCH_DIR}/OpenThoughts-Agent-Latest"
+EVAL_SECRETS_FILE="${SCRATCH_DIR}/secrets_data_org.env"
+PINGGY_PAIRS_FILE="${SCRATCH_DIR}/pinggy_pairs.env"
+EVAL_PROXYCHAINS_BIN_DEFAULT="${SCRATCH_DIR}/proxychains-ng-aarch64/bin/proxychains4"
+
+# --- Repo location ---------------------------------------------------------
+export PYTHONPATH="$DCFT${PYTHONPATH:+:$PYTHONPATH}"
+
+# --- HuggingFace -----------------------------------------------------------
+export HF_HUB_CACHE="/e/data1/datasets/playground/ot/hf_hub"
+export HF_HOME="$HF_HUB_CACHE"
+
+# --- Compile caches (off $HOME — exa_home has tight quota ~21GB hard) ------
+# See jupiter_eval.env.example for the disk-quota incident background.
+export VLLM_CACHE_ROOT="${SCRATCH_DIR}/vllm_cache"
+export TORCHINDUCTOR_CACHE_DIR="${SCRATCH_DIR}/torch_inductor_cache"
+mkdir -p "$VLLM_CACHE_ROOT" "$TORCHINDUCTOR_CACHE_DIR" 2>/dev/null || true
+
+# --- Secrets (data org) ---------------------------------------------------
+if [ -f "$EVAL_SECRETS_FILE" ]; then
+    set -a
+    . "$EVAL_SECRETS_FILE"
+    set +a
+    export DC_AGENT_SECRET_ENV="$EVAL_SECRETS_FILE"
+fi
+export SUPABASE_KEY="${SUPABASE_KEY:-${SUPABASE_ANON_KEY:-}}"
+
+# --- Pinggy pairs ---------------------------------------------------------
+if [ -f "$PINGGY_PAIRS_FILE" ]; then
+    set -a
+    . "$PINGGY_PAIRS_FILE"
+    set +a
+fi
+
+# --- Proxychains ----------------------------------------------------------
+export EVAL_LOGIN_NODE="jpbl-s01-02"
+export EVAL_PROXYCHAINS_BIN="${EVAL_PROXYCHAINS_BIN:-$EVAL_PROXYCHAINS_BIN_DEFAULT}"
+export SSH_KEY="$HOME/.ssh/id_ed25519"
+
+# --- vLLM AOT-compile crash workaround (failure mode #32) -----------------
+export VLLM_USE_AOT_COMPILE=0
+
+# --- SLURM reservation (optional) -----------------------------------------
+# Example (remove or change after expiry):
+#   export SBATCH_RESERVATION="reformo"

--- a/scripts/database/batch_upload_eval.py
+++ b/scripts/database/batch_upload_eval.py
@@ -115,7 +115,7 @@ def get_job_info(job_dir):
                     td = json.load(open(tr))
                     source = td.get("source", "")
                     if source:
-                        for pfx in ["DCAgent2_", "DCAgent_"]:
+                        for pfx in ["DCAgent3_", "DCAgent2_", "DCAgent_"]:
                             if source.startswith(pfx):
                                 source = source[len(pfx):]
                                 break

--- a/scripts/database/batch_upload_eval.py
+++ b/scripts/database/batch_upload_eval.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Batch upload eval job results to Supabase + HuggingFace.
+
+Supports two modes:
+1. Explicit job dirs: upload specific completed jobs
+2. Auto-detect overlong: scan a jobs directory for timed-out jobs
+
+Usage:
+    # Upload specific job dirs (normal eval)
+    python scripts/database/batch_upload_eval.py \
+        jobs/terminal_bench_2_model_A_20260407_* \
+        jobs/dev_set_v2_model_B_20260407_*
+
+    # Upload as overlong (timed-out jobs)
+    python scripts/database/batch_upload_eval.py --overlong \
+        jobs/terminal_bench_2_slow_model_*
+
+    # Auto-detect overlong jobs in a directory
+    python scripts/database/batch_upload_eval.py --auto-detect-overlong \
+        --jobs-dir /path/to/jobs
+
+    # Parallel upload with HF traces
+    python scripts/database/batch_upload_eval.py -p 8 jobs/swebench_*
+
+    # Skip HF upload (DB only)
+    python scripts/database/batch_upload_eval.py --skip-hf jobs/swebench_*
+
+    # Dry run
+    python scripts/database/batch_upload_eval.py --dry-run jobs/swebench_*
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+_db_path = _repo_root / "database" / "unified_db"
+if str(_db_path) not in sys.path:
+    sys.path.insert(0, str(_db_path))
+
+DEFAULT_JOBS_DIR = _repo_root / "jobs"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def parse_iso(ts_str):
+    if not ts_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def derive_hf_repo_id(job_dir):
+    """Derive HF repo ID from job directory name."""
+    name = Path(job_dir).name
+    sanitized = name.replace("@", "-").replace(" ", "-")
+    return f"DCAgent3/{sanitized}-traces"
+
+
+def get_job_info(job_dir):
+    """Extract basic info from a job directory."""
+    job_dir = Path(job_dir)
+    result_file = job_dir / "result.json"
+    if not result_file.exists():
+        return None
+
+    try:
+        d = json.load(open(result_file))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    n_total = d.get("n_total_trials", 0)
+    n_trials = d.get("stats", {}).get("n_trials", 0)
+    finished = d.get("finished_at") is not None
+
+    # Accuracy
+    accuracy = None
+    for eval_data in d.get("stats", {}).get("evals", {}).values():
+        metrics = eval_data.get("metrics", [])
+        if metrics and isinstance(metrics, list):
+            mr = metrics[0].get("mean_reward")
+            if mr is not None:
+                accuracy = mr
+
+    # Model from meta.env
+    model = None
+    meta_env = job_dir / "meta.env"
+    if meta_env.exists():
+        with open(meta_env) as f:
+            for line in f:
+                if line.startswith("MODEL="):
+                    model = line.strip().split("=", 1)[1]
+                    break
+
+    # Benchmark from trial source
+    benchmark = None
+    for entry in sorted(job_dir.iterdir()):
+        if entry.is_dir() and "__" in entry.name:
+            tr = entry / "result.json"
+            if tr.exists():
+                try:
+                    td = json.load(open(tr))
+                    source = td.get("source", "")
+                    if source:
+                        for pfx in ["DCAgent2_", "DCAgent_"]:
+                            if source.startswith(pfx):
+                                source = source[len(pfx):]
+                                break
+                        benchmark = source
+                except (json.JSONDecodeError, OSError):
+                    pass
+                break
+
+    model_short = (model.split("/")[-1] if model and "/" in model else model) or job_dir.name
+
+    return {
+        "dir": job_dir,
+        "model": model or job_dir.name,
+        "model_short": model_short,
+        "benchmark": benchmark or "unknown",
+        "n_trials": n_trials,
+        "n_total": n_total,
+        "finished": finished,
+        "accuracy": accuracy,
+    }
+
+
+def detect_overlong_jobs(jobs_dir, min_elapsed_h=20, benchmark_filter=None):
+    """Find jobs that timed out (no finished_at, elapsed > min_elapsed_h)."""
+    results = []
+    jobs_dir = Path(jobs_dir)
+
+    for entry in sorted(jobs_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        info = get_job_info(entry)
+        if not info or info["finished"] or info["n_trials"] == 0:
+            continue
+
+        # Check elapsed
+        try:
+            d = json.load(open(entry / "result.json"))
+        except:
+            continue
+        started = parse_iso(d.get("started_at"))
+        if not started:
+            continue
+
+        latest = None
+        for te in entry.iterdir():
+            if not te.is_dir() or "__" not in te.name:
+                continue
+            tr = te / "result.json"
+            if tr.exists():
+                try:
+                    td = json.load(open(tr))
+                    fa = td.get("finished_at")
+                    if fa:
+                        ft = parse_iso(fa)
+                        if ft and (latest is None or ft > latest):
+                            latest = ft
+                except:
+                    pass
+
+        if latest is None:
+            continue
+        elapsed_h = (latest - started).total_seconds() / 3600
+        if elapsed_h < min_elapsed_h:
+            continue
+
+        if benchmark_filter and benchmark_filter.lower() not in info["benchmark"].lower():
+            continue
+
+        info["elapsed_h"] = elapsed_h
+        results.append(info)
+
+    # Deduplicate: same model+benchmark, keep best progress
+    seen = {}
+    for r in results:
+        key = (r["model"], r["benchmark"])
+        if key not in seen or r["n_trials"] > seen[key]["n_trials"]:
+            seen[key] = r
+    return sorted(seen.values(), key=lambda r: (r["benchmark"], r["model"]))
+
+
+def upload_one(job_dir, benchmark_name=None, skip_hf=False, is_overlong=False):
+    """Upload a single job. Returns (success, label, message)."""
+    from hpc.launch_utils import sync_eval_to_database
+
+    job_dir = Path(job_dir)
+    label = job_dir.name
+    hf_repo_id = None if skip_hf else derive_hf_repo_id(job_dir)
+
+    try:
+        # is_overlong only passed if True; older sync_eval_to_database (PR clone) doesn't accept it
+        extra = {}
+        if is_overlong:
+            extra["is_overlong"] = True
+        result = sync_eval_to_database(
+            job_dir=job_dir,
+            error_mode="skip_on_error",
+            benchmark_name=benchmark_name,
+            register_benchmark=True,
+            forced_update=True,
+            hf_repo_id=hf_repo_id,
+            hf_token=os.environ.get("HF_TOKEN"),
+            **extra,
+        )
+        if result.get("success"):
+            job_id = result.get("job_id")
+            n_trials = result.get("n_trials_uploaded", 0)
+            hf_url = result.get("hf_dataset_url", "n/a")
+            return True, label, f"job_id={job_id}, trials={n_trials}, hf={hf_url}"
+        else:
+            return False, label, result.get("error", "unknown")
+    except Exception as e:
+        return False, label, str(e)
+
+
+def run_uploads(jobs_to_upload, n_workers, skip_hf, is_overlong):
+    """Run uploads sequentially or in parallel."""
+    n_workers = min(n_workers, len(jobs_to_upload))
+
+    if n_workers <= 1:
+        success = failed = 0
+        for job in jobs_to_upload:
+            ok, label, msg = upload_one(
+                job["dir"], job.get("benchmark"), skip_hf, is_overlong)
+            print(f"  [{'OK' if ok else 'FAIL'}] {label}: {msg}")
+            if ok:
+                success += 1
+            else:
+                failed += 1
+    else:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        success = failed = 0
+
+        def _worker(job):
+            return upload_one(job["dir"], job.get("benchmark"), skip_hf, is_overlong)
+
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            futures = {pool.submit(_worker, j): j for j in jobs_to_upload}
+            for future in as_completed(futures):
+                ok, label, msg = future.result()
+                print(f"  [{'OK' if ok else 'FAIL'}] {label}: {msg}")
+                if ok:
+                    success += 1
+                else:
+                    failed += 1
+
+    print(f"\nDone: {success} uploaded, {failed} failed")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Batch upload eval results to Supabase + HuggingFace.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    # Mode
+    parser.add_argument("job_dirs", nargs="*", type=Path,
+                        help="Job directories to upload (glob-friendly)")
+    parser.add_argument("--auto-detect-overlong", action="store_true",
+                        help="Auto-detect overlong jobs (>20h elapsed, incomplete)")
+    parser.add_argument("--jobs-dir", type=Path, default=DEFAULT_JOBS_DIR,
+                        help="Jobs directory for --auto-detect-overlong mode")
+
+    # Upload options
+    parser.add_argument("--overlong", action="store_true",
+                        help="Mark uploaded jobs as overlong (is_overlong=true)")
+    parser.add_argument("--skip-hf", action="store_true",
+                        help="Skip HuggingFace upload (DB only)")
+    parser.add_argument("--force", action="store_true",
+                        help="Override quality gates (low accuracy, incomplete trials)")
+    parser.add_argument("--parallel", "-p", type=int, default=1,
+                        help="Number of parallel upload workers (default: 1)")
+
+    # Filters (for auto-detect mode)
+    parser.add_argument("--benchmark", "-b", type=str, default=None,
+                        help="Filter by benchmark substring")
+    parser.add_argument("--min-elapsed", type=float, default=20,
+                        help="Min elapsed hours for overlong detection (default: 20)")
+
+    # Safety
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be uploaded without uploading")
+
+    args = parser.parse_args()
+
+    if args.force:
+        os.environ["EVAL_UPLOAD_FORCE"] = "1"
+
+    if args.auto_detect_overlong:
+        # Auto-detect mode
+        print(f"Scanning {args.jobs_dir} for overlong jobs (>{args.min_elapsed}h elapsed, incomplete)...")
+        jobs_to_upload = detect_overlong_jobs(args.jobs_dir, args.min_elapsed, args.benchmark)
+        is_overlong = True
+        print(f"Found {len(jobs_to_upload)} overlong model/benchmark pairs\n")
+    elif args.job_dirs:
+        # Explicit job dirs mode
+        jobs_to_upload = []
+        for jd in args.job_dirs:
+            jd = jd.resolve()
+            if not jd.exists():
+                print(f"  [SKIP] {jd}: directory not found")
+                continue
+            info = get_job_info(jd)
+            if info is None:
+                print(f"  [SKIP] {jd}: no result.json")
+                continue
+            jobs_to_upload.append(info)
+        is_overlong = args.overlong
+        print(f"Found {len(jobs_to_upload)} job(s) to upload\n")
+    else:
+        parser.print_help()
+        return
+
+    if not jobs_to_upload:
+        print("Nothing to upload.")
+        return
+
+    # Display table
+    hdr_elapsed = "Elapsed" if args.auto_detect_overlong else ""
+    print(f"  {'Model':<55} {'Benchmark':<25} {'Progress':>10} {'Acc':>7} {hdr_elapsed:>8}")
+    print("  " + "-" * 110)
+    for r in jobs_to_upload:
+        acc = f"{r['accuracy']:.1%}" if r['accuracy'] is not None else "N/A"
+        elapsed = f"{r.get('elapsed_h', 0):.1f}h" if args.auto_detect_overlong else ""
+        print(f"  {r['model_short']:<55} {r['benchmark']:<25} {r['n_trials']:>4}/{r['n_total']:<4} {acc:>7} {elapsed:>8}")
+
+    mode = "overlong" if is_overlong else "normal"
+    hf = "skip" if args.skip_hf else "enabled"
+    print(f"\n  Mode: {mode} | HF: {hf} | Workers: {args.parallel}")
+
+    if args.dry_run:
+        print("\n  Dry run — pass without --dry-run to upload.")
+        return
+
+    print()
+    run_uploads(jobs_to_upload, args.parallel, args.skip_hf, is_overlong)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/check_firing_candidates.py
+++ b/scripts/database/check_firing_candidates.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Check eval status of recently-added models across multiple benchmark families.
+
+For the firing agent: scope to models added to the DB in the last N days,
+show per-benchmark status, and write per-benchmark "still needs firing"
+priority files ready for unified_eval_listener.py.
+
+Default scope: models with creation_time within the last 7 days, sized 32B,
+checked against terminal_bench_2 + swebench-verified-random-100-folders.
+
+Examples:
+  # Default: 32B, last 7 days, tb2 + swebench
+  python scripts/database/check_firing_candidates.py
+
+  # 8B last 3 days, write priority files
+  python scripts/database/check_firing_candidates.py --size 8 --max-age-days 3 \
+      --output-dir eval/.local_notes/uneval_lists
+
+  # Add an include filter on model name
+  python scripts/database/check_firing_candidates.py --include EtashGuha
+
+  # Different benchmarks
+  python scripts/database/check_firing_candidates.py \
+      --benchmarks terminal_bench_2,dev_set_v2
+
+Requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (sourced from
+hpc/dotenv/jupiter_eval.env).
+"""
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# Reuse helpers from the unevaled-models query.
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+from query_unevaled_models import (  # noqa: E402
+    _build_root_size_map,
+    _size_in_bucket,
+    get_client,
+    resolve_benchmark_family,
+)
+
+
+def parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def get_recent_models(
+    client,
+    cutoff: datetime,
+    size: Optional[int],
+    includes: List[str],
+    excludes: List[str],
+) -> List[dict]:
+    """Return models with creation_time >= cutoff, optionally size-filtered."""
+    # Pull once, classify in-process. Models table is small enough.
+    models = client.table("models").select(
+        "id,name,model_size_b,base_model_id,creation_time"
+    ).execute().data
+    root_sizes = _build_root_size_map(models) if size is not None else {}
+
+    out = []
+    for m in models:
+        name = m.get("name") or ""
+        if not name or name.startswith("/"):
+            continue
+        ts = m.get("creation_time")
+        if not ts:
+            continue
+        if parse_iso(ts) < cutoff:
+            continue
+        if includes and not any(s in name for s in includes):
+            continue
+        if any(s in name for s in excludes):
+            continue
+        if size is not None:
+            root_size = root_sizes.get(m["id"])
+            own_size = m.get("model_size_b")
+            if not (
+                _size_in_bucket(root_size, size)
+                or _size_in_bucket(own_size, size)
+                or (
+                    root_size is None
+                    and own_size is None
+                    and (f"{size}B" in name or f"{size}b" in name)
+                )
+            ):
+                continue
+        out.append(m)
+    return out
+
+
+def get_evaled_for_family(client, family_ids: Set[str]) -> Set[str]:
+    """All model_ids with any sandbox_job (any status) against the family."""
+    evaled = set()
+    for bid in family_ids:
+        # Filter to non-null model_id at query time to keep the response small.
+        rows = client.table("sandbox_jobs").select("model_id").eq(
+            "benchmark_id", bid
+        ).execute().data
+        for r in rows:
+            mid = r.get("model_id")
+            if mid:
+                evaled.add(mid)
+    return evaled
+
+
+def sanitize(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", name)
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Check firing candidates: recent models × benchmarks."
+    )
+    p.add_argument(
+        "--benchmarks",
+        default="terminal_bench_2,swebench-verified-random-100-folders",
+        help="Comma-separated benchmark names (resolved to families via duplicate_of).",
+    )
+    p.add_argument("--size", type=int, default=32, help="Size bucket in B (default 32).")
+    p.add_argument("--max-age-days", type=int, default=7, help="Max model age in days (default 7).")
+    p.add_argument("--include", action="append", default=[], help="Substring filter (repeatable).")
+    p.add_argument("--exclude", action="append", default=[], help="Substring exclusion (repeatable).")
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="If set, write per-benchmark priority files of unevaled models.",
+    )
+    p.add_argument(
+        "--blacklist-output-dir",
+        default=None,
+        help="If set, write per-benchmark blacklist files (all evaled models in DB) here.",
+    )
+    args = p.parse_args()
+
+    benchmarks = [b.strip() for b in args.benchmarks.split(",") if b.strip()]
+    if not benchmarks:
+        print("Error: at least one benchmark required.", file=sys.stderr)
+        sys.exit(1)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=args.max_age_days)
+    client = get_client()
+
+    # Resolve every benchmark family.
+    families: Dict[str, Tuple[str, Set[str]]] = {}
+    for b in benchmarks:
+        _parent, family_ids, family_names = resolve_benchmark_family(client, b)
+        families[b] = (family_ids, family_names)
+
+    # Pull recent candidates.
+    recent = get_recent_models(client, cutoff, args.size, args.include, args.exclude)
+    if not recent:
+        print(
+            f"No models found with creation_time >= {cutoff.isoformat()} "
+            f"(size={args.size}, includes={args.include}, excludes={args.exclude}).",
+            file=sys.stderr,
+        )
+        return
+
+    # Per-benchmark evaled sets.
+    evaled_by_bench: Dict[str, Set[str]] = {}
+    for b, (family_ids, _names) in families.items():
+        evaled_by_bench[b] = get_evaled_for_family(client, family_ids)
+
+    # Build status matrix: rows = models, cols = benchmarks.
+    rows = []
+    for m in sorted(recent, key=lambda x: x.get("creation_time") or ""):
+        statuses = {b: (m["id"] in evaled_by_bench[b]) for b in benchmarks}
+        rows.append((m, statuses))
+
+    # Print summary.
+    print(
+        f"Recent models (creation_time >= {cutoff.date().isoformat()} UTC, "
+        f"size={args.size}B, n={len(rows)}):",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+    print(f"  {'created':<10} {'name':<70} " + " ".join(f"{b[:18]:<18}" for b in benchmarks))
+    print(f"  {'-' * 10} {'-' * 70} " + " ".join(f"{'-' * 18:<18}" for b in benchmarks))
+    for m, statuses in rows:
+        created = (m.get("creation_time") or "")[:10]
+        cells = " ".join(
+            f"{('✓ evaled' if statuses[b] else '✗ MISSING'):<18}" for b in benchmarks
+        )
+        print(f"  {created:<10} {m['name']:<70} {cells}")
+
+    # Per-benchmark unevaled priority lists.
+    if args.output_dir:
+        out_dir = Path(args.output_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for b in benchmarks:
+            missing = sorted(m["name"] for m, st in rows if not st[b])
+            path = out_dir / f"uneval_{sanitize(b)}_{args.size}b_{args.max_age_days}d.txt"
+            path.write_text("\n".join(missing) + ("\n" if missing else ""))
+            print(f"\nWrote {len(missing)} models to {path}", file=sys.stderr)
+
+    # Combined "needs any benchmark" list.
+    if args.output_dir:
+        any_missing = sorted(
+            {m["name"] for m, st in rows if not all(st.values())}
+        )
+        path = Path(args.output_dir) / f"uneval_any_{args.size}b_{args.max_age_days}d.txt"
+        path.write_text("\n".join(any_missing) + ("\n" if any_missing else ""))
+        print(f"Wrote {len(any_missing)} models to {path}", file=sys.stderr)
+
+    # Optional: dump full blacklist (all evaled models per benchmark, regardless of age).
+    if args.blacklist_output_dir:
+        bl_dir = Path(args.blacklist_output_dir)
+        bl_dir.mkdir(parents=True, exist_ok=True)
+        # We need names for evaled ids, so map ids back via the models table.
+        all_models = {
+            m["id"]: m["name"]
+            for m in client.table("models").select("id,name").execute().data
+            if m.get("name")
+        }
+        for b in benchmarks:
+            evaled_names = sorted(
+                all_models[mid] for mid in evaled_by_bench[b] if mid in all_models
+            )
+            path = bl_dir / f"blacklist_{sanitize(b)}.txt"
+            path.write_text("\n".join(evaled_names) + ("\n" if evaled_names else ""))
+            print(
+                f"Wrote {len(evaled_names)} evaled models to {path} (blacklist)",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/manual_db_eval_push.py
+++ b/scripts/database/manual_db_eval_push.py
@@ -15,7 +15,7 @@ Usage (from OpenThoughts-Agent/):
     # With explicit HuggingFace repo
     python scripts/database/manual_db_eval_push.py \\
         --job-dir trace_jobs/my-eval-job \\
-        --hf-repo DCAgent2/my-eval-traces
+        --hf-repo DCAgent3/my-eval-traces
 
     # Skip HF upload (database only)
     python scripts/database/manual_db_eval_push.py \\
@@ -84,7 +84,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--hf-repo",
         default=None,
-        help="HuggingFace repo ID (e.g., DCAgent2/my-traces). Default: auto-derived from job name.",
+        help="HuggingFace repo ID (e.g., DCAgent3/my-traces). Default: auto-derived from job name.",
     )
     parser.add_argument(
         "--hf-private",
@@ -207,7 +207,7 @@ def derive_benchmark_name(job_dir: Path) -> str:
     return derive_benchmark_from_job_dir(job_dir)
 
 
-def derive_hf_repo_id(job_name: str, org: str = "DCAgent2") -> str:
+def derive_hf_repo_id(job_name: str, org: str = "DCAgent3") -> str:
     """Derive HuggingFace repo ID from job name.
 
     Note: Sanitization happens in launch_utils.sync_eval_to_database().

--- a/scripts/database/upload_overlong_jobs.py
+++ b/scripts/database/upload_overlong_jobs.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Detect and upload overlong eval jobs (hit SLURM 24h time limit).
+
+Scans a jobs directory for incomplete runs that elapsed >20h, checks if the
+model/benchmark pair already has a Finished record in Supabase, and uploads
+missing ones with is_overlong=true.
+
+Usage:
+    # Dry run (default) — show what would be uploaded
+    python scripts/database/upload_overlong_jobs.py
+
+    # Actually upload
+    python scripts/database/upload_overlong_jobs.py --upload
+
+    # Filter to specific benchmark
+    python scripts/database/upload_overlong_jobs.py --upload --benchmark terminal_bench_2
+
+    # Custom jobs dir
+    python scripts/database/upload_overlong_jobs.py --upload --jobs-dir /path/to/jobs
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[2]
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+_db_path = _repo_root / "database" / "unified_db"
+if str(_db_path) not in sys.path:
+    sys.path.insert(0, str(_db_path))
+
+DEFAULT_JOBS_DIR = _repo_root / "jobs"
+
+
+def parse_iso(ts_str):
+    if not ts_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def detect_overlong_jobs(jobs_dir, min_elapsed_h=20, benchmark_filter=None):
+    """Find jobs that timed out (no finished_at, elapsed > min_elapsed_h)."""
+    results = []
+    jobs_dir = Path(jobs_dir)
+
+    for entry in sorted(jobs_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        rf = entry / "result.json"
+        if not rf.exists():
+            continue
+        try:
+            d = json.load(open(rf))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if d.get("finished_at") is not None:
+            continue
+        n_total = d.get("n_total_trials", 0)
+        n_trials = d.get("stats", {}).get("n_trials", 0)
+        if n_trials == 0:
+            continue
+
+        started = parse_iso(d.get("started_at"))
+        if not started:
+            continue
+
+        # Find latest trial finish time
+        latest = None
+        for te in entry.iterdir():
+            if not te.is_dir() or "__" not in te.name:
+                continue
+            tr = te / "result.json"
+            if tr.exists():
+                try:
+                    td = json.load(open(tr))
+                    fa = td.get("finished_at")
+                    if fa:
+                        ft = parse_iso(fa)
+                        if ft and (latest is None or ft > latest):
+                            latest = ft
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+        if latest is None:
+            continue
+        elapsed_h = (latest - started).total_seconds() / 3600
+        if elapsed_h < min_elapsed_h:
+            continue
+
+        # Parse model from meta.env
+        model = None
+        meta_env = entry / "meta.env"
+        if meta_env.exists():
+            with open(meta_env) as f:
+                for line in f:
+                    if line.startswith("MODEL="):
+                        model = line.strip().split("=", 1)[1]
+                        break
+
+        # Derive benchmark from trial source field
+        benchmark = None
+        for te in sorted(entry.iterdir()):
+            if not te.is_dir() or "__" not in te.name:
+                continue
+            tr = te / "result.json"
+            if tr.exists():
+                try:
+                    td = json.load(open(tr))
+                    source = td.get("source", "")
+                    if source:
+                        for org_prefix in ["DCAgent2_", "DCAgent_"]:
+                            if source.startswith(org_prefix):
+                                source = source[len(org_prefix):]
+                                break
+                        benchmark = source
+                    break
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+        # Fallback: infer from dir name
+        if not benchmark:
+            dirname = entry.name
+            for prefix in ["swebench_verified_random_100_folders", "terminal_bench_2",
+                           "dev_set_v2", "bfcl"]:
+                if dirname.startswith(prefix):
+                    benchmark = prefix
+                    break
+
+        if not model:
+            dirname = entry.name
+            for prefix in ["swebench_verified_random_100_folders_", "terminal_bench_2_",
+                           "dev_set_v2_", "bfcl_"]:
+                if dirname.startswith(prefix):
+                    rest = dirname[len(prefix):]
+                    parts = rest.rsplit("_", 2)
+                    if len(parts) >= 3 and len(parts[-1]) == 6 and len(parts[-2]) == 8:
+                        model = "_".join(parts[:-2])
+                    break
+
+        if benchmark_filter and benchmark_filter.lower() not in (benchmark or "").lower():
+            continue
+
+        # Extract accuracy
+        accuracy = None
+        for eval_data in d.get("stats", {}).get("evals", {}).values():
+            metrics = eval_data.get("metrics", [])
+            if metrics and isinstance(metrics, list):
+                mr = metrics[0].get("mean_reward")
+                if mr is not None:
+                    accuracy = mr
+
+        results.append({
+            "dir": entry,
+            "model": model or entry.name,
+            "model_short": (model.split("/")[-1] if model and "/" in model else model) or entry.name,
+            "benchmark": benchmark or "unknown",
+            "n_trials": n_trials,
+            "n_total": n_total,
+            "elapsed_h": elapsed_h,
+            "accuracy": accuracy,
+        })
+
+    # Deduplicate: same model+benchmark, keep best progress
+    seen = {}
+    for r in results:
+        key = (r["model"], r["benchmark"])
+        if key not in seen or r["n_trials"] > seen[key]["n_trials"]:
+            seen[key] = r
+    return sorted(seen.values(), key=lambda r: (r["benchmark"], r["model"]))
+
+
+def check_db_exists(model_name, benchmark_name):
+    """Check if model/benchmark pair already has a Finished job in DB."""
+    try:
+        from unified_db.utils import get_model_by_name, get_benchmark_by_name, get_supabase_client
+
+        model = get_model_by_name(model_name)
+        if not model:
+            return False, None
+
+        benchmark = get_benchmark_by_name(benchmark_name)
+        if not benchmark:
+            return False, None
+
+        client = get_supabase_client()
+        resp = (
+            client.table("sandbox_jobs")
+            .select("id,job_status,is_overlong")
+            .eq("model_id", model["id"])
+            .eq("benchmark_id", benchmark["id"])
+            .eq("job_status", "Finished")
+            .limit(1)
+            .execute()
+        )
+
+        if resp.data:
+            return True, resp.data[0]
+        return False, None
+    except Exception as e:
+        print(f"  [warn] DB check failed for {model_name}/{benchmark_name}: {e}")
+        return False, None
+
+
+def derive_hf_repo_id(job_dir):
+    """Derive HF repo ID from job directory name."""
+    name = Path(job_dir).name
+    sanitized = name.replace("@", "-").replace(" ", "-")
+    return f"DCAgent2/{sanitized}-traces"
+
+
+def upload_job(job_dir, benchmark_name, skip_hf=False):
+    """Upload a single overlong job."""
+    from hpc.launch_utils import sync_eval_to_database
+
+    hf_repo_id = None if skip_hf else derive_hf_repo_id(job_dir)
+
+    result = sync_eval_to_database(
+        job_dir=job_dir,
+        error_mode="skip_on_error",
+        benchmark_name=benchmark_name,
+        register_benchmark=True,
+        forced_update=True,
+        is_overlong=True,
+        hf_repo_id=hf_repo_id,
+        hf_token=os.environ.get("HF_TOKEN"),
+    )
+    return result
+
+
+def _upload_one(args_tuple):
+    """Worker function for parallel uploads."""
+    r, skip_hf = args_tuple
+    label = f"{r['model_short']} / {r['benchmark']}"
+    try:
+        result = upload_job(r["dir"], r["benchmark"], skip_hf=skip_hf)
+        if result.get("success"):
+            job_id = result.get("job_id")
+            n_trials = result.get("n_trials_uploaded", 0)
+            hf_url = result.get("hf_dataset_url", "n/a")
+            return True, label, f"job_id={job_id}, trials={n_trials}, hf={hf_url}"
+        else:
+            return False, label, result.get("error", "unknown")
+    except Exception as e:
+        return False, label, str(e)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect and upload overlong eval jobs")
+    parser.add_argument("--jobs-dir", type=Path, default=DEFAULT_JOBS_DIR)
+    parser.add_argument("--upload", action="store_true", help="Actually upload (default: dry run)")
+    parser.add_argument("--benchmark", "-b", type=str, default=None, help="Filter by benchmark")
+    parser.add_argument("--min-elapsed", type=float, default=20, help="Min elapsed hours to consider overlong")
+    parser.add_argument("--skip-db-check", action="store_true", help="Skip checking DB for existing records")
+    parser.add_argument("--skip-hf", action="store_true", help="Skip HuggingFace upload (DB only)")
+    parser.add_argument("--force", action="store_true", help="Override quality gates")
+    parser.add_argument("--parallel", "-p", type=int, default=1, help="Number of parallel upload workers (default: 1)")
+    args = parser.parse_args()
+
+    if args.force:
+        os.environ["EVAL_UPLOAD_FORCE"] = "1"
+
+    print(f"Scanning {args.jobs_dir} for overlong jobs (>{args.min_elapsed}h elapsed, incomplete)...")
+    overlong = detect_overlong_jobs(args.jobs_dir, args.min_elapsed, args.benchmark)
+    print(f"Found {len(overlong)} overlong model/benchmark pairs\n")
+
+    if not overlong:
+        return
+
+    # Display table
+    print(f"{'Model':<55} {'Benchmark':<20} {'Progress':>12} {'Elapsed':>8} {'Accuracy':>8} {'Action':>10}")
+    print("-" * 120)
+
+    to_upload = []
+    for r in overlong:
+        acc_str = f"{r['accuracy']:.1%}" if r['accuracy'] is not None else "N/A"
+        progress = f"{r['n_trials']}/{r['n_total']}"
+
+        if not args.skip_db_check:
+            exists, existing = check_db_exists(r["model"], r["benchmark"])
+            if exists:
+                is_ol = existing.get("is_overlong", False) if existing else False
+                action = "skip (exists" + (", overlong" if is_ol else "") + ")"
+            else:
+                action = "UPLOAD" if args.upload else "would upload"
+                to_upload.append(r)
+        else:
+            action = "UPLOAD" if args.upload else "would upload"
+            to_upload.append(r)
+
+        print(f"{r['model_short']:<55} {r['benchmark']:<20} {progress:>12} {r['elapsed_h']:>6.1f}h {acc_str:>8} {action:>10}")
+
+    print(f"\n{len(to_upload)} jobs to upload, {len(overlong) - len(to_upload)} already in DB")
+
+    if not args.upload:
+        print("\nDry run — pass --upload to actually upload.")
+        return
+
+    if not to_upload:
+        print("\nNothing to upload.")
+        return
+
+    n_workers = min(args.parallel, len(to_upload))
+    hf_label = "skip" if args.skip_hf else "enabled"
+    print(f"\nUploading {len(to_upload)} overlong jobs (workers={n_workers}, hf={hf_label})...\n")
+
+    if n_workers <= 1:
+        # Sequential
+        success = 0
+        failed = 0
+        for r in to_upload:
+            ok, label, msg = _upload_one((r, args.skip_hf))
+            status = "OK" if ok else "FAILED"
+            print(f"  [{status}] {label}: {msg}")
+            if ok:
+                success += 1
+            else:
+                failed += 1
+    else:
+        # Parallel
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        success = 0
+        failed = 0
+        work = [(r, args.skip_hf) for r in to_upload]
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            futures = {pool.submit(_upload_one, w): w[0]["model_short"] for w in work}
+            for future in as_completed(futures):
+                ok, label, msg = future.result()
+                status = "OK" if ok else "FAILED"
+                print(f"  [{status}] {label}: {msg}")
+                if ok:
+                    success += 1
+                else:
+                    failed += 1
+
+    print(f"\nDone: {success} uploaded, {failed} failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/database/upload_overlong_jobs.py
+++ b/scripts/database/upload_overlong_jobs.py
@@ -37,6 +37,34 @@ if str(_db_path) not in sys.path:
 DEFAULT_JOBS_DIR = _repo_root / "jobs"
 
 
+def _preset_dataset_prefixes():
+    """Run-tag prefixes derived from the listener's PRESETS dict.
+
+    Run dirs are named ``<safe-dataset>_<safe-model>_<date>_<time>`` where the
+    safe-dataset name is the last path segment of the HF dataset id with
+    ``-`` -> ``_``. Reading PRESETS keeps this list in sync as new presets
+    are added (instead of a hardcoded list that drifts).
+    """
+    try:
+        from eval.unified_eval_listener import PRESETS
+    except Exception:  # listener importable in any env that ships the repo
+        return []
+
+    seen = []
+    for cfg in PRESETS.values():
+        # PRESETS uses 'datasets' (plural list); fall back to 'dataset' for safety.
+        datasets = cfg.get("datasets") or ([cfg["dataset"]] if cfg.get("dataset") else [])
+        for ds in datasets:
+            short = ds.split("/", 1)[-1] if "/" in ds else ds
+            short = short.replace("-", "_")
+            if short and short not in seen:
+                seen.append(short)
+    return seen
+
+
+_PRESET_PREFIXES = _preset_dataset_prefixes()
+
+
 def parse_iso(ts_str):
     if not ts_str:
         return None
@@ -129,21 +157,24 @@ def detect_overlong_jobs(jobs_dir, min_elapsed_h=20, benchmark_filter=None):
                 except (json.JSONDecodeError, OSError):
                     pass
 
-        # Fallback: infer from dir name
+        # Fallback: infer from dir name. The prefix list comes from the
+        # listener's PRESETS dict, so any new preset auto-stays-in-sync.
+        # Match longest first so e.g. "swebench_verified_random_100_folders"
+        # wins over a shorter conflicting prefix.
+        prefixes_long_first = sorted(_PRESET_PREFIXES, key=len, reverse=True)
         if not benchmark:
             dirname = entry.name
-            for prefix in ["swebench_verified_random_100_folders", "terminal_bench_2",
-                           "dev_set_v2", "bfcl"]:
+            for prefix in prefixes_long_first:
                 if dirname.startswith(prefix):
                     benchmark = prefix
                     break
 
         if not model:
             dirname = entry.name
-            for prefix in ["swebench_verified_random_100_folders_", "terminal_bench_2_",
-                           "dev_set_v2_", "bfcl_"]:
-                if dirname.startswith(prefix):
-                    rest = dirname[len(prefix):]
+            for prefix in prefixes_long_first:
+                token = prefix + "_"
+                if dirname.startswith(token):
+                    rest = dirname[len(token):]
                     parts = rest.rsplit("_", 2)
                     if len(parts) >= 3 and len(parts[-1]) == 6 and len(parts[-2]) == 8:
                         model = "_".join(parts[:-2])


### PR DESCRIPTION
## Summary

Adds the listener-driven eval pipeline used for terminus-2 reg eval (`v2 / swebench / tb2`), OOD presets (`aider / bfcl / medagentbench / gaia / financeagent / swebench_full`), and preferred-harness installed-agent reproductions (swe-agent / openhands / mini-swe-agent / aider). A user can now fire (model × dataset × scaffold) eval jobs against a SLURM cluster with vLLM-served models and harbor-fix as the agent runtime, **and diagnose failures using the catalog and tools shipped with the PR**.

8 commits, 26 files, +8767 / -4.

## What's in

- **Listener trio** (Commit 1) — `eval/unified_eval_listener.py` + `unified_eval_harbor.sbatch` + `build_vllm_cmd.sh`. Adds `--config-yaml`, Pinggy plumbing, sliding-window batches, a per-listener job cap, and `${DCFT}` expansion of baseline-yaml `extra_args` so absolute-path footguns become portable.
- **Configs** (Commit 2) — `baseline_model_configs_minimal.yaml` (single source of truth for per-model vLLM serving overrides) + 6 scaffold-specific Harbor configs + Pattern C assets (`nano_v3_reasoning_parser.py`, `nemotron_chat_template.jinja`).
- **Cluster template** (Commit 3) — `eval/clusters/example.yaml` + `hpc/dotenv/example.env`. Documented placeholders, no real cluster paths or secrets.
- **Helpers** (Commit 4) — `eval/check_progress.py` upgrade: multi-log-dir search + OOD section.
- **DB recovery** (Commit 5) — `scripts/database/upload_overlong_jobs.py` for SLURM-TIMEOUT'd runs.
- **Docs** (Commits 6, 8) — `eval/README.md` + `eval/EVAL_GUIDE.md` (cluster-diagnostic spine, 30-mode failure-modes catalog, Pattern A/B/C/D table, Pinggy management with cross-cluster collision check, monitoring + n≥150 trust threshold) + `eval/docs/PREFERRED_HARNESS_REPRODUCTION.md` (per-model recipe lookup) + `eval/lists/README.md` + `eval/envs/{otagent-fix,otagent2-fix}.yml` + `eval/envs/README.md` (pins harbor-fix to `9980f967` on `penfever/temp-override`, lists the patches the branch carries, documents 3 uncommitted installed-agent patches Cat 3 fires need).
- **Example list** (Commit 7) — `eval/lists/EXAMPLE.txt` showing priority-file format.

## What's not in

- Training (SFT/RL) infra — orthogonal.
- Harbor source changes — those live in `harbor-fix`; this PR pins the commit and documents the patches.
- Daily fire history, ablation experiments, personal priority lists, session-internal docs — distilled into `EVAL_GUIDE.md` + PHR instead of shipping `eval/.local_notes/`.
- `eval/health_check.py` — modified in working tree but defer to follow-up cleanup PR.
- `eval/legacy/` — unchanged in this PR; cleanup is independent concern.

## Test plan

- [x] All YAMLs lint-parse (`yaml.safe_load`).
- [x] All bash files pass `bash -n`.
- [x] All Python files parse via `ast.parse`.
- [x] Listener `--help` exposes `--config-yaml`, `--pinggy-url`, `--pinggy-token`, `--batch-size`, `--max-jobs-submitted`, `--no-auto-snapshot`, `--agent-parser`, `--force-reeval`, `--vllm-max-retries`, `--cluster-config`.
- [x] No `/lustrefs/...` paths in `baseline_model_configs_minimal.yaml`; 2 `${DCFT}` hits on the Nemotron-Nano line. `os.path.expandvars` sanity test confirms expansion.
- [x] Diff vs `origin/main` clean: no `RUNNING_JOBS`, no `listener-m1`/`pr-overleaf` session names, no JID numbers, no cluster-specific paths, no secrets (`dtn_*`, `hf_*`, `sk-*`).
- [x] Cat 1 dry-run for `Qwen/Qwen3-32B` (`--dry-run`) submits with the correct Pattern B config (`hermes` + `qwen3` parsers from `baseline_model_configs_minimal.yaml`).
- [ ] **Reviewer**: real-fire smoke for `Qwen/Qwen3-32B` on `swebench` preset on a fresh checkout — confirm RUNNING within 30 s, vLLM warm within 15 min, first trial completes.
- [ ] **Reviewer**: Cat 3 smoke for `SWE-bench/SWE-agent-LM-7B` on Pattern B + swe-agent regular — confirm Pinggy URL appears in slurm log + first trial completes without `FunctionCallingFormatError` storm.

## Open questions for the reviewer

1. **DB scripts scope** — both `manual_db_eval_push.py` (already on main) and `upload_overlong_jobs.py` (new) are recovery-time tools. Recommended: keep both.
2. **`eval/health_check.py`** — defer to follow-up cleanup PR. Recommended: yes, defer.
3. **Legacy cleanup** — `eval/legacy/{miniswe,openhands_*,swe_*,unified_eval_harbor_v4,unified_eval_listener_v4}.{sbatch,py}` — independent concern. Recommended: follow-up PR.
4. **Multi-cluster docs** — only `eval/clusters/example.yaml` template, or also cluster-shape variants (8×H200, 4×A100, etc.)? Recommended: one generic template; cluster-shape variants can be added by contributors who use those shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)