### PR TITLE
Package the Grug external endpoint eval config

### DIFF
--- a/hpc/datagen_yaml/grug_external_endpoint.yaml
+++ b/hpc/datagen_yaml/grug_external_endpoint.yaml
@@ -1,0 +1,13 @@
+# External-endpoint (hosted vLLM) config for the Grug agentic ID eval.
+# The OpenCode agent receives the scoped Iris capability URL at launch through
+# `api_base`; this file only selects the OpenAI engine and model shape.
+engine:
+  type: openai
+  model: vllm/laion/grug-67b-a2b-sft-s3-agentic-step1903
+  max_output_tokens: 4096
+  healthcheck_interval: 300
+  openai:
+    api_key_env: OPENAI_API_KEY
+backend:
+  type: none
+vllm_server: null

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -146,7 +146,7 @@ def main() -> int:
         default="hpc/harbor_yaml/eval/configs/eval_opencode_ctx64k.yaml",
     )
     parser.add_argument(
-        "--datagen-config", default="scratch_grug_external_endpoint.yaml"
+        "--datagen-config", default="hpc/datagen_yaml/grug_external_endpoint.yaml"
     )
     parser.add_argument("--model", required=True)
     parser.add_argument("--dataset-path", required=True)

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -3,6 +3,7 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 _SCRIPT = (
@@ -13,6 +14,13 @@ _SPEC = importlib.util.spec_from_file_location("launch_external_opencode_eval", 
 assert _SPEC and _SPEC.loader
 _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
+
+
+def test_grug_external_endpoint_config_is_packaged_and_uses_openai():
+    config_path = _SCRIPT.parents[2] / "hpc/datagen_yaml/grug_external_endpoint.yaml"
+    config = yaml.safe_load(config_path.read_text())
+    assert config["engine"]["type"] == "openai"
+    assert config["backend"]["type"] == "none"
 
 
 def test_mint_requires_one_capability_url(monkeypatch):


### PR DESCRIPTION
Track the non-secret OpenAI engine config for the Grug external-endpoint agentic eval and use it as the launcher default. This makes the config available in canonical Iris workspace bundles.

Validation: Ruff check and `pytest tests/iris/test_launch_external_opencode_eval.py -q` (5 passed). Required to correct the failed user-authorized Grug relaunch.