### PR TITLE
ci: provision locked Iris test environment

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Set up Python 3.12
         run: uv python pin 3.12
 
-      - name: Create virtualenv
-        run: uv venv --python 3.12
-
-      - name: Install base package + pytest (no accelerator extras)
-        run: uv pip install -e . pytest
+      - name: Install locked CI test environment
+        run: uv sync --group dev --python 3.12
 
       - name: Run CI-safe unit tests (tests/)
         run: uv run pytest tests/ -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,12 @@ markers = [
 extra-index-url = ["https://download.pytorch.org/whl/cu128"]
 
 [dependency-groups]
-dev = []
+dev = [
+    "boto3",
+    "matplotlib",
+    "marin-iris @ git+https://github.com/marin-community/marin.git@33525a77c#subdirectory=lib/iris",
+    "pytest",
+]
 
 [tool.uv]
 index-strategy = "unsafe-best-match"

--- a/scripts/iris/iris_ops.py
+++ b/scripts/iris/iris_ops.py
@@ -59,12 +59,15 @@ from typing import Any
 # Iris implementation from Marin main, not a copy vendored into this repo.
 MARIN_MAIN_ROOT = Path(os.environ.get("MARIN_MAIN_ROOT", "/Users/benjaminfeuer/Documents/marin"))
 MARIN_IRIS_SOURCE = MARIN_MAIN_ROOT / "lib" / "iris" / "src"
-if not MARIN_IRIS_SOURCE.exists():
-    raise RuntimeError(f"Marin Iris source is unavailable at {MARIN_IRIS_SOURCE}.")
-if str(MARIN_IRIS_SOURCE) not in sys.path:
+if MARIN_IRIS_SOURCE.exists() and str(MARIN_IRIS_SOURCE) not in sys.path:
     sys.path.insert(0, str(MARIN_IRIS_SOURCE))
-
-from iris.cluster.types import JobName  # noqa: E402
+try:
+    from iris.cluster.types import JobName  # noqa: E402
+except ModuleNotFoundError as exc:
+    raise RuntimeError(
+        "Marin Iris is unavailable: install the locked dev dependency or provide "
+        f"MARIN_MAIN_ROOT (looked for {MARIN_IRIS_SOURCE})."
+    ) from exc
 
 # --- iris invocation ------------------------------------------------------
 # The CoreWeave GPU (k8s) backend needs a `kubernetes` install that the bare

--- a/tests/analysis/test_failure_mode_judge.py
+++ b/tests/analysis/test_failure_mode_judge.py
@@ -1,6 +1,10 @@
 import pytest
 
-from scripts.analysis.failure_mode_judge import batched, request_json_array, strip_json_code_fence
+from scripts.analysis.failure_mode_judge import (
+    batched,
+    request_json_array,
+    strip_json_code_fence,
+)
 
 
 class _FakeCompletions:
@@ -73,14 +77,17 @@ def test_shared_judge_retries_transient_client_errors():
     client = _FlakyClient("[]")
     retries = []
 
-    assert request_json_array(
-        client,
-        model="judge",
-        temperature=0.0,
-        system_prompt="system",
-        user_prompt="user",
-        max_attempts=2,
-        on_retry=lambda attempt, exc: retries.append((attempt, str(exc))),
-    ) == []
+    assert (
+        request_json_array(
+            client,
+            model="judge",
+            temperature=0.0,
+            system_prompt="system",
+            user_prompt="user",
+            max_attempts=2,
+            on_retry=lambda attempt, exc: retries.append((attempt, str(exc))),
+        )
+        == []
+    )
     assert retries == [(1, "temporary failure")]
     assert len(client.completions.calls) == 1

--- a/tests/analysis/test_iris_ops.py
+++ b/tests/analysis/test_iris_ops.py
@@ -12,22 +12,35 @@ import pytest
 from botocore.exceptions import ClientError
 
 from scripts.iris import coreweave_ops
-from scripts.iris.iris_ops import job_bundle, job_id_parts, load_bundle_manifest, write_bundle_manifest
+from scripts.iris.iris_ops import (
+    job_bundle,
+    job_id_parts,
+    load_bundle_manifest,
+    write_bundle_manifest,
+)
 from scripts.iris import watch_coreweave_rl
 
 
 def test_job_bundle_uses_cluster_and_full_iris_identity(tmp_path):
     bundle = job_bundle(tmp_path, "cw-rno2a", "/benjaminfeuer/glm52-r10")
 
-    assert bundle.directory == tmp_path / "jobs" / "cw-rno2a" / "benjaminfeuer" / "glm52-r10"
+    assert (
+        bundle.directory
+        == tmp_path / "jobs" / "cw-rno2a" / "benjaminfeuer" / "glm52-r10"
+    )
 
     write_bundle_manifest(bundle, {"kind": "harbor", "progress": {"completed": 4}})
 
-    assert json.loads(bundle.manifest_path.read_text())["job_id"] == "/benjaminfeuer/glm52-r10"
+    assert (
+        json.loads(bundle.manifest_path.read_text())["job_id"]
+        == "/benjaminfeuer/glm52-r10"
+    )
     assert load_bundle_manifest(bundle)["progress"] == {"completed": 4}
 
 
-@pytest.mark.parametrize("job_id", ["glm52-r10", "/benjaminfeuer", "/benjaminfeuer/../bad"])
+@pytest.mark.parametrize(
+    "job_id", ["glm52-r10", "/benjaminfeuer", "/benjaminfeuer/../bad"]
+)
 def test_job_id_parts_rejects_noncanonical_or_unsafe_ids(job_id):
     with pytest.raises(ValueError):
         job_id_parts(job_id)
@@ -44,7 +57,9 @@ def test_find_pod_uses_untruncated_iris_job_label(monkeypatch):
                     {
                         "metadata": {
                             "name": "iris-benjaminfeuer-grug-agentic-eval-v2-65k-harbor39-c309bb6c-0",
-                            "labels": {"iris.job_id": "benjaminfeuer.grug-agentic-eval-v2-65k-harbor394c-r3"},
+                            "labels": {
+                                "iris.job_id": "benjaminfeuer.grug-agentic-eval-v2-65k-harbor394c-r3"
+                            },
                         },
                         "status": {"phase": "Running"},
                     }
@@ -53,9 +68,9 @@ def test_find_pod_uses_untruncated_iris_job_label(monkeypatch):
         ),
     )
 
-    assert coreweave_ops.find_pod(["kubectl"], SimpleNamespace(job=job_id, pod=None)) == (
-        "iris-benjaminfeuer-grug-agentic-eval-v2-65k-harbor39-c309bb6c-0"
-    )
+    assert coreweave_ops.find_pod(
+        ["kubectl"], SimpleNamespace(job=job_id, pod=None)
+    ) == ("iris-benjaminfeuer-grug-agentic-eval-v2-65k-harbor39-c309bb6c-0")
 
 
 def test_save_ray_logs_reports_empty_tar_stream_as_sync_error(monkeypatch, tmp_path):
@@ -66,7 +81,9 @@ def test_save_ray_logs_reports_empty_tar_stream_as_sync_error(monkeypatch, tmp_p
         def wait(self) -> int:
             return 1
 
-    monkeypatch.setattr(coreweave_ops.subprocess, "Popen", lambda *_args, **_kwargs: EmptyTarProcess())
+    monkeypatch.setattr(
+        coreweave_ops.subprocess, "Popen", lambda *_args, **_kwargs: EmptyTarProcess()
+    )
 
     with pytest.raises(RuntimeError, match="Could not archive Ray/vLLM logs"):
         coreweave_ops.save_ray_logs(
@@ -77,7 +94,9 @@ def test_save_ray_logs_reports_empty_tar_stream_as_sync_error(monkeypatch, tmp_p
             100,
             tmp_path,
         )
-    assert (tmp_path / "ray-vllm-sync-error.txt").read_text() == "tar: session log vanished"
+    assert (
+        tmp_path / "ray-vllm-sync-error.txt"
+    ).read_text() == "tar: session log vanished"
 
 
 def test_save_ray_logs_retries_transient_kubectl_html(monkeypatch, tmp_path):
@@ -104,7 +123,9 @@ def test_save_ray_logs_retries_transient_kubectl_html(monkeypatch, tmp_path):
         ]
     )
     delays: list[int] = []
-    monkeypatch.setattr(coreweave_ops.subprocess, "Popen", lambda *_args, **_kwargs: next(processes))
+    monkeypatch.setattr(
+        coreweave_ops.subprocess, "Popen", lambda *_args, **_kwargs: next(processes)
+    )
     monkeypatch.setattr(coreweave_ops.time, "sleep", delays.append)
 
     saved, skipped = coreweave_ops.save_ray_logs(
@@ -133,7 +154,9 @@ def _ray_delta_archive(entries: list[tuple[str, int, bytes]]) -> bytes:
     return archive_bytes.getvalue()
 
 
-def test_save_ray_logs_incrementally_appends_and_replaces_rotated_logs(monkeypatch, tmp_path):
+def test_save_ray_logs_incrementally_appends_and_replaces_rotated_logs(
+    monkeypatch, tmp_path
+):
     class CapturingInput(BytesIO):
         def close(self) -> None:
             self.closed_by_sync = True
@@ -166,14 +189,28 @@ def test_save_ray_logs_incrementally_appends_and_replaces_rotated_logs(monkeypat
     monkeypatch.setattr(coreweave_ops.subprocess, "Popen", fake_popen)
     initial = [{"path": "worker-1.out", "size": 3, "inode": 41}]
     saved, skipped = coreweave_ops.save_ray_logs(
-        ["kubectl"], "pod", "task", initial, 100, tmp_path, incremental=True, python_executable="python"
+        ["kubectl"],
+        "pod",
+        "task",
+        initial,
+        100,
+        tmp_path,
+        incremental=True,
+        python_executable="python",
     )
     assert (saved, skipped) == (initial, [])
     assert (tmp_path / "worker-1.out").read_bytes() == b"abc"
 
     grown = [{"path": "worker-1.out", "size": 6, "inode": 41}]
     coreweave_ops.save_ray_logs(
-        ["kubectl"], "pod", "task", grown, 100, tmp_path, incremental=True, python_executable="python"
+        ["kubectl"],
+        "pod",
+        "task",
+        grown,
+        100,
+        tmp_path,
+        incremental=True,
+        python_executable="python",
     )
     assert (tmp_path / "worker-1.out").read_bytes() == b"abcdef"
     assert b'"offset": 3' in inputs[1].getvalue()
@@ -182,13 +219,27 @@ def test_save_ray_logs_incrementally_appends_and_replaces_rotated_logs(monkeypat
 
     # An unchanged file does not open another kubectl exec stream.
     coreweave_ops.save_ray_logs(
-        ["kubectl"], "pod", "task", grown, 100, tmp_path, incremental=True, python_executable="python"
+        ["kubectl"],
+        "pod",
+        "task",
+        grown,
+        100,
+        tmp_path,
+        incremental=True,
+        python_executable="python",
     )
     assert len(commands) == 2
 
     rotated = [{"path": "worker-1.out", "size": 2, "inode": 99}]
     coreweave_ops.save_ray_logs(
-        ["kubectl"], "pod", "task", rotated, 100, tmp_path, incremental=True, python_executable="python"
+        ["kubectl"],
+        "pod",
+        "task",
+        rotated,
+        100,
+        tmp_path,
+        incremental=True,
+        python_executable="python",
     )
     assert (tmp_path / "worker-1.out").read_bytes() == b"xy"
     assert b'"offset": 0' in inputs[2].getvalue()
@@ -197,12 +248,16 @@ def test_save_ray_logs_incrementally_appends_and_replaces_rotated_logs(monkeypat
 def test_coreweave_command_retries_transient_kubectl_html(monkeypatch):
     results = iter(
         [
-            subprocess.CompletedProcess([], 1, stderr="<!doctype html><html>temporary proxy error"),
+            subprocess.CompletedProcess(
+                [], 1, stderr="<!doctype html><html>temporary proxy error"
+            ),
             subprocess.CompletedProcess([], 0, stdout="ok\n"),
         ]
     )
     delays: list[int] = []
-    monkeypatch.setattr(coreweave_ops.subprocess, "run", lambda *_args, **_kwargs: next(results))
+    monkeypatch.setattr(
+        coreweave_ops.subprocess, "run", lambda *_args, **_kwargs: next(results)
+    )
     monkeypatch.setattr(coreweave_ops.time, "sleep", delays.append)
 
     assert coreweave_ops.command(["kubectl", "get", "pods"]) == "ok\n"
@@ -212,12 +267,16 @@ def test_coreweave_command_retries_transient_kubectl_html(monkeypatch):
 def test_coreweave_command_retries_generic_kubectl_exec_transport_failure(monkeypatch):
     results = iter(
         [
-            subprocess.CompletedProcess([], 1, stderr="command terminated with exit code 1"),
+            subprocess.CompletedProcess(
+                [], 1, stderr="command terminated with exit code 1"
+            ),
             subprocess.CompletedProcess([], 0, stdout="ok\n"),
         ]
     )
     delays: list[int] = []
-    monkeypatch.setattr(coreweave_ops.subprocess, "run", lambda *_args, **_kwargs: next(results))
+    monkeypatch.setattr(
+        coreweave_ops.subprocess, "run", lambda *_args, **_kwargs: next(results)
+    )
     monkeypatch.setattr(coreweave_ops.time, "sleep", delays.append)
 
     assert coreweave_ops.command(["kubectl", "exec", "pod", "--", "true"]) == "ok\n"
@@ -228,7 +287,9 @@ def test_ray_log_inventory_uses_explicit_python_for_rl_images(monkeypatch):
     monkeypatch.setattr(
         coreweave_ops,
         "resolve_container_python",
-        lambda *_args: (_ for _ in ()).throw(AssertionError("generic discovery should not run")),
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("generic discovery should not run")
+        ),
     )
     commands: list[list[str]] = []
 
@@ -238,9 +299,15 @@ def test_ray_log_inventory_uses_explicit_python_for_rl_images(monkeypatch):
 
     monkeypatch.setattr(coreweave_ops, "command", fake_command)
 
-    assert coreweave_ops.ray_log_inventory(
-        ["kubectl"], "pod", "task", python_executable="/opt/openthoughts/envs/rl/bin/python"
-    ) == []
+    assert (
+        coreweave_ops.ray_log_inventory(
+            ["kubectl"],
+            "pod",
+            "task",
+            python_executable="/opt/openthoughts/envs/rl/bin/python",
+        )
+        == []
+    )
     assert "/opt/openthoughts/envs/rl/bin/python" in commands[0]
     assert "st_ino" in commands[0][-1]
 
@@ -262,7 +329,9 @@ def test_rl_progress_reporter_writes_phase_and_elapsed_time(monkeypatch, capsys)
     assert capsys.readouterr().err == "[rl-watch +01:05] trace inventory 1/2\n"
 
 
-def test_rl_discovery_skips_iris_preamble_and_includes_recent_terminal_jobs(monkeypatch):
+def test_rl_discovery_skips_iris_preamble_and_includes_recent_terminal_jobs(
+    monkeypatch,
+):
     cluster = watch_coreweave_rl.Cluster("cw-rno2a", Path("/tmp/kubeconfig"), None)
     output = """I20260722 controller tunnel ready
 job_id,state,submitted_at_ms,finished_at_ms,entrypoint_json
@@ -294,12 +363,26 @@ def test_recent_trace_jobs_uses_remote_last_modified_and_preserves_remote_counts
     first = datetime(2026, 7, 22, 10, tzinfo=UTC)
     objects = [
         {"Key": f"{root}z-old/result.json", "Size": 1, "LastModified": first},
-        {"Key": f"{root}a-new/agent/trajectory.json", "Size": 1, "LastModified": first + timedelta(hours=3)},
-        {"Key": f"{root}a-new/result.json", "Size": 1, "LastModified": first + timedelta(hours=2)},
-        {"Key": f"{root}m-middle/result.json", "Size": 1, "LastModified": first + timedelta(hours=2)},
+        {
+            "Key": f"{root}a-new/agent/trajectory.json",
+            "Size": 1,
+            "LastModified": first + timedelta(hours=3),
+        },
+        {
+            "Key": f"{root}a-new/result.json",
+            "Size": 1,
+            "LastModified": first + timedelta(hours=2),
+        },
+        {
+            "Key": f"{root}m-middle/result.json",
+            "Size": 1,
+            "LastModified": first + timedelta(hours=2),
+        },
     ]
 
-    selected, available, completed = watch_coreweave_rl.recent_trace_jobs(objects, root, trace_sync_limit=2)
+    selected, available, completed = watch_coreweave_rl.recent_trace_jobs(
+        objects, root, trace_sync_limit=2
+    )
 
     assert [trace.name for trace in selected] == ["a-new", "m-middle"]
     assert available == 3
@@ -310,13 +393,19 @@ def test_recent_trace_jobs_uses_remote_last_modified_and_preserves_remote_counts
     cluster = watch_coreweave_rl.Cluster("cw-rno2a", Path("/tmp/kubeconfig"), None)
     first_job = watch_coreweave_rl.RlJob(cluster, "/user/first", "running", 0, "")
     second_job = watch_coreweave_rl.RlJob(cluster, "/user/second", "running", 0, "")
-    first_inventory = watch_coreweave_rl.TraceInventory(first_job, "bucket", root, object(), tuple(full), 3, 3)
+    first_inventory = watch_coreweave_rl.TraceInventory(
+        first_job, "bucket", root, object(), tuple(full), 3, 3
+    )
     second_inventory = watch_coreweave_rl.TraceInventory(
         second_job,
         "bucket",
         root,
         object(),
-        (watch_coreweave_rl.TraceJobObjects("other", first + timedelta(hours=4), (), True),),
+        (
+            watch_coreweave_rl.TraceJobObjects(
+                "other", first + timedelta(hours=4), (), True
+            ),
+        ),
         1,
         1,
     )
@@ -325,12 +414,23 @@ def test_recent_trace_jobs_uses_remote_last_modified_and_preserves_remote_counts
         [first_inventory, second_inventory], trace_sync_limit=2
     )
 
-    assert [trace.name for trace in fleet_selected[("cw-rno2a", "/user/first")]] == ["a-new"]
-    assert [trace.name for trace in fleet_selected[("cw-rno2a", "/user/second")]] == ["other"]
+    assert [trace.name for trace in fleet_selected[("cw-rno2a", "/user/first")]] == [
+        "a-new"
+    ]
+    assert [trace.name for trace in fleet_selected[("cw-rno2a", "/user/second")]] == [
+        "other"
+    ]
     manifest = watch_coreweave_rl.trace_selection_manifest(
-        fleet_selected[("cw-rno2a", "/user/first")], first_inventory, 2, fleet_available=4, fleet_selected=2
+        fleet_selected[("cw-rno2a", "/user/first")],
+        first_inventory,
+        2,
+        fleet_available=4,
+        fleet_selected=2,
     )
-    assert manifest["selection"] == "latest_object_store_last_modified_across_active_rl_jobs"
+    assert (
+        manifest["selection"]
+        == "latest_object_store_last_modified_across_active_rl_jobs"
+    )
     assert manifest["omitted_traces"] == 2
     assert manifest["fleet_selected_traces"] == 2
 
@@ -352,7 +452,9 @@ def test_recent_trace_jobs_requires_remote_last_modified_metadata():
 def test_trace_sync_skips_object_that_disappears_after_listing(tmp_path):
     class MissingObjectClient:
         def download_file(self, _bucket, _key, _destination):
-            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+            raise ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+            )
 
     cluster = watch_coreweave_rl.Cluster("cw-rno2a", Path("/tmp/kubeconfig"), None)
     job = watch_coreweave_rl.RlJob(cluster, "/user/rl-job", "running", 0, "")
@@ -385,7 +487,9 @@ def test_trace_sync_skips_object_that_disappears_after_listing(tmp_path):
 
     assert status.endswith("0 copied, 1 skipped")
     assert (available, completed, error) == (1, 1, None)
-    assert json.loads((tmp_path / "trace_jobs" / "skipped_objects.json").read_text()) == [
+    assert json.loads(
+        (tmp_path / "trace_jobs" / "skipped_objects.json").read_text()
+    ) == [
         {
             "key": "trial-1/result.json",
             "reason": "missing_after_listing",

--- a/tests/analysis/test_trace_runtime_report.py
+++ b/tests/analysis/test_trace_runtime_report.py
@@ -12,13 +12,29 @@ from scripts.analysis.trace_runtime_report import (
 
 def test_stage_runtime_analysis_reports_quantiles_and_top_exception_paths():
     samples = [
-        StageSample(Path("task-1/result.json"), {"overall": 12.0, "agent_execution": 10.0}, False),
-        StageSample(Path("task-2/result.json"), {"overall": 24.0, "agent_execution": 20.0}, True),
-        StageSample(Path("task-3/result.json"), {"overall": 36.0, "agent_execution": 30.0}, False),
-        StageSample(Path("task-4/result.json"), {"overall": 48.0, "agent_execution": 40.0}, True),
+        StageSample(
+            Path("task-1/result.json"),
+            {"overall": 12.0, "agent_execution": 10.0},
+            False,
+        ),
+        StageSample(
+            Path("task-2/result.json"), {"overall": 24.0, "agent_execution": 20.0}, True
+        ),
+        StageSample(
+            Path("task-3/result.json"),
+            {"overall": 36.0, "agent_execution": 30.0},
+            False,
+        ),
+        StageSample(
+            Path("task-4/result.json"), {"overall": 48.0, "agent_execution": 40.0}, True
+        ),
     ]
     analysis, top_exception_paths = stage_runtime_analysis(
-        [ExperimentRuntime("experiment", [JobRuntime("job", None, stage_samples=samples)])],
+        [
+            ExperimentRuntime(
+                "experiment", [JobRuntime("job", None, stage_samples=samples)]
+            )
+        ],
         [0.0, 0.5, 1.0],
     )
 

--- a/tests/analysis/test_watch_coreweave_datagen.py
+++ b/tests/analysis/test_watch_coreweave_datagen.py
@@ -5,6 +5,7 @@ import subprocess
 from scripts.iris import watch_iris_harbor as monitor
 from scripts.iris import iris_ops
 
+
 def test_run_iris_retries_transient_dns_failure(monkeypatch):
     results = iter(
         [
@@ -26,7 +27,9 @@ def test_run_iris_retries_transient_dns_failure(monkeypatch):
     monkeypatch.setattr(iris_ops.subprocess, "run", fake_run)
     monkeypatch.setattr(iris_ops.time, "sleep", delays.append)
 
-    result = iris_ops.run_iris_command(["query", "SELECT 1"], cluster="marin", iris_bin="/fake/iris")
+    result = iris_ops.run_iris_command(
+        ["query", "SELECT 1"], cluster="marin", iris_bin="/fake/iris"
+    )
 
     assert result.returncode == 0
     assert len(calls) == 2
@@ -43,7 +46,9 @@ def test_run_iris_does_not_retry_non_dns_failure(monkeypatch):
     monkeypatch.setattr(iris_ops.subprocess, "run", fake_run)
     monkeypatch.setattr(iris_ops.time, "sleep", lambda _delay: None)
 
-    result = iris_ops.run_iris_command(["query", "SELECT 1"], cluster="marin", iris_bin="/fake/iris")
+    result = iris_ops.run_iris_command(
+        ["query", "SELECT 1"], cluster="marin", iris_bin="/fake/iris"
+    )
 
     assert result.returncode == 1
     assert len(calls) == 1
@@ -96,8 +101,8 @@ def test_harbor_job_from_row_classifies_datagen_and_keeps_durable_identity():
         "state": "3",
         "submitted_at_ms": "1",
         "entrypoint_json": (
-            'python run_tracegen.py --tasks_input_path DCAgent/tasks --job_name tracegen-test '
-            '--harbor_extra_arg=--jobs-dir=s3://bucket/runs'
+            "python run_tracegen.py --tasks_input_path DCAgent/tasks --job_name tracegen-test "
+            "--harbor_extra_arg=--jobs-dir=s3://bucket/runs"
         ),
     }
 
@@ -119,8 +124,8 @@ def test_harbor_job_from_row_classifies_eval_without_hiding_legacy_log_only_job(
         "state": "3",
         "submitted_at_ms": "1",
         "entrypoint_json": (
-            'exec python -m eval.local.run_eval --dataset_path DCAgent/dev_set '
-            '--harbor_config hpc/harbor_yaml/eval.yaml'
+            "exec python -m eval.local.run_eval --dataset_path DCAgent/dev_set "
+            "--harbor_config hpc/harbor_yaml/eval.yaml"
         ),
     }
 

--- a/tests/data/test_conversation_utils.py
+++ b/tests/data/test_conversation_utils.py
@@ -22,7 +22,10 @@ def test_extracts_role_and_from_conversation_variants():
 def test_preserves_empty_and_last_message_fallbacks():
     assert extract_user_prompt([]) == ""
     assert extract_system_prompt([]) is None
-    assert extract_user_prompt([{"role": "assistant", "content": "Fallback"}]) == "Fallback"
+    assert (
+        extract_user_prompt([{"role": "assistant", "content": "Fallback"}])
+        == "Fallback"
+    )
 
 
 class _TokenCounter:
@@ -52,7 +55,10 @@ def test_token_representations_are_explicit_and_preserve_their_distinct_inputs()
         '[{"from":"human","value":"Hello"},{"from":"gpt","value":"Hi"}]'
     )
     assert render_token_representation(record, "conversation_text") == "Hello\nHi"
-    assert render_token_representation(record, "chat_template", tokenizer=tokenizer) == "<chat-template>"
+    assert (
+        render_token_representation(record, "chat_template", tokenizer=tokenizer)
+        == "<chat-template>"
+    )
     assert tokenizer.template_messages == [
         {"role": "user", "content": "Hello"},
         {"role": "assistant", "content": "Hi"},

--- a/tests/iris/test_harvest_evalchemy_s3.py
+++ b/tests/iris/test_harvest_evalchemy_s3.py
@@ -28,7 +28,10 @@ def test_sync_run_mirrors_every_selected_object(monkeypatch, tmp_path):
 
     monkeypatch.setattr(harvester, "download", fake_download)
 
-    keys = ["iris/marinbase-eval/model/run/results_a.json", "iris/marinbase-eval/model/run/samples.jsonl"]
+    keys = [
+        "iris/marinbase-eval/model/run/results_a.json",
+        "iris/marinbase-eval/model/run/samples.jsonl",
+    ]
     assert harvester.sync_run(object(), keys) == {
         key: tmp_path / Path(key).name for key in keys
     }

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -178,10 +178,14 @@ def test_selected_secrets_file_replaces_stale_inherited_values(tmp_path):
     }
 
 
-def test_main_submits_federated_serve_then_parent_minted_durable_eval(tmp_path, monkeypatch):
+def test_main_submits_federated_serve_then_parent_minted_durable_eval(
+    tmp_path, monkeypatch
+):
     """The default profile must run the full parent→peer→eval launch sequence."""
     secret_path = tmp_path / "secrets.env"
-    secret_path.write_text("DAYTONA_API_KEY=daytona\nHF_TOKEN=hf\nOPENAI_API_KEY=judge\n")
+    secret_path.write_text(
+        "DAYTONA_API_KEY=daytona\nHF_TOKEN=hf\nOPENAI_API_KEY=judge\n"
+    )
     marin_repo = tmp_path / "marin"
     marin_repo.mkdir()
     calls: list[tuple[list[str], dict]] = []
@@ -195,9 +199,13 @@ def test_main_submits_federated_serve_then_parent_minted_durable_eval(tmp_path, 
     def fake_run(command, **kwargs):
         calls.append((command, kwargs))
         if "endpoints" in command and "list" in command:
-            return Result("NAME ACCESS PEER ADDRESS TASK\n/serve/grug-r7-serve link cw-us-east-02a 10.0.0.1 task\n")
+            return Result(
+                "NAME ACCESS PEER ADDRESS TASK\n/serve/grug-r7-serve link cw-us-east-02a 10.0.0.1 task\n"
+            )
         if "endpoints" in command and "mint" in command:
-            return Result("Capability URL: https://iris.oa.dev/proxy/t/token/serve.grug-r7-serve/\n")
+            return Result(
+                "Capability URL: https://iris.oa.dev/proxy/t/token/serve.grug-r7-serve/\n"
+            )
         return Result()
 
     monkeypatch.setattr(_MODULE.subprocess, "run", fake_run)
@@ -229,12 +237,19 @@ def test_main_submits_federated_serve_then_parent_minted_durable_eval(tmp_path, 
         "--cluster",
     ]
     assert "--target-cluster" in serve_command
-    assert serve_command[serve_command.index("--target-cluster") + 1] == "cw-us-east-02a"
+    assert (
+        serve_command[serve_command.index("--target-cluster") + 1] == "cw-us-east-02a"
+    )
     assert serve_kwargs["env"]["KUBECONFIG"] == _MODULE.DEFAULT_KUBECONFIG
 
     eval_command, eval_kwargs = calls[-1]
     assert eval_command[eval_command.index("--job-name") + 1] == "grug-r7"
-    assert eval_command[eval_command.index("--task-image") + 1] == _MODULE.DEFAULT_TASK_IMAGE
+    assert (
+        eval_command[eval_command.index("--task-image") + 1]
+        == _MODULE.DEFAULT_TASK_IMAGE
+    )
     assert eval_kwargs["env"]["KUBECONFIG"] == _MODULE.DEFAULT_KUBECONFIG
     assert "https://iris.oa.dev" not in eval_command[-1]
-    assert "--jobs-dir=s3://marin-us-east-02a/iris/grug-r7/trace_jobs" in eval_command[-1]
+    assert (
+        "--jobs-dir=s3://marin-us-east-02a/iris/grug-r7/trace_jobs" in eval_command[-1]
+    )

--- a/tests/iris/test_mirror_models_and_job_inventory.py
+++ b/tests/iris/test_mirror_models_and_job_inventory.py
@@ -8,37 +8,85 @@ from scripts.iris import list_iris_jobs, mirror_models
 from scripts.iris.launch_mirror import GcsToS3Launcher, HfMirrorIrisLauncher
 
 
-def test_mirror_router_dispatches_hf_to_gcs_without_changing_route_arguments(monkeypatch):
+def test_mirror_router_dispatches_hf_to_gcs_without_changing_route_arguments(
+    monkeypatch,
+):
     calls = []
     monkeypatch.setattr(
         mirror_models.mirror_hf_to_gcs,
         "mirror",
         lambda repo, prefixes, **kwargs: calls.append((repo, prefixes, kwargs)),
     )
-    assert mirror_models.main([
-        "hf-to-gcs", "--repo", "org/model", "--gcs-prefix", "gs://models", "--quiet",
-    ]) == 0
-    assert calls == [("org/model", ["gs://models"], {"verbose": False, "iris_job_id": None})]
+    assert (
+        mirror_models.main(
+            [
+                "hf-to-gcs",
+                "--repo",
+                "org/model",
+                "--gcs-prefix",
+                "gs://models",
+                "--quiet",
+            ]
+        )
+        == 0
+    )
+    assert calls == [
+        ("org/model", ["gs://models"], {"verbose": False, "iris_job_id": None})
+    ]
 
 
 def test_mirror_router_rejects_wrong_source_scheme_before_any_transfer(monkeypatch):
     monkeypatch.setattr(mirror_models.mirror_gcs_to_s3, "mirror_repo", pytest.fail)
     with pytest.raises(SystemExit, match="must start with gs://"):
-        mirror_models.main([
-            "gcs-to-s3", "--repo", "org/model", "--gcs-prefix", "bad", "--s3-bucket", "bucket", "--s3-prefix", "models",
-        ])
+        mirror_models.main(
+            [
+                "gcs-to-s3",
+                "--repo",
+                "org/model",
+                "--gcs-prefix",
+                "bad",
+                "--s3-bucket",
+                "bucket",
+                "--s3-prefix",
+                "models",
+            ]
+        )
 
 
 def test_mirror_launchers_issue_the_canonical_mirror_command():
     hf_args = SimpleNamespace(gcs_prefix=["gs://one", "gs://two"], repo=["org/model"])
-    gcs_args = SimpleNamespace(gcs_prefix="gs://models", s3_bucket="bucket", s3_prefix="models", s3_endpoint=None, repo=["org/model"])
+    gcs_args = SimpleNamespace(
+        gcs_prefix="gs://models",
+        s3_bucket="bucket",
+        s3_prefix="models",
+        s3_endpoint=None,
+        repo=["org/model"],
+    )
     assert HfMirrorIrisLauncher(".").build_task_command(hf_args, "unused") == [
-        "python", "-m", "scripts.iris.mirror_models", "hf-to-gcs",
-        "--gcs-prefix", "gs://one", "--gcs-prefix", "gs://two", "--repo", "org/model",
+        "python",
+        "-m",
+        "scripts.iris.mirror_models",
+        "hf-to-gcs",
+        "--gcs-prefix",
+        "gs://one",
+        "--gcs-prefix",
+        "gs://two",
+        "--repo",
+        "org/model",
     ]
     assert GcsToS3Launcher(".").build_task_command(gcs_args, "unused") == [
-        "python", "-m", "scripts.iris.mirror_models", "gcs-to-s3",
-        "--gcs-prefix", "gs://models", "--s3-bucket", "bucket", "--s3-prefix", "models", "--repo", "org/model",
+        "python",
+        "-m",
+        "scripts.iris.mirror_models",
+        "gcs-to-s3",
+        "--gcs-prefix",
+        "gs://models",
+        "--s3-bucket",
+        "bucket",
+        "--s3-prefix",
+        "models",
+        "--repo",
+        "org/model",
     ]
 
 
@@ -49,11 +97,28 @@ job_id,state,submitted_at_ms,started_at_ms,finished_at_ms,error,exit_code
 /benjaminfeuer/rl-run,3,2000,2100,,,
 /benjaminfeuer/eval-b,6,3000,3100,3200,manual stop,1
 """
-    monkeypatch.setattr(list_iris_jobs, "run_iris_command", lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout=output, stderr=""))
-    rows = list_iris_jobs.query_jobs(user="benjaminfeuer", hours=24, cluster="cw", now_ms=86_400_000)
+    monkeypatch.setattr(
+        list_iris_jobs,
+        "run_iris_command",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0, stdout=output, stderr=""
+        ),
+    )
+    rows = list_iris_jobs.query_jobs(
+        user="benjaminfeuer", hours=24, cluster="cw", now_ms=86_400_000
+    )
     table = list_iris_jobs.render_table(rows)
-    assert [row["job_id"] for row in rows] == ["/benjaminfeuer/tracegen-a", "/benjaminfeuer/rl-run", "/benjaminfeuer/eval-b"]
-    assert "datagen" in table and "RL" in table and "eval" in table and "terminated" in table
+    assert [row["job_id"] for row in rows] == [
+        "/benjaminfeuer/tracegen-a",
+        "/benjaminfeuer/rl-run",
+        "/benjaminfeuer/eval-b",
+    ]
+    assert (
+        "datagen" in table
+        and "RL" in table
+        and "eval" in table
+        and "terminated" in table
+    )
 
 
 def test_job_inventory_overrides_an_inherited_non_coreweave_kubeconfig(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -884,6 +884,74 @@ wheels = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-rl' or extra == 'extra-18-openthoughts-agent-sft-qwen35' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (extra != 'extra-18-openthoughts-agent-datagen' and extra != 'extra-18-openthoughts-agent-datagen-tpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a", size = 292189, upload-time = "2025-07-26T12:02:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77", size = 273251, upload-time = "2025-07-26T12:02:17.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5", size = 335810, upload-time = "2025-07-26T12:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/e35f4c1c93f9275d4e38681a80506b5510e9327350c51f8d4a5a724d178c/contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4", size = 382871, upload-time = "2025-07-26T12:02:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/47b512f936f66a0a900d81c396a7e60d73419868fba959c61efed7a8ab46/contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36", size = 386264, upload-time = "2025-07-26T12:02:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3", size = 363819, upload-time = "2025-07-26T12:02:23.759Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a6/0b185d4cc480ee494945cde102cb0149ae830b5fa17bf855b95f2e70ad13/contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b", size = 1333650, upload-time = "2025-07-26T12:02:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d7/afdc95580ca56f30fbcd3060250f66cedbde69b4547028863abd8aa3b47e/contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36", size = 1404833, upload-time = "2025-07-26T12:02:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/366af18a6d386f41132a48f033cbd2102e9b0cf6345d35ff0826cd984566/contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d", size = 189692, upload-time = "2025-07-26T12:02:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd", size = 232424, upload-time = "2025-07-26T12:02:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/18/79/a9416650df9b525737ab521aa181ccc42d56016d2123ddcb7b58e926a42c/contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339", size = 198300, upload-time = "2025-07-26T12:02:32.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/42/38c159a7d0f2b7b9c04c64ab317042bb6952b713ba875c1681529a2932fe/contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772", size = 306769, upload-time = "2025-07-26T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/26a8205f24bca10974e77460de68d3d7c63e282e23782f1239f226fcae6f/contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77", size = 287892, upload-time = "2025-07-26T12:02:35.807Z" },
+    { url = "https://files.pythonhosted.org/packages/66/06/8a475c8ab718ebfd7925661747dbb3c3ee9c82ac834ccb3570be49d129f4/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13", size = 326748, upload-time = "2025-07-26T12:02:37.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a3/c5ca9f010a44c223f098fccd8b158bb1cb287378a31ac141f04730dc49be/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe", size = 375554, upload-time = "2025-07-26T12:02:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/68bd33ae63fac658a4145088c1e894405e07584a316738710b636c6d0333/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f", size = 388118, upload-time = "2025-07-26T12:02:40.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/52/4c285a6435940ae25d7410a6c36bda5145839bc3f0beb20c707cda18b9d2/contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0", size = 352555, upload-time = "2025-07-26T12:02:42.25Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/3e81e1dd174f5c7fefe50e85d0892de05ca4e26ef1c9a59c2a57e43b865a/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4", size = 1322295, upload-time = "2025-07-26T12:02:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/6d913d4d04e14379de429057cd169e5e00f6c2af3bb13e1710bcbdb5da12/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f", size = 1391027, upload-time = "2025-07-26T12:02:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1036,6 +1104,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/cb/ba61bcd602856aeabf362280cb3c17ed5fe03ae23e84578eb99f5245546c/cupy_cuda12x-14.0.1-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:3be87da86d808d9fec23b0a1df001f15f8f145698bc4bebc6d6938fa7e11519f", size = 144976386, upload-time = "2026-02-20T10:23:29.877Z" },
     { url = "https://files.pythonhosted.org/packages/ba/73/34e5f334f6b1e5c5dff80af8109979fb0e8461b27e4454517e0e47486455/cupy_cuda12x-14.0.1-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:fa356384760e01498d010af2d96de536ef3dad19db1d3a1ad0764e4323fb919f", size = 133521354, upload-time = "2026-02-20T10:23:37.063Z" },
     { url = "https://files.pythonhosted.org/packages/e5/a3/80ff83dcad1ac61741714d97fce5a3ef42c201bb40005ec5cc413e34d75f/cupy_cuda12x-14.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:cafe62131caef63b5e90b71b617bb4bf47d7bd9e11cccabea8104db1e01db02e", size = 96822848, upload-time = "2026-02-20T10:23:42.684Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
 ]
 
 [[package]]
@@ -1836,19 +1913,72 @@ http = [
 name = "gcsfs"
 version = "2026.1.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 'AMD64' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine == 'AMD64' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_machine != 'AMD64' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.14' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version == '3.13.*' and platform_machine != 'AMD64' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "(python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.13' and platform_machine != 'AMD64' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.13' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine != 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "decorator" },
-    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "google-auth" },
-    { name = "google-auth-oauthlib" },
-    { name = "google-cloud-storage" },
-    { name = "google-cloud-storage-control" },
-    { name = "requests" },
+    { name = "aiohttp", marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "decorator", marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-auth", marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-auth-oauthlib", marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-cloud-storage", marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-cloud-storage-control", marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "requests", marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/b7/5337521e212dcd63eeb9e46046ec21a43353435c962de3f1d994079af0a2/gcsfs-2026.1.0.tar.gz", hash = "sha256:ce76686bcab4ac21dd60e3d4dc5ae920046ee081f1fbcecebeabe65c257982c8", size = 129230, upload-time = "2026-01-09T16:02:46.275Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/14/b460d85183aea49af192a5b275bd73e63f8a1e9805c41e860fe1c1eeefd2/gcsfs-2026.1.0-py3-none-any.whl", hash = "sha256:f0016a487d58a99c73e6547085439598995b281142b5d0cae1c1f06cc8f25f03", size = 48531, upload-time = "2026-01-09T16:02:44.799Z" },
+]
+
+[[package]]
+name = "gcsfs"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "aiohttp", marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "decorator", marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-auth", marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-auth-oauthlib", marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-cloud-storage", marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-cloud-storage-control", marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "requests", marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/91/e7a2f237d51436a4fc947f30f039d2c277bb4f4ce02f86628ba0a094a3ce/gcsfs-2026.2.0.tar.gz", hash = "sha256:d58a885d9e9c6227742b86da419c7a458e1f33c1de016e826ea2909f6338ed84", size = 163376, upload-time = "2026-02-06T18:35:52.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/6b/c2f68ac51229fc94f094c7f802648fc1de3d19af36434def5e64c0caa32b/gcsfs-2026.2.0-py3-none-any.whl", hash = "sha256:407feaa2af0de81ebce44ea7e6f68598a3753e5e42257b61d6a9f8c0d6d4754e", size = 57557, upload-time = "2026-02-06T18:35:51.09Z" },
 ]
 
 [[package]]
@@ -2077,7 +2207,7 @@ name = "google-cloud-storage-control"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"], marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "grpc-google-iam-v1" },
     { name = "grpcio" },
@@ -2094,7 +2224,7 @@ name = "google-cloud-tpu"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", extra = ["grpc"], marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "grpcio" },
     { name = "proto-plus" },
@@ -2695,7 +2825,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -3013,6 +3143,92 @@ wheels = [
 ]
 
 [[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/060f45052f2a01ad5762c8fdecd6d7a752b43400dc29ff75cd47225a40fd/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615", size = 123231, upload-time = "2026-03-09T13:14:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02", size = 66489, upload-time = "2026-03-09T13:14:42.534Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/97980f3ad4fae37dd7fe31626e2bf75fbf8bdf5d303950ec1fab39a12da8/kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e", size = 64063, upload-time = "2026-03-09T13:14:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/b06c934a6aa8bc91f566bd2a214fd04c30506c2d9e2b6b171953216a65b6/kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac", size = 1475913, upload-time = "2026-03-09T13:14:46.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f0/f768ae564a710135630672981231320bc403cf9152b5596ec5289de0f106/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05", size = 1282782, upload-time = "2026-03-09T13:14:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/1de7aad00697325f05238a5f2eafbd487fb637cc27a558b5367a5f37fb7f/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd", size = 1300815, upload-time = "2026-03-09T13:14:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c2/297f25141d2e468e0ce7f7a7b92e0cf8918143a0cbd3422c1ad627e85a06/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a", size = 1347925, upload-time = "2026-03-09T13:14:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/f4c73a02eb41520c47610207b21afa8cdd18fdbf64ffd94674ae21c4812d/kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554", size = 991322, upload-time = "2026-03-09T13:14:54.637Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/46/d3f2efef7732fcda98d22bf4ad5d3d71d545167a852ca710a494f4c15343/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581", size = 2232857, upload-time = "2026-03-09T13:14:56.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/2d9756bf2b6d26ae4349b8d3662fb3993f16d80c1f971c179ce862b9dbae/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303", size = 2329376, upload-time = "2026-03-09T13:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9f/876a0a0f2260f1bde92e002b3019a5fabc35e0939c7d945e0fa66185eb20/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9", size = 1982549, upload-time = "2026-03-09T13:14:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/ba3624dfac23a64d54ac4179832860cb537c1b0af06024936e82ca4154a0/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79", size = 2494680, upload-time = "2026-03-09T13:15:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/97716b190ab98911b20d10bf92eca469121ec483b8ce0edd314f51bc85af/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796", size = 2297905, upload-time = "2026-03-09T13:15:03.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e", size = 75086, upload-time = "2026-03-09T13:15:07.775Z" },
+    { url = "https://files.pythonhosted.org/packages/70/15/9b90f7df0e31a003c71649cf66ef61c3c1b862f48c81007fa2383c8bd8d7/kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df", size = 66577, upload-time = "2026-03-09T13:15:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/17/01/7dc8c5443ff42b38e72731643ed7cf1ed9bf01691ae5cdca98501999ed83/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e", size = 125794, upload-time = "2026-03-09T13:15:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4", size = 67646, upload-time = "2026-03-09T13:15:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/35/10a844afc5f19d6f567359bf4789e26661755a2f36200d5d1ed8ad0126e5/kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028", size = 65511, upload-time = "2026-03-09T13:15:13.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/685b297052dd041dcebce8e8787b58923b6e78acc6115a0dc9189011c44b/kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657", size = 1584858, upload-time = "2026-03-09T13:15:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/80/04865e3d4638ac5bddec28908916df4a3075b8c6cc101786a96803188b96/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920", size = 1392539, upload-time = "2026-03-09T13:15:16.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/01/77a19cacc0893fa13fafa46d1bba06fb4dc2360b3292baf4b56d8e067b24/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9", size = 1405310, upload-time = "2026-03-09T13:15:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/53/39/bcaf5d0cca50e604cfa9b4e3ae1d64b50ca1ae5b754122396084599ef903/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d", size = 1456244, upload-time = "2026-03-09T13:15:20.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/72c187abc6975f6978c3e39b7cf67aeb8b3c0a8f9790aa7fd412855e9e1f/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65", size = 1073154, upload-time = "2026-03-09T13:15:22.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/cf5b25783ebbd59143b4371ed0c8428a278abe68d6d0104b01865b1bbd0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa", size = 2334377, upload-time = "2026-03-09T13:15:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e5/b1f492adc516796e88751282276745340e2a72dcd0d36cf7173e0daf3210/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0", size = 2425288, upload-time = "2026-03-09T13:15:25.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e5/9b21fbe91a61b8f409d74a26498706e97a48008bfcd1864373d32a6ba31c/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9", size = 2063158, upload-time = "2026-03-09T13:15:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/02/83f47986138310f95ea95531f851b2a62227c11cbc3e690ae1374fe49f0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f", size = 2597260, upload-time = "2026-03-09T13:15:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+]
+
+[[package]]
 name = "lark"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3270,8 +3486,10 @@ dependencies = [
     { name = "click" },
     { name = "connect-python" },
     { name = "duckdb" },
-    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "gcsfs" },
+    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "gcsfs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "gcsfs", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "marin-rigging" },
     { name = "protobuf" },
     { name = "pyarrow" },
@@ -3299,8 +3517,10 @@ dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
     { name = "connect-python" },
-    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "gcsfs" },
+    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "gcsfs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "gcsfs", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "google-auth" },
     { name = "google-cloud-tpu" },
     { name = "grpcio" },
@@ -3310,14 +3530,15 @@ dependencies = [
     { name = "marin-finelog-server" },
     { name = "marin-rigging" },
     { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
-    { name = "s3fs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "s3fs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "s3fs", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "sqlalchemy" },
     { name = "starlette" },
     { name = "tabulate" },
     { name = "typing-extensions" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "uvicorn", extra = ["standard"] },
     { name = "zstandard" },
 ]
 
@@ -3328,13 +3549,16 @@ source = { git = "https://github.com/marin-community/marin.git?subdirectory=lib%
 dependencies = [
     { name = "click" },
     { name = "connect-python" },
-    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "gcsfs" },
+    { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "fsspec", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "gcsfs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "gcsfs", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "google-auth" },
-    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "s3fs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "s3fs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "s3fs", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "starlette" },
 ]
 
@@ -3423,6 +3647,62 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-rl' or extra == 'extra-18-openthoughts-agent-sft-qwen35' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (extra != 'extra-18-openthoughts-agent-datagen' and extra != 'extra-18-openthoughts-agent-datagen-tpu')" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6c/7ef7ebcb2bd9739b2b66b18b076e077f44bb46fdbe28ca0506edb3c62c79/matplotlib-3.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e15ef41507f3d525f46154ac9e3ae785dacde9f20e593a25de8986267892ef74", size = 9453849, upload-time = "2026-07-18T03:38:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f8/6d0c312c8d9738e7d9677f09fe5c986b3239e651a7b73a2deb38b65e4a71/matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21a67b961a6d597bca54fae826cd20695ba4a6e4d05424a08da6e13e3176fd6b", size = 9283113, upload-time = "2026-07-18T03:38:21.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea", size = 10035615, upload-time = "2026-07-18T03:38:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/4e10e033d9b66589d8ed98b84c95cdbb57033d57c1f41339d7393dbd2f2e/matplotlib-3.11.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c52f7ad20ef476806ed212380b1d54d20310c8b86bdc2c9a68b51f0024a44472", size = 10842559, upload-time = "2026-07-18T03:38:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/88/eb/799612d0f8cd3e816a10fec59329fca52cd2353264df80378dfc541ae855/matplotlib-3.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8b14eb22961fe865efb0e4ff167e333e428908b00115a8d800ccb65ee108e481", size = 10927532, upload-time = "2026-07-18T03:38:28.532Z" },
+    { url = "https://files.pythonhosted.org/packages/88/89/56649bbaa2fd12e20f3be03dbcc135b0c8676d88bac17977599e3eb442a0/matplotlib-3.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:88a2a27dd9691ae448dfae4b26f59036be90c3c28757edd3553a29559d00859f", size = 9333886, upload-time = "2026-07-18T03:38:30.477Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/11/4d124efbbad677b7b7552f6f85a3bd432d4232f95400cea98fcd2ae36ef3/matplotlib-3.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:480194afceca4df2f137c2721227d3cba67121fbf4397b69cee7f83714b0a58a", size = 9007545, upload-time = "2026-07-18T03:38:32.833Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6c/4798363b7fb5644e309fe1fac30216e9146c9f70859d80d588c18caf5317/matplotlib-3.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6771b0cd7838c6a857a7209814158c0ad09bfef878db3033dd82d70ad101f191", size = 9454341, upload-time = "2026-07-18T03:38:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/59/98/6acadbe7f98df19d274bc107ac58bb439fa75df82c33dc110d71a4a8501f/matplotlib-3.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2abdee5ffa2fe11b2d19f7a5c63b785fb7c28cc46c7bc1814156341d9d1a33e1", size = 9283627, upload-time = "2026-07-18T03:38:37.061Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ea/65cec46fe241390ccea1b1754207ee28eb71c5ab866bd5f22fe47e538fa4/matplotlib-3.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0a19dcf73406d3746d25a5ed42d713604c9a3e024d129b102852b0d941cb9f3", size = 10035860, upload-time = "2026-07-18T03:38:39.663Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/10/63fdccccbabe002fb0960876baabc5e3f24d9c1bb4cfb25651457f74b3a0/matplotlib-3.11.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7389b77ed2ab0552f46d9a90b81b7b8e6dfcdc42adc36c37a0865799843e0e3e", size = 10843594, upload-time = "2026-07-18T03:38:42.144Z" },
+    { url = "https://files.pythonhosted.org/packages/98/51/a1155945bff7b91381875022ac1522c5dfdac0d006be8e7df389b3134eae/matplotlib-3.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c90be0b73568da4f662afac580956a76e308437e641b4a45aa08925eeb67d95f", size = 10927962, upload-time = "2026-07-18T03:38:44.302Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/3a/3d5e1f42dc761bf53401a62a83ff93389b37de9d2c093b2a3aa49ac34f1b/matplotlib-3.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:68408341f2312836fbbdf6b3c78047f65b2d8752f5fd221c3e72d348f5b34f8b", size = 9334074, upload-time = "2026-07-18T03:38:46.616Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/db/3f5ea5a5b64060ef5e1ff60a19170423e41ce21b8497a6fe15a36e0b43e3/matplotlib-3.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c1f44890d435c1b4ef52f701ad5828cb450ea97bcc83918fda6be74965d6cd2", size = 9007662, upload-time = "2026-07-18T03:38:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/c7ae5e0531425b69c0826b00ebbc264c85cab853f1cd6e096c9983c2cdc1/matplotlib-3.11.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:5e510088c27a89d53580a752f959146893563e63c330e161d159b0fee652af6f", size = 9503790, upload-time = "2026-07-18T03:38:51.527Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/15be162e0a2ed546939674e2e97d0e33ec2447d86d4d4e611fa295bb178c/matplotlib-3.11.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:1524e2bdd48a93557aa47ddcfe9c225dfdd57d5a01a5c49128c20f0632980ee1", size = 9336148, upload-time = "2026-07-18T03:38:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7f/36ffe144fc4aacfe0e3ed2318f72b6755d1e73b041d619b4d393e60f5a66/matplotlib-3.11.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11664c551345553db92e61cae6cf1376f138f8c47cafdf13b64b18f3e3e9e464", size = 10049244, upload-time = "2026-07-18T03:38:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/55812d68c0a840d3a463638f48c00ab1fe338518ec49a640cb6473b444af/matplotlib-3.11.1-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e1f8922ba31959cf6a9dfb51be64b7f7bc582801a3957dc0c2f3afcd3537adf", size = 10860798, upload-time = "2026-07-18T03:38:58.282Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/64/cca444b4eb5e6c768c44fc5e1f0b5211f20ca2b282778051996e996a2bdf/matplotlib-3.11.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83235693abde86e5e0129998f80ee39fc7f58e6d56a88fafb28a9278833e9d5f", size = 10943282, upload-time = "2026-07-18T03:39:00.465Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0f/a49c329d394f2e9ef38506982107e8b04ecf94dd41a9d8423ff82cc737c7/matplotlib-3.11.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9a076f4fc5cdc43fdf510f5981418d25c2db4973418d9f22d8bb3dc8045ada78", size = 9383532, upload-time = "2026-07-18T03:39:02.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/50/103e86afb806d8f64d04ede14e4cfc09dbfc25f512421ff85fdd6ebd59cf/matplotlib-3.11.1-cp313-cp313t-win_arm64.whl", hash = "sha256:216fbb93a74add02ddb4cb38ef5348f59ac00b3e84567eaf16598772d40e150a", size = 9059665, upload-time = "2026-07-18T03:39:04.607Z" },
+    { url = "https://files.pythonhosted.org/packages/35/04/3079499fa8cb661ea66d13d6439d5a3ae6710a7afd5c7f72e08914f275f8/matplotlib-3.11.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c492d4ba9448595b6fd8708c6725963f8148e25c0d8842948da5b05f0ee8d3", size = 9456022, upload-time = "2026-07-18T03:39:07.041Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a2/69acfe84ec1f32930e801a5782a07fc5c79c8c6599a507b806d859d5da8e/matplotlib-3.11.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ac104be2768ffdd8655db9e71b768cbb45f2b9aa7b450cf1595e8f65d3822319", size = 9285475, upload-time = "2026-07-18T03:39:09.562Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/31b15a2ca56d4ddd6aaa1c884c2f51cf9a61cfaf5ca6f6fbd6343d38e6df/matplotlib-3.11.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be943cb68bc6660ead58c55b3aa6366cba2ef7feb06460fbcce32360376f19f", size = 10847102, upload-time = "2026-07-18T03:39:11.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0d/a17e966e620545c1548125af0b29ac812dd17b197a18a7462ac12fa859ee/matplotlib-3.11.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5af0dcda57d471440a7b5b623e70e0a61003518443d9098f211a96ecfbbc25be", size = 11131087, upload-time = "2026-07-18T03:39:13.764Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c5/5e100efdd67abb7de20befaa333612ef9bfc63417fb71398f904f25d083c/matplotlib-3.11.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3d3fd84082b1afbd9398466c81309e20045be20d48fe0fb18c43504d164cbbb2", size = 10929036, upload-time = "2026-07-18T03:39:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/d719a0a36930ecc8dfc801ff340f9dcfc4223f8ca5d39d06b4020032fff8/matplotlib-3.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:9601a1e90be21e4884c53b4f3dc3ee0544654946f9975258d691f1c2e2f119c6", size = 9489571, upload-time = "2026-07-18T03:39:19.449Z" },
+    { url = "https://files.pythonhosted.org/packages/48/65/facabdc2f1f6caba7e856db64dfedddca25f7608df07d96a1c8fd114fd3b/matplotlib-3.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:ae30c6109848ac0f9fa36c5d6270938487614c47ba31860bd5361266dabc5685", size = 9164486, upload-time = "2026-07-18T03:39:21.424Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/18da6cd01cf96354534f98c468a25380c68ce582a2c9dd0cae12b04af4f2/matplotlib-3.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dadfe80797174e2984aae3be0b77594a3c72d2c0a40fbd4a0de48d2728caf3ae", size = 9504876, upload-time = "2026-07-18T03:39:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b0/f0b63555a18b79d038c81fd6126f35fc4dfce0eaff48d96103348c7cf935/matplotlib-3.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:89b193b255f4f6f7948dbcee3691f4f341ab05d9a8874a67b45ddb4182922eda", size = 9336120, upload-time = "2026-07-18T03:39:25.797Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/dd/f210ec7c4a6f198d5567237048a93d0811fb5a1f1691f13320e592f95b41/matplotlib-3.11.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191163532cdefcb1571ca38a6d7e6474baccde64495783e6ba47aa07ec4b9bbb", size = 10858033, upload-time = "2026-07-18T03:39:27.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d2/d6d5324507c5fbb316db48e258c09c2807f3de03d9af47017e120070926f/matplotlib-3.11.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fdf1c818ab05d0e74002091ddaf414478a3a449ec9d51c8976d45be7e3a01e2", size = 11141827, upload-time = "2026-07-18T03:39:30.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/68/3c22e9320bdce2c4d2f1320643ef706db7a24cb7420eea28b97a2d67f5a8/matplotlib-3.11.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b937b9dba5f5f6c1e31c47abe2186c865c0914fd18f2ce0dfc39c9adcef5951d", size = 10943061, upload-time = "2026-07-18T03:39:32.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/907ed190ee81a9df581e0ed5456134fc0f7cb55ffcfda2f9e54ca900761c/matplotlib-3.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f2912f647f3fbe1ccf085f91e213936f9101bead81a5e670565b1f1b3712f4fb", size = 9540074, upload-time = "2026-07-18T03:39:34.789Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d4/97c19b77e0a6e3b48581185bb65088f431cd20186076cc0f650a1757ea46/matplotlib-3.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:54d47b8ae8b579633a3902ca5b4ad6c1e132a5626d64447b2e22a66394e79987", size = 9213472, upload-time = "2026-07-18T03:39:37.141Z" },
 ]
 
 [[package]]
@@ -5095,6 +5375,14 @@ sft-qwen35 = [
     { name = "trufflehog" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "boto3" },
+    { name = "marin-iris" },
+    { name = "matplotlib" },
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'datagen'", specifier = "==1.12.0" },
@@ -5181,7 +5469,12 @@ requires-dist = [
 provides-extras = ["datagen-cpu", "datagen", "datagen-swesmith", "datagen-tpu", "cloud", "cloud-aws", "cloud-lambda", "cloud-vast", "cloud-kubernetes", "cloud-all", "rl", "sft-qwen35", "harbor-docker", "harbor-modal", "harbor-all"]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [
+    { name = "boto3" },
+    { name = "marin-iris", git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Firis&rev=33525a77c" },
+    { name = "matplotlib" },
+    { name = "pytest" },
+]
 
 [[package]]
 name = "opt-einsum"
@@ -6459,7 +6752,7 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -7742,7 +8035,7 @@ name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
@@ -8504,7 +8797,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
     { name = "flax" },
-    { name = "gcsfs" },
+    { name = "gcsfs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" } },
     { name = "google-cloud-storage" },
     { name = "hypothesis" },
     { name = "jax" },
@@ -8936,11 +9229,11 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "httptools" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32') or (platform_python_implementation == 'PyPy' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (platform_python_implementation == 'PyPy' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (platform_python_implementation == 'PyPy' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (platform_python_implementation == 'PyPy' and extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (platform_python_implementation == 'PyPy' and extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (platform_python_implementation == 'PyPy' and extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (sys_platform == 'cygwin' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (sys_platform == 'cygwin' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (sys_platform == 'cygwin' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (sys_platform == 'cygwin' and extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (sys_platform == 'cygwin' and extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (sys_platform == 'cygwin' and extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (sys_platform == 'win32' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-datagen-tpu') or (sys_platform == 'win32' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (sys_platform == 'win32' and extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (sys_platform == 'win32' and extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (sys_platform == 'win32' and extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (sys_platform == 'win32' and extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "watchfiles" },
     { name = "websockets" },
 ]


### PR DESCRIPTION
Makes CI reproducible with the Iris, S3, and plotting dependencies the test suite imports. Uses `uv sync --group dev` against the committed lockfile and allows `scripts.iris.iris_ops` to use the installed Iris package when a local Marin checkout is absent. Also applies the repository’s configured Ruff formatter to pre-existing test drift.