### PR TITLE
fix(ci): align Iris evals with seven-day token TTL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,8 @@ datagen-tpu = [
     "torchvision==0.25.0; (sys_platform == 'linux' and platform_machine == 'aarch64') or (sys_platform == 'darwin' and platform_machine == 'arm64')",
     "ray[default]>=2.50.0",
     "transformers>=5.3.0",
-    "marin-iris @ git+https://github.com/marin-community/marin.git@33525a77c#subdirectory=lib/iris",
-    "marin-rigging @ git+https://github.com/marin-community/marin.git@33525a77c#subdirectory=lib/rigging",
+    "marin-iris @ git+https://github.com/marin-community/marin.git@59f64fcd7e#subdirectory=lib/iris",
+    "marin-rigging @ git+https://github.com/marin-community/marin.git@59f64fcd7e#subdirectory=lib/rigging",
 ]
 cloud = [
     "skypilot>=0.6.1",
@@ -171,7 +171,7 @@ extra-index-url = ["https://download.pytorch.org/whl/cu128"]
 dev = [
     "boto3",
     "matplotlib",
-    "marin-iris @ git+https://github.com/marin-community/marin.git@33525a77c#subdirectory=lib/iris",
+    "marin-iris @ git+https://github.com/marin-community/marin.git@59f64fcd7e#subdirectory=lib/iris",
     "pytest",
 ]
 

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -53,7 +53,7 @@ DEFAULT_TASK_IMAGE = (
 DEFAULT_SERVE_READY_TIMEOUT_SECONDS = 1800.0
 # The serve watches only model-inference requests (not readiness/health probes)
 # and frees the H100x8 slice after this idle interval.  The Marin-side flag is
-# intentionally distinct from the 24-hour capability-token and wall-clock TTLs.
+# intentionally distinct from the seven-day capability-token and wall-clock TTLs.
 DEFAULT_SERVE_IDLE_TIMEOUT_HOURS = 1.0
 # OpenAI-compatible installed agents require a non-empty value, but the scoped
 # capability URL is the credential. Do not use a sidecar bearer here.

--- a/tests/analysis/test_iris_ops.py
+++ b/tests/analysis/test_iris_ops.py
@@ -87,7 +87,9 @@ def test_box_table_color_preserves_plain_layout_and_can_be_stripped():
 
 def test_monitor_error_report_is_separate_stable_and_single_line(tmp_path):
     errors = [
-        MonitorError("cw-rno2a/job-a", "Finelog sync", "proxy failed\nTraceback: details"),
+        MonitorError(
+            "cw-rno2a/job-a", "Finelog sync", "proxy failed\nTraceback: details"
+        ),
         MonitorError("marin", "discovery", "controller unavailable"),
     ]
 
@@ -453,7 +455,9 @@ def test_tis_ratio_summary_uses_distinct_legacy_importance_ratio_label():
 
 
 def test_rl_report_row_replaces_traceback_signal_with_error_report_pointer(tmp_path):
-    (tmp_path / "finelog.log").write_text("Traceback (most recent call last)\nraw details\n")
+    (tmp_path / "finelog.log").write_text(
+        "Traceback (most recent call last)\nraw details\n"
+    )
     cluster = watch_coreweave_rl.Cluster("cw-rno2a", Path("/tmp/kubeconfig"), None)
     job = watch_coreweave_rl.RlJob(cluster, "/user/rl-job", "failed", 0, "")
     artifacts = watch_coreweave_rl.ArtifactResult(
@@ -506,7 +510,9 @@ def test_rl_main_degrades_unexpected_job_sync_failure_into_error_report(
             LookupError("unexpected raw sync exception")
         ),
     )
-    monkeypatch.setattr(watch_coreweave_rl, "write_job_manifest", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        watch_coreweave_rl, "write_job_manifest", lambda *_args, **_kwargs: None
+    )
 
     assert watch_coreweave_rl.main() == 0
 

--- a/tests/analysis/test_watch_coreweave_datagen.py
+++ b/tests/analysis/test_watch_coreweave_datagen.py
@@ -240,7 +240,9 @@ def test_harbor_main_degrades_job_failures_and_writes_separate_error_report(
         ),
     )
     monkeypatch.setattr(monitor, "CLUSTERS", (cluster,))
-    monkeypatch.setattr(monitor, "discover_harbor_jobs", lambda *_args, **_kwargs: ([job], []))
+    monkeypatch.setattr(
+        monitor, "discover_harbor_jobs", lambda *_args, **_kwargs: ([job], [])
+    )
     monkeypatch.setattr(
         monitor,
         "fetch_finelog",
@@ -259,7 +261,9 @@ def test_harbor_main_degrades_job_failures_and_writes_separate_error_report(
             None, None, "unavailable", "progress raw exception"
         ),
     )
-    monkeypatch.setattr(monitor, "write_bundle_manifest", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        monitor, "write_bundle_manifest", lambda *_args, **_kwargs: None
+    )
 
     assert monitor.main() == 0
 

--- a/tests/hpc/test_export_literal_threading.py
+++ b/tests/hpc/test_export_literal_threading.py
@@ -72,11 +72,14 @@ def test_inline_merger_accepts_current_harbor_extractor_keywords(tmp_path):
     trajectory.write_text('{"steps": []}')
     try:
         mkupload._install_inline_subagent_merger()
-        assert traces_utils.extract_conversations_from_trajectory(
-            trajectory,
-            {"agent_name": "terminus-2", "model_name": "m", "start_time": "now"},
-            sft_format=False,
-        ) == []
+        assert (
+            traces_utils.extract_conversations_from_trajectory(
+                trajectory,
+                {"agent_name": "terminus-2", "model_name": "m", "start_time": "now"},
+                sft_format=False,
+            )
+            == []
+        )
     finally:
         traces_utils.extract_conversations_from_trajectory = original
 

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -29,7 +29,7 @@ def test_mint_requires_one_capability_url(monkeypatch):
             parent_cluster="marin",
             parent_ingress_host="https://iris.oa.dev",
             endpoint_name="/serve/example",
-            ttl_hours=24,
+            ttl_hours=168,
         )
         == "https://iris.oa.dev/proxy/t/token/serve.example/v1"
     )
@@ -48,7 +48,7 @@ def test_mint_rejects_missing_or_ambiguous_urls(monkeypatch):
             parent_cluster="marin",
             parent_ingress_host="https://iris.oa.dev",
             endpoint_name="/serve/example",
-            ttl_hours=24,
+            ttl_hours=168,
         )
 
 
@@ -61,7 +61,7 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
         memory="128GB",
         disk="128GB",
         priority="batch",
-        timeout=86400,
+        timeout=604800,
         capability_token_duration_policy_json='{"token_required": true}',
         job_name="eval-v2",
         harbor_config="config.yaml",
@@ -90,7 +90,7 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
     assert "--n_concurrent 256" in shell
     assert "--job_name eval-v2" in shell
     assert "--experiments_dir /tmp/ot-agent-runs/eval-v2" in shell
-    assert command[command.index("--timeout") + 1] == "86400"
+    assert command[command.index("--timeout") + 1] == "604800"
     assert (
         "--harbor_extra_arg=--jobs-dir=s3://marin-us-east-02a/iris/eval-v2/trace_jobs"
         in shell
@@ -161,7 +161,7 @@ def test_mint_rejects_a_peer_ingress_url(monkeypatch):
             parent_cluster="marin",
             parent_ingress_host="https://iris.oa.dev",
             endpoint_name="/serve/example",
-            ttl_hours=24,
+            ttl_hours=168,
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -503,6 +503,15 @@ wheels = [
 ]
 
 [[package]]
+name = "braceexpand"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/93/badd4f5ccf25209f3fef2573073da9fe4a45a3da99fca2f800f942130c0f/braceexpand-0.1.7.tar.gz", hash = "sha256:e6e539bd20eaea53547472ff94f4fb5c3d3bf9d0a89388c4b56663aba765f705", size = 7777, upload-time = "2021-05-07T13:49:07.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/93/e8c04e80e82391a6e51f218ca49720f64236bc824e92152a2633b74cf7ab/braceexpand-0.1.7-py2.py3-none-any.whl", hash = "sha256:91332d53de7828103dcae5773fb43bc34950b0c8160e35e0f44c4427a3b85014", size = 5923, upload-time = "2021-05-07T13:49:05.146Z" },
+]
+
+[[package]]
 name = "bs4"
 version = "0.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3481,7 +3490,7 @@ wheels = [
 [[package]]
 name = "marin-finelog"
 version = "0.2.11"
-source = { git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Ffinelog&rev=33525a77c#33525a77c777d4baab7049d565b013eccd3be58f" }
+source = { git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Ffinelog&rev=59f64fcd7e#59f64fcd7e49f0ba2e2beb6a1b315046e348bcf1" }
 dependencies = [
     { name = "click" },
     { name = "connect-python" },
@@ -3512,7 +3521,7 @@ wheels = [
 [[package]]
 name = "marin-iris"
 version = "0.2.0"
-source = { git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Firis&rev=33525a77c#33525a77c777d4baab7049d565b013eccd3be58f" }
+source = { git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Firis&rev=59f64fcd7e#59f64fcd7e49f0ba2e2beb6a1b315046e348bcf1" }
 dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
@@ -3545,8 +3554,9 @@ dependencies = [
 [[package]]
 name = "marin-rigging"
 version = "0.2.0"
-source = { git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Frigging&rev=33525a77c#33525a77c777d4baab7049d565b013eccd3be58f" }
+source = { git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Frigging&rev=59f64fcd7e#59f64fcd7e49f0ba2e2beb6a1b315046e348bcf1" }
 dependencies = [
+    { name = "braceexpand" },
     { name = "click" },
     { name = "connect-python" },
     { name = "fsspec", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
@@ -3554,6 +3564,7 @@ dependencies = [
     { name = "gcsfs", version = "2026.1.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen' and extra == 'extra-18-openthoughts-agent-sft-qwen35') or (extra == 'extra-18-openthoughts-agent-rl' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "gcsfs", version = "2026.2.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-18-openthoughts-agent-datagen' or extra != 'extra-18-openthoughts-agent-datagen-tpu' or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-rl') or (extra == 'extra-18-openthoughts-agent-datagen-tpu' and extra == 'extra-18-openthoughts-agent-sft-qwen35')" },
     { name = "google-auth" },
+    { name = "prometheus-client" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
     { name = "requests" },
@@ -5416,8 +5427,8 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=0.20.0,<2.0.0" },
     { name = "jinja2", marker = "extra == 'rl'" },
     { name = "liger-kernel", marker = "extra == 'sft-qwen35'", specifier = ">=0.5.0" },
-    { name = "marin-iris", marker = "extra == 'datagen-tpu'", git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Firis&rev=33525a77c" },
-    { name = "marin-rigging", marker = "extra == 'datagen-tpu'", git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Frigging&rev=33525a77c" },
+    { name = "marin-iris", marker = "extra == 'datagen-tpu'", git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Firis&rev=59f64fcd7e" },
+    { name = "marin-rigging", marker = "extra == 'datagen-tpu'", git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Frigging&rev=59f64fcd7e" },
     { name = "modal", marker = "extra == 'harbor-all'", specifier = ">=0.60.0" },
     { name = "modal", marker = "extra == 'harbor-modal'", specifier = ">=0.60.0" },
     { name = "numpy", specifier = "<=2.26.0" },
@@ -5471,7 +5482,7 @@ provides-extras = ["datagen-cpu", "datagen", "datagen-swesmith", "datagen-tpu", 
 [package.metadata.requires-dev]
 dev = [
     { name = "boto3" },
-    { name = "marin-iris", git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Firis&rev=33525a77c" },
+    { name = "marin-iris", git = "https://github.com/marin-community/marin.git?subdirectory=lib%2Firis&rev=59f64fcd7e" },
     { name = "matplotlib" },
     { name = "pytest" },
 ]


### PR DESCRIPTION
Pin Marin Iris and Rigging to the controller revision that raises endpoint capability-token lifetime to seven days. External OpenCode eval defaults and fixtures now resolve to the same 604800-second lifetime.

Also apply the repository Ruff formatter to the three pre-existing test files reported by CI so the branch can pass its all-tests formatting gate.