### PR TITLE
chore(deps): refresh Harbor OpenCode runtime

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2549,7 +2549,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#394c58fe27132cb72ea4bd309872680a6dc8e313" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#6795602ff3cf5a8f66afab3987924469bf3e39af" }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "datasets" },


### PR DESCRIPTION
Refresh the Harbor lock pin to merged Harbor PR #38 (`6795602f`). OpenThoughts jobs installed from `penfever/working` will therefore receive the unconditional `OPENCODE_DISABLE_FFF=1` runtime environment setting.