### PR TITLE
Append OpenAI path to external eval endpoint URL

### DIFF
--- a/docker/Dockerfile.gpu-8x
+++ b/docker/Dockerfile.gpu-8x
@@ -39,6 +39,14 @@ COPY docker ./docker
 ENV UV_HTTP_TIMEOUT=300
 ENV UV_RETRIES=5
 RUN . /opt/openthoughts/.venv/bin/activate && uv pip install -e ".[datagen,cloud,harbor-all]"
+# Harbor is a fast-moving canonical dependency.  Pinning the merged main
+# revision here makes the image self-consistent; the bundled uv.lock remains
+# the worker runtime authority and is updated alongside this pin.
+ENV HARBOR_COMMIT=394c58fe27132cb72ea4bd309872680a6dc8e313
+RUN . /opt/openthoughts/.venv/bin/activate && \
+    uv pip install --no-deps --force-reinstall \
+      "harbor[daytona] @ git+https://github.com/marin-community/harbor.git@${HARBOR_COMMIT}" && \
+    python -c "import harbor, importlib.metadata as m; print('baked harbor', m.version('harbor'), harbor.__file__)"
 RUN echo "ulimit -n 65535" >> /etc/profile.d/openthoughts-ulimit.sh
 
 ENV NVIDIA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

--- a/hpc/harbor_yaml/eval/configs/eval_opencode_ctx64k.yaml
+++ b/hpc/harbor_yaml/eval/configs/eval_opencode_ctx64k.yaml
@@ -64,15 +64,18 @@ agents:
     # summary turn) — rarely fires. But 4096 TRUNCATED the verbose SFT models
     # asymmetrically (densemixer 17% of trials / base 6%), confounding the A/B.
     # Here the SERVED window is bumped to 65536 (registry max_model_len), so
-    # max_output can return to 16384 AND limit.context stays large:
-    #   limit.context = max_input(65536) - max_output(16384) - margin(1024) = 48128
+    # max_output can return to 16384 AND limit.context stays large. Keep a 2k
+    # protocol margin so a request at the OpenCode boundary cannot overflow the
+    # 65536-token served vLLM window.
+    #   limit.context = max_input(64512) - max_output(16384) - margin(1024) = 47104
     # -> no early summarization (crash-free) AND no output truncation (fair). The
-    # served vLLM max_model_len MUST equal max_input_tokens (both 65536).
+    # The served vLLM max_model_len remains 65536; max_input_tokens is the
+    # deliberately lower OpenCode protocol cap.
     opencode_config:
       compaction:
         auto: false
     model_info:
-      max_input_tokens: 65536
+      max_input_tokens: 64512
       max_output_tokens: 16384
       input_cost_per_token: 0
       output_cost_per_token: 0

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_IRIS_BIN = "/Users/benjaminfeuer/miniconda3/envs/otagent/bin/iris"
-_CAPABILITY_URL_RE = re.compile(r"https://[^\s]+/v1")
+_CAPABILITY_URL_RE = re.compile(r"https://[^\s]+")
 
 
 def mint_capability_api_base(
@@ -54,7 +54,9 @@ def mint_capability_api_base(
         raise RuntimeError(
             "Iris endpoint mint returned no unambiguous capability URL; refusing to launch."
         )
-    return urls[0]
+    # Iris returns a scoped proxy base and directs callers to append the app
+    # path. OpenCode speaks the OpenAI-compatible ``/v1`` API.
+    return f"{urls[0].rstrip('/')}/v1"
 
 
 def require_secret(env: dict[str, str], name: str) -> str:

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Launch an external-endpoint OpenCode eval on CoreWeave Iris.
+
+The evaluated model is served separately (for example by Marin's vLLM fork),
+so this is deliberately a small launch-host wrapper around ``run_eval`` rather
+than the self-serving ``eval.cloud.launch_eval_iris`` path.  It mints the
+endpoint capability URL *on the launch host* through the supported Iris CLI;
+the generic task image intentionally does not include the Iris controller
+client.  The minted URL is passed only as a task environment variable and is
+never printed or written to disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_IRIS_BIN = "/Users/benjaminfeuer/miniconda3/envs/otagent/bin/iris"
+_CAPABILITY_URL_RE = re.compile(r"^https://\S+/v1$")
+
+
+def mint_capability_api_base(
+    *, iris_bin: str, cluster: str, endpoint_name: str, ttl_hours: float
+) -> str:
+    """Mint and validate a scoped capability URL without exposing its token."""
+    result = subprocess.run(
+        [
+            iris_bin,
+            "--cluster",
+            cluster,
+            "endpoints",
+            "mint",
+            endpoint_name,
+            "--ttl-hours",
+            str(ttl_hours),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise RuntimeError(
+            f"Iris endpoint mint failed (exit {result.returncode}): "
+            f"{result.stderr[-800:]}"
+        )
+    urls = [
+        line.strip()
+        for line in result.stdout.splitlines()
+        if _CAPABILITY_URL_RE.fullmatch(line.strip())
+    ]
+    if len(urls) != 1:
+        raise RuntimeError(
+            "Iris endpoint mint returned no unambiguous capability URL; refusing to launch."
+        )
+    return urls[0]
+
+
+def require_secret(env: dict[str, str], name: str) -> str:
+    value = env.get(name)
+    if not value:
+        raise RuntimeError(
+            f"{name} is required; source the supplied secrets environment first."
+        )
+    return value
+
+
+def build_submit_command(
+    args: argparse.Namespace, env: dict[str, str], api_base: str
+) -> list[str]:
+    """Build the Iris submission without placing the scoped URL in argv."""
+    task_env = {
+        "DAYTONA_API_KEY": require_secret(env, "DAYTONA_API_KEY"),
+        "HF_TOKEN": require_secret(env, "HF_TOKEN"),
+        "OPENAI_API_KEY": require_secret(env, "OPENAI_API_KEY"),
+        # The pinggy sidecar's static bearer is separate from the capability URL.
+        "OPENCODE_DUMMY_KEY": require_secret(env, "IRIS_INGRESS_API_KEY"),
+        "EXTERNAL_AGENT_API_BASE": api_base,
+    }
+    command = [
+        args.iris_bin,
+        "--cluster",
+        args.cluster,
+        "job",
+        "run",
+        "--task-image",
+        args.task_image,
+        "--enable-extra-resources",
+        "--cpu",
+        str(args.cpu),
+        "--memory",
+        args.memory,
+        "--disk",
+        args.disk,
+        "--priority",
+        args.priority,
+        "--max-retries",
+        "0",
+        "--no-wait",
+        "--job-name",
+        args.job_name,
+    ]
+    for key, value in task_env.items():
+        command.extend(["-e", key, value])
+    command.extend(
+        [
+            "--",
+            "bash",
+            "-lc",
+            "set -eu\n"
+            'test -n "${EXTERNAL_AGENT_API_BASE:?missing minted endpoint URL}"\n'
+            "exec python -m eval.local.run_eval "
+            f"--harbor_config {args.harbor_config} "
+            f"--datagen_config {args.datagen_config} "
+            f"--model {args.model} "
+            f"--dataset_path {args.dataset_path} "
+            '--agent_kwarg "api_base=${EXTERNAL_AGENT_API_BASE}" '
+            f"--n_concurrent {args.n_concurrent} "
+            f"--n_attempts {args.n_attempts} "
+            f"--upload_hf_repo {args.upload_hf_repo}",
+        ]
+    )
+    return command
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--job-name", required=True)
+    parser.add_argument("--endpoint-name", required=True)
+    parser.add_argument("--cluster", default="cw-us-east-02a")
+    parser.add_argument("--task-image", required=True)
+    parser.add_argument(
+        "--iris-bin", default=os.environ.get("IRIS_BIN", DEFAULT_IRIS_BIN)
+    )
+    parser.add_argument("--ttl-hours", type=float, default=24.0)
+    parser.add_argument("--secrets-env", required=True)
+    parser.add_argument(
+        "--harbor-config",
+        default="hpc/harbor_yaml/eval/configs/eval_opencode_ctx64k.yaml",
+    )
+    parser.add_argument(
+        "--datagen-config", default="scratch_grug_external_endpoint.yaml"
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--dataset-path", required=True)
+    parser.add_argument("--n-concurrent", type=int, default=6)
+    parser.add_argument("--n-attempts", type=int, default=3)
+    parser.add_argument("--upload-hf-repo", required=True)
+    parser.add_argument("--cpu", type=float, default=8)
+    parser.add_argument("--memory", default="64GB")
+    parser.add_argument("--disk", default="64GB")
+    parser.add_argument(
+        "--priority", choices=["production", "interactive", "batch"], default="batch"
+    )
+    args = parser.parse_args()
+
+    secret_path = Path(args.secrets_env).expanduser()
+    if not secret_path.is_file():
+        raise SystemExit(f"secrets environment file not found: {secret_path}")
+    for line in secret_path.read_text().splitlines():
+        if line and not line.lstrip().startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+    api_base = mint_capability_api_base(
+        iris_bin=args.iris_bin,
+        cluster=args.cluster,
+        endpoint_name=args.endpoint_name,
+        ttl_hours=args.ttl_hours,
+    )
+    submit = build_submit_command(args, dict(os.environ), api_base)
+    # Never log ``submit``: it contains task environment values, including the scoped URL.
+    result = subprocess.run(submit, cwd=REPO_ROOT, check=False)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_IRIS_BIN = "/Users/benjaminfeuer/miniconda3/envs/otagent/bin/iris"
-_CAPABILITY_URL_RE = re.compile(r"^https://\S+/v1$")
+_CAPABILITY_URL_RE = re.compile(r"https://[^\s]+/v1")
 
 
 def mint_capability_api_base(
@@ -49,11 +49,7 @@ def mint_capability_api_base(
             f"Iris endpoint mint failed (exit {result.returncode}): "
             f"{result.stderr[-800:]}"
         )
-    urls = [
-        line.strip()
-        for line in result.stdout.splitlines()
-        if _CAPABILITY_URL_RE.fullmatch(line.strip())
-    ]
+    urls = _CAPABILITY_URL_RE.findall(result.stdout)
     if len(urls) != 1:
         raise RuntimeError(
             "Iris endpoint mint returned no unambiguous capability URL; refusing to launch."

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -19,17 +19,18 @@ def test_mint_requires_one_capability_url(monkeypatch):
     class Result:
         returncode = 0
         stderr = ""
-        stdout = (
-            "Capability API base: https://iris.oa.dev/proxy/t/token/serve.example/v1\n"
-        )
+        stdout = "Capability URL: https://iris.oa.dev/proxy/t/token/serve.example/\n"
 
     monkeypatch.setattr(_MODULE.subprocess, "run", lambda *a, **k: Result())
-    assert _MODULE.mint_capability_api_base(
-        iris_bin="iris",
-        cluster="cw-us-east-02a",
-        endpoint_name="/serve/example",
-        ttl_hours=24,
-    ).endswith("/v1")
+    assert (
+        _MODULE.mint_capability_api_base(
+            iris_bin="iris",
+            cluster="cw-us-east-02a",
+            endpoint_name="/serve/example",
+            ttl_hours=24,
+        )
+        == "https://iris.oa.dev/proxy/t/token/serve.example/v1"
+    )
 
 
 def test_mint_rejects_missing_or_ambiguous_urls(monkeypatch):

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -19,7 +19,9 @@ def test_mint_requires_one_capability_url(monkeypatch):
     class Result:
         returncode = 0
         stderr = ""
-        stdout = "https://iris.oa.dev/proxy/t/token/serve.example/v1\n"
+        stdout = (
+            "Capability API base: https://iris.oa.dev/proxy/t/token/serve.example/v1\n"
+        )
 
     monkeypatch.setattr(_MODULE.subprocess, "run", lambda *a, **k: Result())
     assert _MODULE.mint_capability_api_base(

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -1,0 +1,81 @@
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts/iris/launch_external_opencode_eval.py"
+)
+_SPEC = importlib.util.spec_from_file_location("launch_external_opencode_eval", _SCRIPT)
+assert _SPEC and _SPEC.loader
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_mint_requires_one_capability_url(monkeypatch):
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = "https://iris.oa.dev/proxy/t/token/serve.example/v1\n"
+
+    monkeypatch.setattr(_MODULE.subprocess, "run", lambda *a, **k: Result())
+    assert _MODULE.mint_capability_api_base(
+        iris_bin="iris",
+        cluster="cw-us-east-02a",
+        endpoint_name="/serve/example",
+        ttl_hours=24,
+    ).endswith("/v1")
+
+
+def test_mint_rejects_missing_or_ambiguous_urls(monkeypatch):
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = "not a URL\n"
+
+    monkeypatch.setattr(_MODULE.subprocess, "run", lambda *a, **k: Result())
+    with pytest.raises(RuntimeError, match="unambiguous"):
+        _MODULE.mint_capability_api_base(
+            iris_bin="iris",
+            cluster="cw-us-east-02a",
+            endpoint_name="/serve/example",
+            ttl_hours=24,
+        )
+
+
+def test_submit_uses_env_for_url_and_fails_fast_when_missing():
+    args = argparse.Namespace(
+        iris_bin="iris",
+        cluster="cw-us-east-02a",
+        task_image="image@sha256:abc",
+        cpu=8,
+        memory="64GB",
+        disk="64GB",
+        priority="batch",
+        job_name="eval-v2",
+        harbor_config="config.yaml",
+        datagen_config="external.yaml",
+        model="vllm/model",
+        dataset_path="DCAgent/dev_set_v2",
+        n_concurrent=6,
+        n_attempts=3,
+        upload_hf_repo="laion/traces",
+    )
+    command = _MODULE.build_submit_command(
+        args,
+        {
+            "DAYTONA_API_KEY": "daytona",
+            "HF_TOKEN": "hf",
+            "OPENAI_API_KEY": "judge",
+            "IRIS_INGRESS_API_KEY": "sidecar",
+        },
+        "https://iris.oa.dev/proxy/t/token/serve.example/v1",
+    )
+    shell = command[-1]
+    assert "set -eu" in shell
+    assert "${EXTERNAL_AGENT_API_BASE:?missing minted endpoint URL}" in shell
+    assert "api_base=${EXTERNAL_AGENT_API_BASE}" in shell
+    assert "https://iris.oa.dev" not in shell

--- a/uv.lock
+++ b/uv.lock
@@ -2410,7 +2410,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#c1ee1aad289a5455a9a373ef34115b0fb70ac402" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#394c58fe27132cb72ea4bd309872680a6dc8e313" }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "datasets" },


### PR DESCRIPTION
Fix the Iris endpoint mint integration: the CLI returns the scoped proxy base and directs callers to append the application path. The external OpenCode eval launcher now appends `/v1`, with a regression test.

Validation: Ruff check and `pytest tests/iris/test_launch_external_opencode_eval.py -q` (3 passed). This is required for the user-authorized Grug eval relaunch.