### PR TITLE
fix(iris): pin Harbor runtime to cancellation fixes

### DIFF
--- a/docker/Dockerfile.gpu-glm52
+++ b/docker/Dockerfile.gpu-glm52
@@ -47,6 +47,15 @@ ENV UV_HTTP_TIMEOUT=300
 ENV UV_RETRIES=5
 RUN . /opt/openthoughts/.venv/bin/activate && uv pip install -e ".[datagen,cloud,harbor-all]"
 
+# GLM jobs use --baked-venv, so pin Harbor from source here as well as in the
+# TPU runtime lock. Changing this value intentionally invalidates Kaniko's
+# cached Harbor layer for every relaunch image.
+ENV HARBOR_COMMIT=772e20f7a76bec749e634a054ff4546a3468f5cb
+RUN . /opt/openthoughts/.venv/bin/activate && \
+    uv pip install --force-reinstall --no-deps \
+      "harbor[daytona] @ git+https://github.com/marin-community/harbor.git@${HARBOR_COMMIT}" && \
+    python -c "import harbor; print('harbor', harbor.__version__, harbor.__file__)"
+
 # --- GLM-5.2: swap the pinned pypi vLLM for the marin-community fork (main). No nvcc on this
 #     runtime base, so use VLLM_USE_PRECOMPILED: setup.py fetches precompiled kernels from the
 #     pinned fork<->upstream merge-base commit (cu129 abi3 wheel; runs on the 12.8 cudnn base)

--- a/docker/Dockerfile.gpu-glm52-nvcc
+++ b/docker/Dockerfile.gpu-glm52-nvcc
@@ -69,12 +69,10 @@ print('vllm', vllm.__version__); \
 assert 'GlmMoeDsaForCausalLM' in R.get_supported_archs(), 'GlmMoeDsaForCausalLM MISSING from vllm registry'; \
 print('GlmMoeDsaForCausalLM OK')"
 
-# Pin + force-reinstall harbor at the commit carrying the s3 endpoint_url->client_kwargs fix
-# (marin-community/harbor #20). harbor is a fast-moving git dep installed via the harbor-all extra
-# above; the HARBOR_COMMIT env-line busts the kaniko layer cache so the rebuild picks up the fix
-# instead of a stale cached harbor@main. --no-deps: the fix is version-robust, so we only swap
-# harbor's own code, not its (already-installed) deps.
-ENV HARBOR_COMMIT=c1ee1aad289a5455a9a373ef34115b0fb70ac402
+# GLM jobs use --baked-venv, so pin Harbor from source here as well as in the
+# TPU runtime lock. Changing this value intentionally invalidates Kaniko's
+# cached Harbor layer for every relaunch image.
+ENV HARBOR_COMMIT=772e20f7a76bec749e634a054ff4546a3468f5cb
 RUN . /opt/openthoughts/.venv/bin/activate && \
     uv pip install --force-reinstall --no-deps \
       "harbor[daytona] @ git+https://github.com/marin-community/harbor.git@${HARBOR_COMMIT}" && \

--- a/docker/Dockerfile.tpu
+++ b/docker/Dockerfile.tpu
@@ -84,10 +84,9 @@ RUN . /opt/openthoughts/.venv/bin/activate && \
 # --force-reinstall makes uv rebuild harbor from the exact pinned commit
 # regardless of any cached wheel. This is why datagen resume/export-push fixes
 # reach the worker deterministically. Bump HARBOR_COMMIT for every harbor change
-# that must ship in the image. 22d75039 = harbor main HEAD (2026-07-15) — PR #6
-# squash-merged the consolidated penfever/working state into main (was 2dde0bbf on
-# the retiring penfever/working branch); harbor now lands via fresh-branch->main.
-ENV HARBOR_COMMIT=22d75039694db5c223797d5eec75b5c1ae975ac6
+# that must ship in the image. Keep this aligned with the Harbor pin in uv.lock;
+# the worker's frozen sync is the runtime authority.
+ENV HARBOR_COMMIT=772e20f7a76bec749e634a054ff4546a3468f5cb
 RUN . /opt/openthoughts/.venv/bin/activate && \
     uv pip install --no-deps --force-reinstall \
         "harbor[daytona] @ git+https://github.com/marin-community/harbor.git@${HARBOR_COMMIT}" && \

--- a/docker/build_gpu_glm52_kaniko.sh
+++ b/docker/build_gpu_glm52_kaniko.sh
@@ -27,8 +27,9 @@ SINGLE_SNAPSHOT="${SINGLE_SNAPSHOT:-0}"
 if [ "$SINGLE_SNAPSHOT" = "1" ]; then SNAPSHOT_FLAG="--single-snapshot"; else SNAPSHOT_FLAG=""; fi
 
 DOCKERFILE="${DOCKERFILE:-docker/Dockerfile.gpu-glm52}"
+IMAGE_TAG_PREFIX="${IMAGE_TAG_PREFIX:-gpu-glm52}"
 CACHE_REPO=ghcr.io/open-thoughts/openthoughts-agent/cache-glm52
-DEST_PINNED=ghcr.io/open-thoughts/openthoughts-agent:gpu-glm52-${GITSHA}
+DEST_PINNED="ghcr.io/open-thoughts/openthoughts-agent:${IMAGE_TAG_PREFIX}-${GITSHA}"
 
 # --- 1. fetch crane (static binary) ---
 apt-get update -y && apt-get install -y --no-install-recommends ca-certificates curl tar

--- a/uv.lock
+++ b/uv.lock
@@ -2549,7 +2549,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#6795602ff3cf5a8f66afab3987924469bf3e39af" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#772e20f7a76bec749e634a054ff4546a3468f5cb" }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "datasets" },


### PR DESCRIPTION
Updates the TPU runtime lock and baked TPU/GLM images to Harbor `772e20f7` (#40).

GLM launchers use `--baked-venv`, so the NVCC image now installs that exact Harbor source revision. TPU workers receive the same revision through `uv.lock`, which their frozen bootstrap reinstall treats as authoritative.

Also makes the GLM Kaniko script support an explicit immutable tag prefix for the NVCC variant.

Tests: `/Users/benjaminfeuer/miniconda3/envs/otagent/bin/python -m pytest tests/hpc/test_iris_launcher_args.py -q` (8 passed); `bash -n docker/build_gpu_glm52_kaniko.sh`.