### PR TITLE
Add RL publication redaction gate

### DIFF
--- a/.agents/skills/rl-agentic-job-cleanup/SKILL.md
+++ b/.agents/skills/rl-agentic-job-cleanup/SKILL.md
@@ -90,7 +90,10 @@ trufflehog filesystem $EXPERIMENTS_DIR/<job_name>/<job_name> --no-update        
 # fallback:
 grep -rIE '(sk-[a-zA-Z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[a-zA-Z0-9]{36}|hf_[a-zA-Z0-9]{34}|eyJ[a-zA-Z0-9._-]+)' $UPLOAD_DIR
 ```
-Remove/redact anything found before proceeding.
+Redact before proceeding (the wrapper emits a JSON finding record even when clean):
+```bash
+python -m scripts.harbor.secret_redaction "$UPLOAD_DIR"
+```
 
 ## 6. Upload to HuggingFace — `laion/<job_name>-<step>-<size>`
 Include the global step and base-model size suffix (`-20-32B`, `-30-8B`).
@@ -158,6 +161,16 @@ Produces `metrics.csv`, `vllm_metrics.csv`, `trial_stats.csv`, `report.md`, `rew
 **WARNING:** never use `huggingface_hub.upload_folder()` without `delete_patterns=[]` — it deletes files absent
 locally and clobbers the weights. `hf upload` is additive (safe).
 
-## 10. Clean up the experiments dir
+## 10. Verify the published model and write the completion record
+The model is complete only when its remote repo has weights, `README.md` with **Training Traces**, and
+redacted `training_logs/`. Record every artifact as **present**, **absent**, or **not applicable** in the
+cleanup handoff; an absent required artifact is not a completed cleanup.
+```bash
+hf api repo-info laion/<job_name>-<step>-<size> --repo-type model --expand siblings \
+ | python -c 'import json,sys; files=[x["rfilename"] for x in json.load(sys.stdin)["siblings"]]; print({"weights": any(x.endswith(".safetensors") for x in files), "readme": "README.md" in files, "training_logs": any(x.startswith("training_logs/") for x in files)})'
+```
+Fetch `README.md` and verify it contains `## Training Traces` and the exact `penfever/<job_name>` URL.
+
+## 11. Clean up the experiments dir
 After all prior steps succeed, `rm -rf` the local job dir. Detach a large GPFS removal with `nohup` or `tmux`;
 do not `du` or `find` it first.

--- a/scripts/harbor/make_and_upload_trace_dataset.py
+++ b/scripts/harbor/make_and_upload_trace_dataset.py
@@ -89,10 +89,11 @@ def _install_safe_episode_guard() -> None:
 
 
 def _install_dataset_sanitizer() -> None:
-    """Patch Harbor's rows_to_dataset to sanitize surrogate characters before HF conversion."""
+    """Patch Harbor rows before HF conversion to redact credentials and sanitize surrogates."""
     try:
         from harbor.utils import traces_utils  # type: ignore
         from scripts.harbor.run_and_export_traces import _strip_surrogates  # type: ignore
+        from scripts.harbor.secret_redaction import redact_record
     except Exception:
         return
 
@@ -106,7 +107,10 @@ def _install_dataset_sanitizer() -> None:
         cleaned_rows = []
         for row in rows:
             if isinstance(row, dict):
-                cleaned_rows.append({k: _strip_surrogates(v) for k, v in row.items()})
+                redacted, findings = redact_record(row)
+                if findings:
+                    print(f"[trace-export] Redacted {len(findings)} credential-shaped values.")
+                cleaned_rows.append({k: _strip_surrogates(v) for k, v in redacted.items()})
             else:
                 cleaned_rows.append(row)
         return original_rows_to_dataset(cleaned_rows, *args, **kwargs)

--- a/scripts/harbor/secret_redaction.py
+++ b/scripts/harbor/secret_redaction.py
@@ -1,0 +1,85 @@
+"""Redact credential-shaped text before publishing models or trace datasets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One replaced credential shape and its source location."""
+
+    shape: str
+    location: str
+    line: int | None = None
+
+
+REDACTIONS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("pem_private_key", re.compile(r"-----BEGIN [^-]*PRIVATE KEY-----.*?-----END [^-]*PRIVATE KEY-----", re.DOTALL)),
+    ("jwt", re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")),
+    ("aws_access_key", re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")),
+    ("openai_key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
+    ("huggingface_token", re.compile(r"\bhf_[A-Za-z0-9]{20,}\b")),
+    ("github_token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b")),
+)
+
+
+def redact(text: str, *, location: str = "text") -> tuple[str, list[Finding]]:
+    """Replace known credential shapes with stable markers and report every replacement."""
+    findings: list[Finding] = []
+    for shape, pattern in REDACTIONS:
+        def replace(match: re.Match[str]) -> str:
+            findings.append(Finding(shape, location, text.count("\n", 0, match.start()) + 1))
+            return f"<redacted:{shape}>"
+        text = pattern.sub(replace, text)
+    return text, findings
+
+
+def redact_record(record: dict[str, Any], *, _location: str = "") -> tuple[dict[str, Any], list[Finding]]:
+    """Recursively redact a JSON-compatible trace record without mutating it."""
+    findings: list[Finding] = []
+    def visit(value: Any, location: str) -> Any:
+        if isinstance(value, str):
+            cleaned, found = redact(value, location=location)
+            findings.extend(found)
+            return cleaned
+        if isinstance(value, list):
+            return [visit(item, f"{location}[{index}]") for index, item in enumerate(value)]
+        if isinstance(value, dict):
+            return {key: visit(item, f"{location}.{key}" if location else key) for key, item in value.items()}
+        return value
+    return visit(record, _location), findings
+
+
+def redact_tree(root: Path) -> list[Finding]:
+    """Redact UTF-8 text files in a staging tree in place and return findings."""
+    findings: list[Finding] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        cleaned, found = redact(text, location=str(path.relative_to(root)))
+        if found:
+            path.write_text(cleaned, encoding="utf-8")
+            findings.extend(found)
+    return findings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Redact credential-shaped text in a staging tree.")
+    parser.add_argument("root", type=Path)
+    args = parser.parse_args()
+    findings = redact_tree(args.root)
+    print(json.dumps({"findings": [asdict(finding) for finding in findings]}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/harbor/test_secret_redaction.py
+++ b/tests/harbor/test_secret_redaction.py
@@ -1,0 +1,24 @@
+from scripts.harbor.secret_redaction import redact, redact_record
+
+
+def test_redact_replaces_known_credentials_and_reports_shapes() -> None:
+    token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJydW4ifQ.signature"
+
+    cleaned, findings = redact(f"proxy={token} key=sk-abcdefghijklmnopqrstuvwxyz")
+
+    assert token not in cleaned
+    assert "<redacted:jwt>" in cleaned
+    assert {finding.shape for finding in findings} == {"jwt", "openai_key"}
+
+
+def test_redact_record_is_recursive_and_idempotent() -> None:
+    record = {"messages": [{"content": "hf_abcdefghijklmnopqrstuvwxyz"}]}
+
+    cleaned, findings = redact_record(record)
+    cleaned_again, later_findings = redact_record(cleaned)
+
+    assert record["messages"][0]["content"].startswith("hf_")
+    assert cleaned["messages"][0]["content"] == "<redacted:huggingface_token>"
+    assert findings[0].location == "messages[0].content"
+    assert cleaned_again == cleaned
+    assert later_findings == []


### PR DESCRIPTION
Restore durable RL-cleanup publication gates with a tested credential redactor, trace-export integration, redacted training-log instructions, and explicit remote artifact completion checks.