### PR TITLE
eval: fix Cat-3 (swe-agent) resume — Pinggy tunnel + tunnel-env export (G18/G18b)

### DIFF
--- a/eval/check_progress.py
+++ b/eval/check_progress.py
@@ -152,8 +152,16 @@ def parse_eval_log(jid, job_name, all_log_dirs=None, max_lines=2000):
                     break
                 if line.startswith("Model: "):
                     model = line.strip()[7:]
+                # API-mode sbatch banner uses "Model (DB-name): <unprefixed>"
+                # (preferred for display since it matches the registered DB
+                # name) plus "Model (LiteLLM): <prefixed>" as a sibling. Prefer
+                # the DB-name line; fall back to LiteLLM if it shows up first.
+                elif line.startswith("Model (DB-name): "):
+                    model = line.strip()[len("Model (DB-name): "):].strip()
+                elif line.startswith("Model (LiteLLM): ") and model is None:
+                    model = line.strip()[len("Model (LiteLLM): "):].strip()
                 elif line.startswith("Dataset: "):
-                    bench = line.strip()[9:]
+                    bench = line.strip()[len("Dataset: "):].strip()
                 elif line.startswith("Run tag: "):
                     run_tag = line.strip()[9:]
                 elif line.startswith("N concurrent: "):
@@ -164,6 +172,13 @@ def parse_eval_log(jid, job_name, all_log_dirs=None, max_lines=2000):
                 elif line.startswith("Timeout multiplier: "):
                     try:
                         timeout_mult = float(line.strip()[20:])
+                    except ValueError:
+                        pass
+                # API-mode sbatch uses the shorter label "Timeout multi: " for
+                # banner alignment. Same numeric value.
+                elif line.startswith("Timeout multi: "):
+                    try:
+                        timeout_mult = float(line.strip()[len("Timeout multi: "):].strip())
                     except ValueError:
                         pass
                 elif "total shards)" in line:
@@ -323,27 +338,40 @@ def collect_job_data(jobs_dir):
     # this resume continues from). A run dir gets one log per fire (original +
     # each resume); we sort numerically so the highest JID < current is the
     # immediate predecessor.
+    # Reading the run tag out of every historical slurm log is pure I/O on a
+    # network filesystem and dominates wall time (thousands of logs accumulate).
+    # Each read is independent, so fan them out over a thread pool — same as the
+    # per-job work below — then assemble the dict from the results.
     fire_index: dict[str, list[str]] = {}
-    for log_dir in all_log_dirs:
-        if not log_dir.is_dir():
-            continue
-        for f in log_dir.glob("data_*.out"):
-            try:
-                fjid = f.stem.split("_", 1)[1]
-            except IndexError:
-                continue
-            try:
-                with open(f, "r", errors="replace") as fh:
-                    for i, line in enumerate(fh):
-                        if i > 200:
-                            break
-                        if line.startswith("Run tag: "):
-                            rt = line[len("Run tag: "):].strip()
-                            if rt:
-                                fire_index.setdefault(rt, []).append(fjid)
-                            break
-            except (OSError, IOError):
-                continue
+    fire_log_files = [
+        f for log_dir in all_log_dirs if log_dir.is_dir()
+        for f in log_dir.glob("data_*.out")
+    ]
+
+    def _read_fire_tag(f):
+        try:
+            fjid = f.stem.split("_", 1)[1]
+        except IndexError:
+            return None
+        try:
+            with open(f, "r", errors="replace") as fh:
+                for i, line in enumerate(fh):
+                    if i > 200:
+                        break
+                    if line.startswith("Run tag: "):
+                        rt = line[len("Run tag: "):].strip()
+                        return (rt, fjid) if rt else None
+        except (OSError, IOError):
+            return None
+        return None
+
+    if fire_log_files:
+        fi_workers = min(32, max(4, len(fire_log_files)))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=fi_workers) as fi_exec:
+            for res in fi_exec.map(_read_fire_tag, fire_log_files):
+                if res is not None:
+                    rt, fjid = res
+                    fire_index.setdefault(rt, []).append(fjid)
 
     def process_one(job):
         jid, name, state, start_time = job

--- a/eval/configs/baseline_model_configs_minimal.yaml
+++ b/eval/configs/baseline_model_configs_minimal.yaml
@@ -210,6 +210,67 @@ models:
     tool_call_parser: hermes
     extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
 
+  # ethanlshen Qwen3-32B SERA reproductions — Pattern A paper-parity flags
+  # (mirror allenai/SERA-32B: hermes + enforce-eager + disable-cascade-attn + seed 42).
+  # Size ladder: 316, 1000, 3160 (converted from broken FSDP upload), 10000 rows.
+  "ethanlshen/Qwen3-32B-316_sera_46_47000":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  "ethanlshen/Qwen3-32B-1000_sera_46_47000":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  "ethanlshen/Qwen3-32B-3160_sera_46_47000-converted":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  "ethanlshen/Qwen3-32B-10000_sera_46_47000":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  "ethanlshen/Qwen3-32B-31600_sera_46_47000_converted":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  # ethanlshen Qwen3-32B-47000-46 — SERA Pattern A (mirror 31600/SERA-32B).
+  "ethanlshen/Qwen3-32B-47000-46":
+    tensor_parallel_size: 2
+    max_model_len: 32768
+    swap_space: 32
+    trust_remote_code: true
+    tool_call_parser: hermes
+    extra_args: "--enforce-eager --disable-cascade-attn --seed 42"
+
+  # GLM-4_7 swesmith 131k-fixthink 8B — model name contains "131k" which triggers
+  # the generic `131k|-lc$` pattern → yarn rope_scaling factor 4.0 = 131k context.
+  # User requested REGULAR 32k config (not 131k). Exact-match overrides the pattern.
+  "laion/GLM-4_7-swesmith-sandboxes-with_tests-oracle_verified_120s-maxeps-131k-fixthink":
+    tensor_parallel_size: 1
+    max_model_len: 32768
+    swap_space: 32
+    extra_args: "--enable-prefix-caching"
+
   # SWE-bench/SWE-agent-LM-32B — trained for swe-agent scaffold, needs hermes parser.
   "SWE-bench/SWE-agent-LM-32B":
     tensor_parallel_size: 2
@@ -234,6 +295,39 @@ models:
     swap_space: 32
     trust_remote_code: true
     extra_args: "--enable-prefix-caching"
+
+  # QuantTrio/GLM-4.{6,7}-AWQ — 358B Glm4MoeForCausalLM AWQ INT4
+  # (~180 GB weights). Same arch family as zai-org/GLM-4.7-FP8 (see
+  # eval/.local_notes/GLM_4_7_FP8_PROCEDURE.md). Fits TP=4 on a single Jupiter
+  # GH200 node (4×96=384 GB). Pattern D for terminus-2 reg eval — NO
+  # tool_call_parser, NO reasoning_parser (both hijack the plain-JSON output
+  # the terminus-2 agent parses client-side; vendor glm47/glm45/deepseek_v3
+  # parsers are for native-tool / openhands scaffolds, not terminus-2).
+  # NB: vLLM 0.17.1 in otagent2-fix had a deterministic q_norm CUDA crash on
+  # swebench-length prompts for the FP8 variant (project_glm47_fp8_qnorm_crash);
+  # AWQ may inherit. Smoke v2 + tb2 before swebench.
+  # max_num_seqs sized to comfortably hold listener --n-concurrent 32 without
+  # waiting (52 for 4.7, 64 for 4.6 per vendor/guha1 spec).
+  "QuantTrio/GLM-4.6-AWQ":
+    conda_env: otagent2-fix
+    tensor_parallel_size: 4
+    max_model_len: 32768
+    swap_space: 8
+    trust_remote_code: true
+    extra_args: "--enable-expert-parallel --enable-prefix-caching --enable-chunked-prefill --max-num-seqs 64 --max-num-batched-tokens 32768 --dtype bfloat16 --kv-cache-dtype fp8"
+
+  # NB: 504964 (fp16 KV) saturated at 32 concurrent trials (Waiting 1-7, KV
+  # 95-100%). Switching default to fp8 KV (matches 4.6 entry above) to halve
+  # per-token KV and roughly double effective cache. vLLM 0.17.1 requires
+  # --dtype bfloat16 when kv_cache_dtype=fp8 (FP16 activations + FP8 KV is an
+  # unsupported combination — 505124 died at engine init with this error).
+  "QuantTrio/GLM-4.7-AWQ":
+    conda_env: otagent2-fix
+    tensor_parallel_size: 4
+    max_model_len: 32768
+    swap_space: 4
+    trust_remote_code: true
+    extra_args: "--enable-expert-parallel --enable-prefix-caching --enable-chunked-prefill --max-num-seqs 52 --max-num-batched-tokens 32768 --dtype bfloat16 --kv-cache-dtype fp8"
 
   # Lite-Coder/LiteCoder-Terminal-30b-a3b-sft — 30B MoE (3B active), SFT for
   # terminus scaffold. Pattern D — do NOT add tool_call_parser or

--- a/eval/configs/dcagent_eval_config_swe_agent.yaml
+++ b/eval/configs/dcagent_eval_config_swe_agent.yaml
@@ -14,13 +14,18 @@ orchestrator:
   retry:
     max_retries: 10
     exclude_exceptions:
-      - AgentTimeoutError
-      - AgentEnvironmentTimeoutError
-      - BadRequestError
+      # Aligned to the M1 parity run 7d05ffbf (2026-04-22, SERA-32B 48.67%).
+      # That run RETRIED ContextLengthExceededError / BadRequestError /
+      # AgentEnvironmentTimeoutError (they are NOT terminal here) — important for
+      # long-output SERA checkpoints (e.g. 47K overflowing 32k context, then
+      # recovering on retry). The later wrapup snapshot had drifted to make these
+      # terminal, which suppressed scores vs the parity run.
       - VerifierTimeoutError
-      - SummarizationTimeout
       - SummarizationTimeoutError
-      - ContextLengthExceededError
+      - AgentTimeoutError
+      - VerifierOutputParseError
+      - RewardFileEmptyError
+      - RewardFileNotFoundError
     wait_multiplier: 1.0
     min_wait_sec: 1.0
     max_wait_sec: 60.0

--- a/eval/resume_chunked.py
+++ b/eval/resume_chunked.py
@@ -133,6 +133,19 @@ def build_listener_argv(
         cmd += ["--resume-error-threshold", str(args.resume_error_threshold)]
     if args.enable_thinking:
         cmd.append("--enable-thinking")
+    # Cat 3 (preferred-harness reproduction): pass through Pinggy URL/token so the
+    # sbatch opens a tunnel and the unified_eval_harbor.sbatch resume sed-patch
+    # can rewrite the dir's config.json from the (dead) old Pinggy URL to this
+    # new one. Each fire needs its own free pair. resume_chunked.py is single-
+    # pair per invocation; for multi-model batches, fire one chunk per pair.
+    if args.pinggy_url:
+        cmd += ["--pinggy-url", args.pinggy_url]
+    if args.pinggy_token:
+        cmd += ["--pinggy-token", args.pinggy_token]
+    if args.config_yaml:
+        cmd += ["--config-yaml", args.config_yaml]
+    if args.agent_parser is not None:
+        cmd += ["--agent-parser", args.agent_parser]
     return cmd
 
 
@@ -225,6 +238,20 @@ def main() -> int:
                          "inspector's slurm-log-based --max-total-fires filter). Default: 1, "
                          "meaning the listener will also refuse to resume a dir whose meta.env "
                          "shows >= 1 prior resume completed. Bump if you raised --max-total-fires."))
+    p.add_argument("--pinggy-url", default=None,
+                   help=("Cat 3 only. Pinggy URL (e.g. dadccqeqqf.a.pinggy.link) for the "
+                         "tunnel back to the served model. Pair with --pinggy-token. The "
+                         "sbatch will sed-rewrite the existing dir's config.json's stale "
+                         "Pinggy URL to this one. Single pair per orchestrator invocation; "
+                         "for multi-model resumes, fire one invocation per (model, pair)."))
+    p.add_argument("--pinggy-token", default=None,
+                   help="Cat 3 only. Pinggy auth token, paired with --pinggy-url.")
+    p.add_argument("--config-yaml", default=None,
+                   help=("Cat 3 only. Harbor config YAML (e.g. dcagent_eval_config_swe_agent.yaml). "
+                         "Listener passes this to the sbatch for scaffold/parser selection."))
+    p.add_argument("--agent-parser", default=None,
+                   help=("Cat 3 only. Agent parser override (typically empty string '' for "
+                         "swe-agent which doesn't use a parser). Empty string = disable parser."))
     p.add_argument("--resume-error-threshold", type=int, default=None,
                    help=("Listener-side --resume-error-threshold passthrough. When omitted, the "
                          "listener uses its own default (10). Pass -1 to enable resuming "

--- a/eval/unified_eval_harbor.sbatch
+++ b/eval/unified_eval_harbor.sbatch
@@ -441,13 +441,22 @@ unset -v VLLM_PORT_ENV  # ensure no VLLM_PORT env var leaks to subprocesses
 echo "Physical GPUs: $_PHYSICAL_GPUS (CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES), vLLM port: $VLLM_PORT"
 
 # Pre-download model via proxychains (compute nodes have no direct internet)
+# Try offline-resolve first (cache may be read-only for current user when the
+# HF Hub HEAD has advanced past the cached snapshot — fetching a new snapshot
+# into a foreign-owned cache dir fails with PermissionError). Only fall back
+# to online download if the model isn't already cached.
 echo "Pre-downloading model: $MODEL"
 proxied $PYTHON_BIN -c "
 from huggingface_hub import snapshot_download
-import os
+import os, sys
 cache = os.environ.get('HF_HUB_CACHE')
-path = snapshot_download('$MODEL', cache_dir=cache)
-print(f'Model cached at: {path}')
+try:
+    path = snapshot_download('$MODEL', cache_dir=cache, local_files_only=True)
+    print(f'Model cached at (offline): {path}')
+except Exception as e:
+    print(f'Offline resolve failed ({type(e).__name__}: {e}); attempting online fetch...', flush=True)
+    path = snapshot_download('$MODEL', cache_dir=cache)
+    print(f'Model cached at (online): {path}')
 "
 if [ $? -ne 0 ]; then
     echo "ERROR: Model pre-download failed for $MODEL. Exiting."
@@ -849,6 +858,62 @@ if [ "${EVAL_FORCE_FRESH:-false}" != "true" ] && [ -d "$EXISTING_JOB_DIR" ] && [
         find "$EXISTING_JOB_DIR" -mindepth 2 -maxdepth 2 -name config.json -print0 2>/dev/null | \
             xargs -0 -r sed -i.bak-port "s|\"api_base\": \"http://localhost:[0-9]\+/|\"api_base\": \"http://localhost:${VLLM_PORT}/|g"
     fi
+    # Cat 3 resume (Pinggy tunnel): the dir's saved api_base points to the OLD
+    # Pinggy URL from the prior fire (e.g. https://pydpungncw.a.pinggy.link/v1).
+    # That tunnel died with the prior SLURM job. The current fire opens a new
+    # tunnel at $EVAL_PINGGY_URL — rewrite the config.json + per-trial configs
+    # so harbor uses the new URL. If $EVAL_PINGGY_URL matches what's already in
+    # config.json (same pair re-allocated), the sed is a no-op.
+    if [ -n "${EVAL_PINGGY_URL:-}" ]; then
+        echo "Patching api_base Pinggy URL in config.json: -> https://${EVAL_PINGGY_URL}/v1"
+        sed -i.bak-pinggy "s|\"api_base\": \"https://[a-zA-Z0-9]\+\.a\.pinggy\.link/v1\"|\"api_base\": \"https://${EVAL_PINGGY_URL}/v1\"|g" "$EXISTING_JOB_DIR/config.json"
+        if [ "$PATCHED_TRIAL_COUNT" -gt 0 ]; then
+            echo "Patching Pinggy URL in $PATCHED_TRIAL_COUNT per-trial config.json files: -> https://${EVAL_PINGGY_URL}/v1"
+            find "$EXISTING_JOB_DIR" -mindepth 2 -maxdepth 2 -name config.json -print0 2>/dev/null | \
+                xargs -0 -r sed -i.bak-pinggy "s|\"api_base\": \"https://[a-zA-Z0-9]\+\.a\.pinggy\.link/v1\"|\"api_base\": \"https://${EVAL_PINGGY_URL}/v1\"|g"
+        fi
+    fi
+    # --- FIX (G18): Cat-3 installed-agent resume needs the Pinggy tunnel too.
+    # The fresh-fire branch starts the tunnel (see "Tunnel for installed agents"
+    # below), but the resume branch previously only patched the Pinggy URL into
+    # the configs WITHOUT starting a tunnel → swe-agent sandboxes hit
+    # "[Errno 111] Connection refused" on every LLM call → 100% trial failure.
+    # (Confirmed empirically on JIDs 581168/581169/581170, 2026-06-04.)
+    # Gated on EVAL_PINGGY_URL: only Cat-3 installed-agent resumes set it;
+    # terminus-2 resumes leave it empty, so this is a no-op for them.
+    if [ -n "${EVAL_PINGGY_URL:-}" ] && [ -n "${EVAL_PINGGY_TOKEN:-}" ]; then
+        echo "[pinggy] (resume) Starting SSH tunnel to ${EVAL_PINGGY_URL} (port $VLLM_PORT)..."
+        PINGGY_LOG="$EVAL_LOGS_DIR/pinggy_${SLURM_JOB_ID}.log"
+        _PINGGY_PROXY_PREFIX=""
+        if [ -x "$PROXYCHAINS_BIN" ] && [ -n "${PROXYCHAINS_CONF_FILE:-}" ]; then
+            _PINGGY_PROXY_PREFIX="$PROXYCHAINS_BIN -f $PROXYCHAINS_CONF_FILE "
+        fi
+        bash -c "while true; do ${_PINGGY_PROXY_PREFIX}ssh -p 443 \
+            -R0:localhost:${VLLM_PORT} \
+            -o StrictHostKeyChecking=no \
+            -o ServerAliveInterval=30 \
+            -o ExitOnForwardFailure=yes \
+            ${EVAL_PINGGY_TOKEN}@pro.pinggy.io; \
+            sleep 10; done" > "$PINGGY_LOG" 2>&1 &
+        PINGGY_PID=$!
+        echo "[pinggy] (resume) Started with PID $PINGGY_PID"
+        _pinggy_verified=false
+        for _vt in $(seq 1 6); do
+            if proxied curl -sk --connect-timeout 5 "https://${EVAL_PINGGY_URL}/v1/models" 2>/dev/null | grep -q "object"; then
+                echo "[pinggy] (resume) Connectivity verified: https://${EVAL_PINGGY_URL} (attempt $_vt)"
+                _pinggy_verified=true
+                break
+            fi
+            sleep 5
+        done
+        if [ "$_pinggy_verified" = false ]; then
+            echo "[pinggy] (resume) FATAL: connectivity test failed after 6 attempts (30s)."
+            echo "[pinggy] (resume) Installed-agent fires require a working tunnel; refusing to waste compute."
+            tail -20 "$PINGGY_LOG" 2>/dev/null || true
+            cleanup
+            exit 1
+        fi
+    fi
     proxied $HARBOR_BIN jobs resume \
         -p "$EXISTING_JOB_DIR" \
         --filter-error-type EnvironmentStartTimeoutError \
@@ -953,7 +1018,15 @@ print(agents[0].get('name', 'terminus-2') if agents else 'terminus-2')
             echo "[pinggy] Starting SSH tunnel to ${EVAL_PINGGY_URL} (port $VLLM_PORT)..."
             PINGGY_LOG="$EVAL_LOGS_DIR/pinggy_${SLURM_JOB_ID}.log"
 
-            bash -c "while true; do ssh -p 443 \
+            # Build proxychains prefix so the SSH-out can reach pro.pinggy.io
+            # from no-internet compute nodes (Jupiter). On clusters with direct
+            # internet (PROXYCHAINS_BIN empty), this expands to nothing.
+            _PINGGY_PROXY_PREFIX=""
+            if [ -x "$PROXYCHAINS_BIN" ] && [ -n "${PROXYCHAINS_CONF_FILE:-}" ]; then
+                _PINGGY_PROXY_PREFIX="$PROXYCHAINS_BIN -f $PROXYCHAINS_CONF_FILE "
+            fi
+
+            bash -c "while true; do ${_PINGGY_PROXY_PREFIX}ssh -p 443 \
                 -R0:localhost:${VLLM_PORT} \
                 -o StrictHostKeyChecking=no \
                 -o ServerAliveInterval=30 \
@@ -978,11 +1051,25 @@ print(agents[0].get('name', 'terminus-2') if agents else 'terminus-2')
 
             if [ "$_PINGGY_OK" = true ]; then
                 TUNNEL_URL="https://${EVAL_PINGGY_URL}"
-                # Verify connectivity
-                if curl -sk "${TUNNEL_URL}/v1/models" 2>/dev/null | grep -q "object"; then
-                    echo "[pinggy] Connectivity verified: $TUNNEL_URL"
-                else
-                    echo "[pinggy] WARNING: connectivity test failed, continuing anyway..."
+                # Verify connectivity (proxied: curl must also egress via the
+                # SOCKS5 tunnel on no-internet clusters). Retry to account for
+                # Pinggy DNS / vLLM-readiness lag.
+                _pinggy_verified=false
+                for _vt in $(seq 1 6); do
+                    if proxied curl -sk --connect-timeout 5 "${TUNNEL_URL}/v1/models" 2>/dev/null | grep -q "object"; then
+                        echo "[pinggy] Connectivity verified: $TUNNEL_URL (attempt $_vt)"
+                        _pinggy_verified=true
+                        break
+                    fi
+                    sleep 5
+                done
+                if [ "$_pinggy_verified" = false ]; then
+                    echo "[pinggy] FATAL: connectivity test failed after 6 attempts (30s)."
+                    echo "[pinggy] Installed-agent fires require a working tunnel; refusing to waste compute."
+                    echo "[pinggy] Last 20 lines of $PINGGY_LOG:"
+                    tail -20 "$PINGGY_LOG" 2>/dev/null || true
+                    cleanup
+                    exit 1
                 fi
             fi
         fi

--- a/eval/unified_eval_harbor.sbatch
+++ b/eval/unified_eval_harbor.sbatch
@@ -913,6 +913,30 @@ if [ "${EVAL_FORCE_FRESH:-false}" != "true" ] && [ -d "$EXISTING_JOB_DIR" ] && [
             cleanup
             exit 1
         fi
+        # --- FIX (G18b, 2026-06-09): export the tunnel env so the SANDBOXED agent
+        # uses the public Pinggy URL, NOT the localhost api_base saved in config.json.
+        # The per-trial/job config api_base is "http://localhost:<port>/v1" (harmless
+        # on FRESH fires because the agent reads OPENAI_BASE_URL/OPENAI_API_BASE which
+        # the fresh-fire tunnel block exports — see ~L1123-1165). The resume branch
+        # started the tunnel but never exported these, so swe-agent/openhands/etc.
+        # fell back to localhost inside the remote Daytona sandbox → [Errno 111]
+        # Connection refused → empty patch → reward 0 on EVERY post-resume trial
+        # (confirmed: 668150/158/165 etc., 2026-06-09; pre-resume ~50%, post ~0%).
+        TUNNEL_URL="https://${EVAL_PINGGY_URL}"
+        export OPENAI_API_KEY="fake_key"
+        export OPENAI_API_BASE="${TUNNEL_URL}/v1"
+        export OPENAI_BASE_URL="${TUNNEL_URL}/v1"
+        _RESUME_AGENT_NAME=$(${PYTHON_BIN:-python3} -c "import yaml;c=yaml.safe_load(open('$EXISTING_JOB_DIR/config.json'));a=(c.get('agents') or [{}]);print((a[0] or {}).get('name',''))" 2>/dev/null || echo "")
+        if [ "$_RESUME_AGENT_NAME" = "openhands" ]; then
+            export LLM_BASE_URL="${TUNNEL_URL}/v1"
+            export LLM_API_KEY="fake_key"
+        fi
+        if [ "$_RESUME_AGENT_NAME" = "mini-swe-agent" ]; then
+            export MSWEA_MODEL_API_KEY="fake_key"
+            export MSWEA_MODEL_API_BASE="${TUNNEL_URL}/v1"
+            export HOSTED_VLLM_API_BASE="${TUNNEL_URL}/v1"
+        fi
+        echo "[pinggy] (resume) Exported tunnel env: OPENAI_BASE_URL=${TUNNEL_URL}/v1 (agent=${_RESUME_AGENT_NAME:-unknown})"
     fi
     proxied $HARBOR_BIN jobs resume \
         -p "$EXISTING_JOB_DIR" \

--- a/eval/unified_eval_listener.py
+++ b/eval/unified_eval_listener.py
@@ -2896,7 +2896,10 @@ class EvalListener:
 
             # v6: Filter out (model, dataset) pairs currently running in squeue.
             # This prevents resuming old dirs when a job for the same model+dataset is active.
-            if active_pairs:
+            # Bypassed by --force-reeval (mirrors the fresh-fire path behavior at the active_pairs
+            # check earlier — needed e.g. when an active job uses a different scaffold than the
+            # resume target, so the (model, dataset) collision is a false positive).
+            if active_pairs and not self.config.force_reeval:
                 before = len(resume_candidates)
                 resume_candidates = [rc for rc in resume_candidates
                                      if (rc["hf_model"], rc.get("dataset", "")) not in active_pairs]
@@ -3178,6 +3181,7 @@ class EvalListener:
                     "EVAL_API_KEY_ENV": api_cfg["api_key_env"] or "",
                     "EVAL_API_AGENT_KWARGS": ak_string,
                     "EVAL_N_CONCURRENT": str(n_eff),
+                    "EVAL_DB_MODEL_NAME": hf_model,
                 })
                 log(f"  [API] {hf_model} → {sbatch_model_override} "
                     f"(api_base={api_cfg['api_base']}, key_env={api_cfg['api_key_env']}, "
@@ -3238,6 +3242,13 @@ class EvalListener:
                     log(f"  -> Submitted as SLURM job {slurm_job_id} (job_name={job_name})")
                     self._submitted_jobs.add(slurm_job_id)
                     self._dep_chain.append(slurm_job_id)
+                    # Fold freshly-submitted JID into active_ids so later jobs in
+                    # the same iteration see it when computing sliding-window deps.
+                    # Without this, --batch-size silently has no effect in --once
+                    # mode with many models per priority file (active_ids was
+                    # snapshotted before this loop began).
+                    if batch_size and batch_size > 0:
+                        active_ids.add(slurm_job_id)
                 submitted += 1
             else:
                 log(f"  -> Submission failed")


### PR DESCRIPTION
## Summary
Resume-stack fixes for the cluster-agnostic eval system, centered on making **Cat-3 installed-agent (swe-agent) resumes** actually work. Found + fixed while resuming SERA swe-agent jobs that walltime-capped on Jupiter.

## The bug chain (G18 → G18b)
- **G18:** the sbatch *resume* branch never started the Pinggy tunnel (that block lived only in the fresh-fire branch). Cat-3 swe-agent resumes hit `[Errno 111] Connection refused` on every LLM call → 100% failure.
- **G18b (the real killer):** after adding the tunnel-start, resumes *still* scored 0%. Root cause: the resume branch started the tunnel but never **exported `OPENAI_BASE_URL`/`OPENAI_API_BASE`** — which the sandboxed agent reads *with priority* over the localhost `api_base` saved in `config.json`. The fresh-fire path exports these (~L1123-1165); the resume branch didn't, so swe-agent fell back to `localhost:<port>` inside the remote Daytona sandbox → Errno 111 → empty patches → reward 0 on every post-resume trial (pre-resume ~50% → post ~0%). The `(resume) Connectivity verified` check is a **false positive** (curls from the compute node, never the sandbox).

## Fix
In the resume branch, after the tunnel verify, export `TUNNEL_URL` + `OPENAI_API_KEY/OPENAI_API_BASE/OPENAI_BASE_URL` (+ openhands `LLM_BASE_URL`, mini-swe-agent `MSWEA_*`/`HOSTED_VLLM_API_BASE`; agent read from saved config.json). Gated inside the `EVAL_PINGGY_URL`/`EVAL_PINGGY_TOKEN` block → **no-op for terminus-2 and all fresh fires**.

Also includes G10/G12 api_base port + per-trial config rewrite on resume, and supporting eval-stack changes: `resume_chunked.py` orchestrator passthrough (`--pinggy-url/--pinggy-token/--config-yaml/--agent-parser`, `--max-resume-count`), listener resume detection + API-mode model-name, `check_progress.py` resume tagging + API-mode banners, SERA Pattern A per-model entries, and `dcagent_eval_config_swe_agent.yaml` exclude_exceptions parity.

## Verification
Refired 6 SERA swe-agent resumes (672921-672926) with the fix: Pinggy `TC` 54-68 (vs the broken **TC=2**) = real sandbox traffic; post-resume accuracy back to pre-resume levels (~50% swebench, ~33% aider); no Errno 111. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
