### PR TITLE
Support capability-proxy auth for external evals

### DIFF
--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -76,8 +76,12 @@ def build_submit_command(
         "DAYTONA_API_KEY": require_secret(env, "DAYTONA_API_KEY"),
         "HF_TOKEN": require_secret(env, "HF_TOKEN"),
         "OPENAI_API_KEY": require_secret(env, "OPENAI_API_KEY"),
-        # The pinggy sidecar's static bearer is separate from the capability URL.
-        "OPENCODE_DUMMY_KEY": require_secret(env, "IRIS_INGRESS_API_KEY"),
+        # Capability-proxy URLs authenticate in their path. Retain the static
+        # bearer for a sidecar endpoint, but do not require it for Iris-minted
+        # no-auth capability URLs.
+        "OPENCODE_DUMMY_KEY": env.get(
+            "IRIS_INGRESS_API_KEY", "capability-url-no-auth-header"
+        ),
         "EXTERNAL_AGENT_API_BASE": api_base,
     }
     command = [

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -82,3 +82,30 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
     assert "${EXTERNAL_AGENT_API_BASE:?missing minted endpoint URL}" in shell
     assert "api_base=${EXTERNAL_AGENT_API_BASE}" in shell
     assert "https://iris.oa.dev" not in shell
+
+
+def test_submit_uses_capability_no_auth_default_when_sidecar_bearer_is_absent():
+    args = argparse.Namespace(
+        iris_bin="iris",
+        cluster="cw-us-east-02a",
+        task_image="image@sha256:abc",
+        cpu=8,
+        memory="64GB",
+        disk="64GB",
+        priority="batch",
+        job_name="eval-v2",
+        harbor_config="config.yaml",
+        datagen_config="external.yaml",
+        model="vllm/model",
+        dataset_path="DCAgent/dev_set_v2",
+        n_concurrent=6,
+        n_attempts=3,
+        upload_hf_repo="laion/traces",
+    )
+    command = _MODULE.build_submit_command(
+        args,
+        {"DAYTONA_API_KEY": "daytona", "HF_TOKEN": "hf", "OPENAI_API_KEY": "judge"},
+        "https://iris.oa.dev/proxy/t/token/serve.example/v1",
+    )
+    key_index = command.index("OPENCODE_DUMMY_KEY")
+    assert command[key_index + 1] == "capability-url-no-auth-header"


### PR DESCRIPTION
Allow the external OpenCode eval launcher to use an Iris-minted capability URL without a sidecar bearer. It retains `IRIS_INGRESS_API_KEY` whenever supplied and otherwise uses the project-standard no-auth dummy value.

Validation: Ruff check and `pytest tests/iris/test_launch_external_opencode_eval.py -q` (4 passed). Required for the user-authorized Grug eval relaunch.