### PR TITLE
fix(hpc): avoid served-model ID timestamp collisions

### DIFF
--- a/hpc/launch_utils.py
+++ b/hpc/launch_utils.py
@@ -300,7 +300,7 @@ def generate_served_model_id(job_name: Optional[str] = None) -> str:
     deterministic-per-job ID makes the YAML stable across launches so the
     equality check passes on resume.
 
-    When ``job_name`` is omitted, falls back to a microsecond timestamp
+    When ``job_name`` is omitted, falls back to a nanosecond timestamp
     (legacy behavior; used by ad-hoc paths like
     ``hpc/local_runner_utils.py`` that don't have a job name in hand).
     """
@@ -310,7 +310,10 @@ def generate_served_model_id(job_name: Optional[str] = None) -> str:
         # Take the top 64 bits, convert to decimal, truncate to 16 chars.
         # 64 bits → up to 20 decimal digits; truncate for vLLM-friendly length.
         return str(int(digest_hex[:16], 16))[:16]
-    return str(int(time.time() * 1_000_000))
+    # A microsecond timestamp can collide when two local serves are assembled in
+    # the same tick (including ordinary sequential Python calls). Keep the
+    # legacy 16-digit numeric shape while using the clock's finer-grained value.
+    return f"{time.time_ns() % 10**16:016d}"
 
 
 def hosted_vllm_alias(served_id: str) -> str:

--- a/tests/hpc/test_resume_determinism.py
+++ b/tests/hpc/test_resume_determinism.py
@@ -45,6 +45,18 @@ def test_served_model_id_deterministic_for_same_job_name():
     )
 
 
+def test_served_model_id_without_job_name_uses_nanosecond_precision(monkeypatch):
+    timestamps = iter([1_234_567_890_123_456_789, 1_234_567_890_123_456_790])
+    monkeypatch.setattr("hpc.launch_utils.time.time_ns", lambda: next(timestamps))
+
+    first = generate_served_model_id(job_name=None)
+    second = generate_served_model_id(job_name=None)
+
+    assert first == "4567890123456789"
+    assert second == "4567890123456790"
+    assert len(first) == len(second) == 16
+
+
 def test_harbor_run_dir_name_stable_when_job_name_set():
     # local_runner_utils computes: job_name = args.job_name or default_job_name(...).
     # With a stable args.job_name the run dir is that name (deterministic); without


### PR DESCRIPTION
## Summary
- use nanosecond precision for legacy no-job-name served model IDs
- retain the 16-digit numeric model alias shape

## Test
- `/Users/benjaminfeuer/miniconda3/envs/otagent/bin/python -m pytest -q tests/hpc/test_resume_determinism.py`