### PR TITLE
Append OpenAI path to external eval endpoint URL

### DIFF
--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_IRIS_BIN = "/Users/benjaminfeuer/miniconda3/envs/otagent/bin/iris"
-_CAPABILITY_URL_RE = re.compile(r"https://[^\s]+/v1")
+_CAPABILITY_URL_RE = re.compile(r"https://[^\s]+")
 
 
 def mint_capability_api_base(
@@ -54,7 +54,9 @@ def mint_capability_api_base(
         raise RuntimeError(
             "Iris endpoint mint returned no unambiguous capability URL; refusing to launch."
         )
-    return urls[0]
+    # Iris returns a scoped proxy base and directs callers to append the app
+    # path. OpenCode speaks the OpenAI-compatible ``/v1`` API.
+    return f"{urls[0].rstrip('/')}/v1"
 
 
 def require_secret(env: dict[str, str], name: str) -> str:

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -19,17 +19,18 @@ def test_mint_requires_one_capability_url(monkeypatch):
     class Result:
         returncode = 0
         stderr = ""
-        stdout = (
-            "Capability API base: https://iris.oa.dev/proxy/t/token/serve.example/v1\n"
-        )
+        stdout = "Capability URL: https://iris.oa.dev/proxy/t/token/serve.example/\n"
 
     monkeypatch.setattr(_MODULE.subprocess, "run", lambda *a, **k: Result())
-    assert _MODULE.mint_capability_api_base(
-        iris_bin="iris",
-        cluster="cw-us-east-02a",
-        endpoint_name="/serve/example",
-        ttl_hours=24,
-    ).endswith("/v1")
+    assert (
+        _MODULE.mint_capability_api_base(
+            iris_bin="iris",
+            cluster="cw-us-east-02a",
+            endpoint_name="/serve/example",
+            ttl_hours=24,
+        )
+        == "https://iris.oa.dev/proxy/t/token/serve.example/v1"
+    )
 
 
 def test_mint_rejects_missing_or_ambiguous_urls(monkeypatch):


### PR DESCRIPTION
Fix the Iris endpoint mint integration: the CLI returns the scoped proxy base and directs callers to append the application path. The external OpenCode eval launcher now appends `/v1`, with a regression test.

Validation: Ruff check and `pytest tests/iris/test_launch_external_opencode_eval.py -q` (3 passed). Required for the user-authorized Grug eval relaunch.