### PR TITLE
[RL] Centralize checkpoint path resolution

### DIFF
--- a/docs/debug-log-rl-resume-path-resolution.md
+++ b/docs/debug-log-rl-resume-path-resolution.md
@@ -23,7 +23,8 @@ resume source differs from the checkpoint write directory.
 ## Decision rule
 
 An automatically selected checkpoint makes its containing run root the owner of checkpoints, exports, and
-trials for the resumed launch. With no checkpoint, durable state uses the canonical root even if configs and
+trials for the resumed launch. It uses `resume_mode=latest` on that fixed checkpoint directory so chained
+restarts observe checkpoints written after submission. With no checkpoint, durable state uses the canonical root even if configs and
 logs were collision-renamed. Explicit resume settings are validated only at their stated path and never fall
 back to a sibling. Built-in launcher configs leave `resume_mode` unset so first launches use automatic
 discovery; a user-authored `resume_mode=latest` is strict and requires a usable checkpoint at the resolved path.

--- a/docs/debug-log-rl-resume-path-resolution.md
+++ b/docs/debug-log-rl-resume-path-resolution.md
@@ -25,4 +25,5 @@ resume source differs from the checkpoint write directory.
 An automatically selected checkpoint makes its containing run root the owner of checkpoints, exports, and
 trials for the resumed launch. With no checkpoint, durable state uses the canonical root even if configs and
 logs were collision-renamed. Explicit resume settings are validated only at their stated path and never fall
-back to a sibling.
+back to a sibling. Built-in launcher configs leave `resume_mode` unset so first launches use automatic
+discovery; a user-authored `resume_mode=latest` is strict and requires a usable checkpoint at the resolved path.

--- a/docs/debug-log-rl-resume-path-resolution.md
+++ b/docs/debug-log-rl-resume-path-resolution.md
@@ -10,7 +10,8 @@ would begin at step zero.
 ## Hypothesis
 
 A single RL path manager can resolve the durable state root before Hydra arguments are built. Resume validation
-and subsequent checkpoint, export, and trial writes can then consume the same resolved object.
+and subsequent checkpoint, export, trial upload, and cleanup paths can then consume the same resolved object.
+YAML path values are inputs to that decision, while explicit Hydra overrides retain final precedence.
 
 ## Test design
 

--- a/docs/debug-log-rl-resume-path-resolution.md
+++ b/docs/debug-log-rl-resume-path-resolution.md
@@ -1,0 +1,27 @@
+# RL resume path resolution
+
+## Failure contract
+
+RL launcher artifacts may be collision-renamed from `<run>` to `<run>_N`. Checkpoint, export, and trial paths
+were independently derived from that mutable launcher path, while the auto-resume guard inspected only the
+unrenamed path. A checkpoint written under a fork could therefore be omitted from the next launch and training
+would begin at step zero.
+
+## Hypothesis
+
+A single RL path manager can resolve the durable state root before Hydra arguments are built. Resume validation
+and subsequent checkpoint, export, and trial writes can then consume the same resolved object.
+
+## Test design
+
+The path contract covers checkpoint discovery across canonical and numbered fork roots, highest-step selection,
+strict validation of explicit `resume_mode=latest`, malformed marker rejection, ambiguous equal-step siblings,
+canonical placement for a new run whose launcher artifacts were collision-renamed, and rejection when an explicit
+resume source differs from the checkpoint write directory.
+
+## Decision rule
+
+An automatically selected checkpoint makes its containing run root the owner of checkpoints, exports, and
+trials for the resumed launch. With no checkpoint, durable state uses the canonical root even if configs and
+logs were collision-renamed. Explicit resume settings are validated only at their stated path and never fall
+back to a sibling.

--- a/hpc/experiment_path_names.py
+++ b/hpc/experiment_path_names.py
@@ -1,0 +1,15 @@
+"""Shared naming rules for collision-forked experiment directories."""
+
+from __future__ import annotations
+
+import re
+
+
+def numbered_experiment_fork_name(base_name: str, suffix: int) -> str:
+    """Return the sibling name used for a collision-forked experiment."""
+    return f"{base_name}_{suffix}"
+
+
+def numbered_experiment_fork_pattern(base_name: str) -> re.Pattern[str]:
+    """Match numbered collision forks of one canonical experiment name."""
+    return re.compile(rf"{re.escape(base_name)}_(\d+)$")

--- a/hpc/launch_utils.py
+++ b/hpc/launch_utils.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Union
 
 from hpc.hpc import detect_hpc
+from hpc.experiment_path_names import numbered_experiment_fork_name
 
 # Re-export HuggingFace utilities for backwards compatibility
 from hpc.hf_utils import sanitize_hf_repo_id
@@ -684,7 +685,7 @@ def setup_experiments_dir(
                 if (experiments_abs / "configs").exists()
                 else []
             ):
-                experiments_abs = base.parent / f"{base.name}_{suffix}"
+                experiments_abs = base.parent / numbered_experiment_fork_name(base.name, suffix)
                 suffix += 1
             renamed_for_collision = experiments_abs != base
             if renamed_for_collision:

--- a/hpc/rl_config_utils.py
+++ b/hpc/rl_config_utils.py
@@ -5,9 +5,11 @@ replacing 50+ Hydra CLI arguments with a single --rl_config YAML file.
 
 Usage:
     from hpc.rl_config_utils import parse_rl_config, build_skyrl_hydra_args
+    from hpc.rl_paths import RLPathManager
 
     parsed = parse_rl_config("terminal_bench.yaml")
-    hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc)
+    run_paths = RLPathManager(job_name, canonical_root, launch_root).resolve()
+    hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc, run_paths=run_paths)
 """
 
 from __future__ import annotations
@@ -17,6 +19,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
+
+from hpc.rl_paths import RLRunPaths
 
 # Directory containing built-in SkyRL config YAML files
 SKYRL_CONFIG_DIR = Path(__file__).parent / "skyrl_yaml"
@@ -416,12 +420,14 @@ def build_skyrl_hydra_args(
     parsed: ParsedRLConfig,
     exp_args: Dict[str, Any],
     hpc: Any,
+    *,
+    run_paths: RLRunPaths,
 ) -> List[str]:
     """Convert parsed config + exp_args to Hydra CLI arguments.
 
     This function:
     1. Adds config groups with + prefix
-    2. Derives paths from experiments_dir/job_name if not set
+    2. Applies paths resolved by the RL path manager
     3. Computes num_inference_engines from cluster config
     4. Flattens nested dicts to dotted Hydra keys
     5. Applies data paths from CLI
@@ -430,6 +436,7 @@ def build_skyrl_hydra_args(
         parsed: ParsedRLConfig from parse_rl_config().
         exp_args: Experiment arguments dictionary from CLI.
         hpc: HPC configuration object with cluster settings.
+        run_paths: Validated checkpoint, export, trial, and resume paths.
 
     Returns:
         List of Hydra CLI argument strings.
@@ -444,19 +451,14 @@ def build_skyrl_hydra_args(
     trainer = dict(parsed.trainer)
     generator = dict(parsed.generator)
     data = dict(parsed.data)
+    job_name = run_paths.job_name
 
-    # Derive paths if null
-    experiments_dir = exp_args.get("experiments_dir", "")
-    job_name = exp_args.get("job_name", "")
-
-    if not trainer.get("run_name") and job_name:
+    if not trainer.get("run_name"):
         trainer["run_name"] = job_name
-    if not trainer.get("export_path") and experiments_dir and job_name:
-        trainer["export_path"] = f"{experiments_dir}/{job_name}/exports"
-        print(f"Auto-set trainer.export_path: {trainer['export_path']}")
-    if not trainer.get("ckpt_path") and experiments_dir and job_name:
-        trainer["ckpt_path"] = f"{experiments_dir}/{job_name}/checkpoints"
-        print(f"Auto-set trainer.ckpt_path: {trainer['ckpt_path']}")
+    trainer["export_path"] = str(run_paths.export_dir)
+    trainer["ckpt_path"] = str(run_paths.checkpoint_dir)
+    trainer["resume_mode"] = run_paths.resume_mode.value
+    trainer["resume_path"] = str(run_paths.resume_path) if run_paths.resume_path is not None else None
 
     # Derive placement from num_nodes
     num_nodes = int(exp_args.get("num_nodes", 1))
@@ -587,10 +589,7 @@ def build_skyrl_hydra_args(
     if parsed.terminal_bench:
         terminal_bench = dict(parsed.terminal_bench)
 
-        # Derive trials_dir from experiments_dir if not set
-        # This is where Harbor stores trial execution artifacts
-        if not terminal_bench.get("trials_dir") and experiments_dir and job_name:
-            terminal_bench["trials_dir"] = f"{experiments_dir}/{job_name}/trace_jobs"
+        terminal_bench["trials_dir"] = str(run_paths.trials_dir)
 
         for key, val in _flatten_dict(terminal_bench).items():
             args.append(_format_hydra_arg(f"terminal_bench_config.{key}", val, prefix="+"))

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -27,7 +27,8 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 
 from hpc.hf_utils import is_hf_dataset_path
 from hpc.launch_utils import get_daytona_api_key_override
-from hpc.rl_paths import RLPathManager, RLRunPaths
+from hpc.rl_config_utils import get_skyrl_command_preview
+from hpc.rl_paths import RLPathManager, RLRunPaths, hydra_override_values
 
 
 # Default Apptainer bind mounts for the RL container runtime mode.
@@ -795,6 +796,7 @@ class RLJobConfig:
     # Paths
     checkpoints_dir: Optional[str] = None
     export_path: Optional[str] = None
+    trials_dir: Optional[str] = None
 
     # Cluster-specific flags
     needs_ssh_tunnel: bool = False
@@ -842,7 +844,6 @@ class RLLaunchArtifacts:
     """Resolved launch script and the exact SkyRL command it contains."""
 
     sbatch_path: Path
-    run_paths: RLRunPaths
     skyrl_entrypoint: str
     hydra_args: tuple[str, ...]
 
@@ -1062,8 +1063,7 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
 
     # Resolve launcher artifact paths before the durable RL paths. A collision
     # may rename the artifact directory, while RLPathManager must still inspect
-    # the canonical directory and its numbered siblings. See
-    # ``notes/ot-agent/agent_logs/2026-05-26_launcher_trials_dir_collision_bug.md``.
+    # the canonical directory and its numbered siblings.
     job_setup = resolve_job_and_paths(
         exp_args,
         job_type_label="RL",
@@ -1078,6 +1078,8 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         exp_paths.canonical_root or exp_paths.root,
         exp_paths.root,
     ).resolve(
+        trainer_config=parsed.trainer,
+        terminal_bench_config=parsed.terminal_bench or {},
         skyrl_overrides=skyrl_overrides,
         fresh_start_requested=bool(exp_args.get("overwrite_output_dir") or exp_args.get("allow_overwrite")),
     )
@@ -1109,8 +1111,8 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         tensor_parallel_size=parsed.tensor_parallel_size,
         ray_port=int(exp_args.get("ray_port") or 6379),
         master_port=int(exp_args.get("master_port") or 12345),
-        checkpoints_dir=str(run_paths.checkpoint_dir),
         export_path=str(run_paths.export_dir),
+        trials_dir=str(run_paths.trials_dir),
         needs_ssh_tunnel=hpc.needs_ssh_tunnel,
         needs_cuda_detection=getattr(hpc, "needs_cuda_detection", False),
         # Pinggy tunnel settings (for cloud backends with installed agents)
@@ -1216,7 +1218,6 @@ fi"""
 
     return RLLaunchArtifacts(
         sbatch_path=sbatch_output,
-        run_paths=run_paths,
         skyrl_entrypoint=parsed.entrypoint,
         hydra_args=tuple(hydra_args),
     )
@@ -1266,7 +1267,6 @@ def launch_rl_job(exp_args: dict, hpc) -> Optional[str]:
         Job ID if submitted, None if dry_run.
     """
     from hpc.launch_utils import launch_sbatch
-    from hpc.rl_config_utils import get_skyrl_command_preview
 
     # Check for RL environment
     rl_env_path = check_rl_environment()
@@ -1362,19 +1362,7 @@ class RLJobRunner:
         the leading ``+``/``++`` override markers Hydra allows. Returns None if the
         key is absent.
         """
-        found: Optional[str] = None
-        for arg in hydra_args:
-            if "=" not in arg:
-                continue
-            k, v = arg.split("=", 1)
-            if k.lstrip("+").strip() == key:
-                v = v.strip()
-                # Strip a single layer of surrounding quotes that _format_hydra_arg
-                # may add for paths/values containing Hydra special chars.
-                if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
-                    v = v[1:-1]
-                found = v
-        return found
+        return hydra_override_values(hydra_args).get(key)
 
     def _already_complete_on_disk(self) -> bool:
         """True iff the canonical checkpoint already reached max_steps.
@@ -1414,6 +1402,16 @@ class RLJobRunner:
             )
             return True
         return False
+
+    def _trials_dir(self) -> Path:
+        """Return the configured Harbor trials directory.
+
+        The fallback keeps already-serialized job configs launchable after this
+        field was added; new configs always carry the manager-resolved path.
+        """
+        if self.config.trials_dir:
+            return Path(self.config.trials_dir)
+        return Path(self.config.experiments_dir) / self.config.job_name / "trace_jobs"
 
     def run(self) -> int:
         """Execute the RL training job.
@@ -1473,7 +1471,7 @@ class RLJobRunner:
             if upload_exit_code == 0:
                 print(f"[RLJobRunner] Trace upload completed successfully.", flush=True)
                 if self.config.trace_upload_cleanup:
-                    trace_jobs_dir = Path(self.config.experiments_dir) / self.config.job_name / "trace_jobs"
+                    trace_jobs_dir = self._trials_dir()
                     if trace_jobs_dir.exists():
                         import shutil
                         print(f"[RLJobRunner] Cleaning up traces directory: {trace_jobs_dir}", flush=True)
@@ -1557,9 +1555,8 @@ class RLJobRunner:
             print(f"[RLJobRunner] Trace upload disabled, skipping.", flush=True)
             return None
 
-        # The trace jobs directory is where Harbor stores trial artifacts
-        job_dir = Path(self.config.experiments_dir) / self.config.job_name
-        trace_jobs_dir = job_dir / "trace_jobs"
+        # The trials directory is the exact path configured in Harbor.
+        trace_jobs_dir = self._trials_dir()
         if not trace_jobs_dir.exists():
             print(f"[RLJobRunner] No trace_jobs directory found at {trace_jobs_dir}, skipping upload.", flush=True)
             return None
@@ -1573,7 +1570,7 @@ class RLJobRunner:
 
         cmd = [
             sys.executable, "-m", "scripts.harbor.make_and_upload_trace_dataset",
-            "--job_dir", str(job_dir),
+            "--job_dir", str(trace_jobs_dir),
             "--repo_id", repo_id,
             "--episodes", self.config.trace_upload_episodes,
             "--dataset_type", self.config.trace_upload_dataset_type,
@@ -1581,7 +1578,7 @@ class RLJobRunner:
 
         print(f"[RLJobRunner] Launching trace upload (training exit code: {training_exit_code}):", flush=True)
         print(f"  repo_id: {repo_id}", flush=True)
-        print(f"  job_dir: {job_dir}", flush=True)
+        print(f"  trials_dir: {trace_jobs_dir}", flush=True)
         print(f"  episodes: {self.config.trace_upload_episodes}", flush=True)
         print(f"  log: {log_path}", flush=True)
 

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -23,7 +23,7 @@ import sys
 import time
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from hpc.hf_utils import is_hf_dataset_path
 from hpc.launch_utils import get_daytona_api_key_override
@@ -1368,11 +1368,6 @@ class RLJobRunner:
                 self._hpc = detect_hpc()
         return self._hpc
 
-    @staticmethod
-    def _hydra_arg_value(hydra_args: Sequence[str], key: str) -> Optional[str]:
-        """Return the effective value for a Hydra key, or None when absent."""
-        return hydra_override_values(hydra_args).get(key)
-
     def _already_complete_on_disk(self) -> bool:
         """True iff the canonical checkpoint already reached max_steps.
 
@@ -1386,8 +1381,9 @@ class RLJobRunner:
         guard keys off, so the two guards agree on what "complete" means.
         """
         hydra_args = list(getattr(self.config, "skyrl_hydra_args", []) or [])
-        max_steps_raw = self._hydra_arg_value(hydra_args, "trainer.max_steps")
-        ckpt_path = self._hydra_arg_value(hydra_args, "trainer.ckpt_path")
+        hydra_values = hydra_override_values(hydra_args)
+        max_steps_raw = hydra_values.get("trainer.max_steps")
+        ckpt_path = hydra_values.get("trainer.ckpt_path")
         if not max_steps_raw or not ckpt_path:
             return False
         try:

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 from hpc.hf_utils import is_hf_dataset_path
 from hpc.launch_utils import get_daytona_api_key_override
 from hpc.rl_config_utils import get_skyrl_command_preview
-from hpc.rl_paths import RLPathManager, RLRunPaths, hydra_override_values
+from hpc.rl_paths import LATEST_CHECKPOINT_FILE, RLPathManager, RLRunPaths, hydra_override_values
 
 
 # Default Apptainer bind mounts for the RL container runtime mode.
@@ -776,6 +776,7 @@ class RLJobConfig:
 
     # SkyRL settings
     skyrl_entrypoint: str
+    trials_dir: str
     skyrl_hydra_args: List[str] = field(default_factory=list)
 
     # Model and data
@@ -796,7 +797,6 @@ class RLJobConfig:
     # Paths
     checkpoints_dir: Optional[str] = None
     export_path: Optional[str] = None
-    trials_dir: Optional[str] = None
 
     # Cluster-specific flags
     needs_ssh_tunnel: bool = False
@@ -940,7 +940,7 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         hpc: HPC cluster configuration.
 
     Returns:
-        Generated sbatch path, durable run paths, and the exact SkyRL command.
+        Generated sbatch path and the exact SkyRL command.
     """
     from hpc.launch_utils import (
         resolve_job_and_paths,
@@ -1356,12 +1356,7 @@ class RLJobRunner:
 
     @staticmethod
     def _hydra_arg_value(hydra_args: Sequence[str], key: str) -> Optional[str]:
-        """Last-wins lookup of a dotted Hydra ``key`` in ``trainer.*=value`` args.
-
-        Hydra is last-wins, so we scan in order and keep the final match. Strips
-        the leading ``+``/``++`` override markers Hydra allows. Returns None if the
-        key is absent.
-        """
+        """Return the effective value for a Hydra key, or None when absent."""
         return hydra_override_values(hydra_args).get(key)
 
     def _already_complete_on_disk(self) -> bool:
@@ -1388,7 +1383,7 @@ class RLJobRunner:
         if max_steps <= 0:
             return False
 
-        marker = Path(ckpt_path) / "latest_ckpt_global_step.txt"
+        marker = Path(ckpt_path) / LATEST_CHECKPOINT_FILE
         try:
             completed = int(marker.read_text().strip())
         except (OSError, ValueError):
@@ -1402,16 +1397,6 @@ class RLJobRunner:
             )
             return True
         return False
-
-    def _trials_dir(self) -> Path:
-        """Return the configured Harbor trials directory.
-
-        The fallback keeps already-serialized job configs launchable after this
-        field was added; new configs always carry the manager-resolved path.
-        """
-        if self.config.trials_dir:
-            return Path(self.config.trials_dir)
-        return Path(self.config.experiments_dir) / self.config.job_name / "trace_jobs"
 
     def run(self) -> int:
         """Execute the RL training job.
@@ -1471,7 +1456,7 @@ class RLJobRunner:
             if upload_exit_code == 0:
                 print(f"[RLJobRunner] Trace upload completed successfully.", flush=True)
                 if self.config.trace_upload_cleanup:
-                    trace_jobs_dir = self._trials_dir()
+                    trace_jobs_dir = Path(self.config.trials_dir)
                     if trace_jobs_dir.exists():
                         import shutil
                         print(f"[RLJobRunner] Cleaning up traces directory: {trace_jobs_dir}", flush=True)
@@ -1555,8 +1540,7 @@ class RLJobRunner:
             print(f"[RLJobRunner] Trace upload disabled, skipping.", flush=True)
             return None
 
-        # The trials directory is the exact path configured in Harbor.
-        trace_jobs_dir = self._trials_dir()
+        trace_jobs_dir = Path(self.config.trials_dir)
         if not trace_jobs_dir.exists():
             print(f"[RLJobRunner] No trace_jobs directory found at {trace_jobs_dir}, skipping upload.", flush=True)
             return None

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 
 from hpc.hf_utils import is_hf_dataset_path
 from hpc.launch_utils import get_daytona_api_key_override
+from hpc.rl_paths import RLPathManager, RLRunPaths
 
 
 # Default Apptainer bind mounts for the RL container runtime mode.
@@ -588,33 +589,9 @@ def get_tensor_parallel_size(
         return 1
 
 
-def derive_skyrl_export_path(
-    experiments_dir: str,
-    run_name: str,
-    exports_subdir: str = "exports",
-) -> str:
-    """
-    Derive the SkyRL export path from experiments directory and run name.
-
-    The export path is where SkyRL saves model checkpoints during training.
-
-    Args:
-        experiments_dir: Base experiments directory.
-        run_name: Name of the training run.
-        exports_subdir: Subdirectory name for exports (default: "exports").
-
-    Returns:
-        Full path to the SkyRL export directory.
-
-    Example:
-        >>> derive_skyrl_export_path("/scratch/experiments", "qwen3_8b_nl2bash")
-        '/scratch/experiments/qwen3_8b_nl2bash/exports'
-    """
-    return str(Path(experiments_dir) / run_name / exports_subdir)
-
-
 def build_rl_env_vars(
     exp_args: Dict[str, Any],
+    run_paths: RLRunPaths,
     hpc: Optional[Any] = None,
 ) -> Dict[str, str]:
     """
@@ -622,6 +599,7 @@ def build_rl_env_vars(
 
     Args:
         exp_args: Experiment arguments dictionary.
+        run_paths: Validated durable RL paths.
         hpc: Optional HPC configuration object.
 
     Returns:
@@ -646,11 +624,7 @@ def build_rl_env_vars(
     else:
         env_vars["POLICY_NUM_NODES"] = str(num_nodes)
 
-    # SkyRL export path
-    experiments_dir = exp_args.get("experiments_dir", "")
-    run_name = exp_args.get("run_name") or exp_args.get("job_name", "")
-    if experiments_dir and run_name:
-        env_vars["SKYRL_EXPORT_PATH"] = derive_skyrl_export_path(experiments_dir, run_name)
+    env_vars["SKYRL_EXPORT_PATH"] = str(run_paths.export_dir)
 
     # Inherit all HPC-specific environment variables (WANDB_MODE, GLOO_USE_IPV6, etc.)
     if hpc is not None and hasattr(hpc, "env_vars"):
@@ -661,18 +635,19 @@ def build_rl_env_vars(
     return env_vars
 
 
-def get_rl_env_exports(exp_args: Dict[str, Any], hpc: Optional[Any] = None) -> str:
+def get_rl_env_exports(exp_args: Dict[str, Any], run_paths: RLRunPaths, hpc: Optional[Any] = None) -> str:
     """
     Generate shell export statements for RL environment variables.
 
     Args:
         exp_args: Experiment arguments dictionary.
+        run_paths: Validated durable RL paths.
         hpc: Optional HPC configuration object.
 
     Returns:
         Multi-line string of export statements.
     """
-    env_vars = build_rl_env_vars(exp_args, hpc)
+    env_vars = build_rl_env_vars(exp_args, run_paths, hpc)
 
     if not env_vars:
         return "# No RL-specific environment variables"
@@ -861,6 +836,17 @@ class RLJobConfig:
     trace_upload_dataset_type: str = "SFT"
     trace_upload_cleanup: bool = True
 
+
+@dataclass(frozen=True)
+class RLLaunchArtifacts:
+    """Resolved launch script and the exact SkyRL command it contains."""
+
+    sbatch_path: Path
+    run_paths: RLRunPaths
+    skyrl_entrypoint: str
+    hydra_args: tuple[str, ...]
+
+
 def build_skyrl_command_string(config: RLJobConfig) -> str:
     """Build the full SkyRL command string for the sbatch template.
 
@@ -943,7 +929,7 @@ def _build_rl_container_env(container: Mapping[str, Any], exp_args: dict) -> str
     return "\n".join(lines)
 
 
-def construct_rl_sbatch_script(exp_args: dict, hpc) -> str:
+def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
     """Construct RL sbatch script using the universal template system.
 
     This follows the same pattern as construct_sft_sbatch_script() but for RL jobs.
@@ -953,7 +939,7 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> str:
         hpc: HPC cluster configuration.
 
     Returns:
-        Path to the generated sbatch script.
+        Generated sbatch path, durable run paths, and the exact SkyRL command.
     """
     from hpc.launch_utils import (
         resolve_job_and_paths,
@@ -1074,14 +1060,9 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> str:
     elif model_path:
         exp_args["model_path"] = model_path
 
-    # Resolve job_name and paths (job_name already set by get_job_name() in launch.py)
-    # IMPORTANT: this must run BEFORE build_skyrl_hydra_args, because the
-    # collision-rename logic inside setup_experiments_dir updates
-    # exp_args["experiments_dir"] in place. build_skyrl_hydra_args reads
-    # that value to derive trainer.trials_dir, trainer.ckpt_path, and
-    # trainer.export_path; if it ran first it would use the un-suffixed
-    # canonical path while the sbatch/configs/logs went to the renamed dir
-    # — that's the bug in
+    # Resolve launcher artifact paths before the durable RL paths. A collision
+    # may rename the artifact directory, while RLPathManager must still inspect
+    # the canonical directory and its numbered siblings. See
     # ``notes/ot-agent/agent_logs/2026-05-26_launcher_trials_dir_collision_bug.md``.
     job_setup = resolve_job_and_paths(
         exp_args,
@@ -1091,69 +1072,21 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> str:
     exp_paths = job_setup.paths
     experiments_subdir = str(exp_paths.root)
 
-    # Build Hydra args from YAML + CLI overrides
-    hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc)
-
-    # Apply CLI overrides (--skyrl_override key=value)
     skyrl_overrides = exp_args.get("skyrl_override") or []
+    run_paths = RLPathManager(
+        job_name,
+        exp_paths.canonical_root or exp_paths.root,
+        exp_paths.root,
+    ).resolve(
+        skyrl_overrides=skyrl_overrides,
+        fresh_start_requested=bool(exp_args.get("overwrite_output_dir") or exp_args.get("allow_overwrite")),
+    )
+    print(run_paths.describe())
+
+    hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc, run_paths=run_paths)
     if skyrl_overrides:
         hydra_args.extend(skyrl_overrides)
         print(f"Applied {len(skyrl_overrides)} CLI overrides")
-
-    # --- Auto-resume guard: defeat the dedup-fork -> step-0 trap -------------
-    # When the run dir collides with a prior run, setup_experiments_dir forks it
-    # to <name>_N (and --dry_run redirects it to <name>__dryrun).
-    # build_skyrl_hydra_args then derives trainer.ckpt_path / trainer.export_path
-    # from that redirected dir -- which is empty -- so SkyRL silently restarts
-    # from global_step_0, discarding all prior progress. If the ORIGINAL
-    # (canonical) run dir already holds checkpoints and the user did NOT request
-    # a fresh start (--overwrite_output_dir / --allow_overwrite), pin ckpt_path,
-    # export_path, and resume_mode at the canonical dir so this launch resumes
-    # the real run. Hydra is last-wins: these append AFTER both the
-    # build-derived args and the user's --skyrl_override, so they override the
-    # (empty) derived ckpt_path. We skip any key the user pinned explicitly via
-    # --skyrl_override so manual overrides still win.
-    _fresh_start_requested = bool(
-        exp_args.get("overwrite_output_dir") or exp_args.get("allow_overwrite")
-    )
-    canonical_root = getattr(exp_paths, "canonical_root", None)
-    if canonical_root is not None and not _fresh_start_requested:
-        canonical_ckpt = Path(canonical_root) / job_name / "checkpoints"
-        derived_ckpt = Path(experiments_subdir) / job_name / "checkpoints"
-        try:
-            has_ckpts = canonical_ckpt.is_dir() and any(
-                p.is_dir() and p.name.startswith("global_step")
-                for p in canonical_ckpt.iterdir()
-            )
-        except OSError:
-            has_ckpts = False
-        if has_ckpts and canonical_ckpt.resolve() != derived_ckpt.resolve():
-            def _user_pinned(key: str) -> bool:
-                return any(
-                    a.split("=", 1)[0].lstrip("+").strip() == key
-                    for a in skyrl_overrides
-                )
-
-            canonical_export = Path(canonical_root) / job_name / "exports"
-            injected = []
-            if not _user_pinned("trainer.ckpt_path"):
-                hydra_args.append(f"trainer.ckpt_path={canonical_ckpt}")
-                injected.append("ckpt_path")
-            if not _user_pinned("trainer.export_path"):
-                hydra_args.append(f"trainer.export_path={canonical_export}")
-                injected.append("export_path")
-            if not _user_pinned("trainer.resume_mode"):
-                hydra_args.append("trainer.resume_mode=latest")
-                injected.append("resume_mode")
-            if injected:
-                print(
-                    "[rl_launch] AUTO-RESUME: canonical run dir "
-                    f"{canonical_ckpt} has checkpoints and this launch was "
-                    f"redirected to {experiments_subdir}. Pinned "
-                    f"{', '.join(injected)} to the canonical dir so training "
-                    "resumes instead of restarting from global_step_0. "
-                    "Pass --overwrite_output_dir true to force a fresh run."
-                )
 
     # Extract config values
     num_nodes = int(exp_args.get("num_nodes") or 1)
@@ -1176,7 +1109,8 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> str:
         tensor_parallel_size=parsed.tensor_parallel_size,
         ray_port=int(exp_args.get("ray_port") or 6379),
         master_port=int(exp_args.get("master_port") or 12345),
-        export_path=derive_skyrl_export_path(experiments_subdir, job_name),
+        checkpoints_dir=str(run_paths.checkpoint_dir),
+        export_path=str(run_paths.export_dir),
         needs_ssh_tunnel=hpc.needs_ssh_tunnel,
         needs_cuda_detection=getattr(hpc, "needs_cuda_detection", False),
         # Pinggy tunnel settings (for cloud backends with installed agents)
@@ -1219,7 +1153,7 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> str:
     sbatch_directives = build_sbatch_directives(hpc, exp_args)
 
     # Generate RL environment exports
-    rl_env_exports = get_rl_env_exports(exp_args, hpc)
+    rl_env_exports = get_rl_env_exports(exp_args, run_paths, hpc)
 
     # Generate CUDA setup code
     cuda_setup = ""
@@ -1280,7 +1214,12 @@ fi"""
     os.chmod(sbatch_output, 0o750)
     print(f"Wrote RL sbatch script to {sbatch_output}")
 
-    return str(sbatch_output)
+    return RLLaunchArtifacts(
+        sbatch_path=sbatch_output,
+        run_paths=run_paths,
+        skyrl_entrypoint=parsed.entrypoint,
+        hydra_args=tuple(hydra_args),
+    )
 
 
 def check_rl_environment() -> Optional[Path]:
@@ -1327,7 +1266,7 @@ def launch_rl_job(exp_args: dict, hpc) -> Optional[str]:
         Job ID if submitted, None if dry_run.
     """
     from hpc.launch_utils import launch_sbatch
-    from hpc.rl_config_utils import get_skyrl_command_preview, parse_rl_config, build_skyrl_hydra_args
+    from hpc.rl_config_utils import get_skyrl_command_preview
 
     # Check for RL environment
     rl_env_path = check_rl_environment()
@@ -1342,7 +1281,8 @@ def launch_rl_job(exp_args: dict, hpc) -> Optional[str]:
         print("=" * 60 + "\n")
 
     # Construct the sbatch script
-    sbatch_path = construct_rl_sbatch_script(exp_args, hpc)
+    artifacts = construct_rl_sbatch_script(exp_args, hpc)
+    sbatch_path = str(artifacts.sbatch_path)
 
     # Get dependency if specified
     dependency = exp_args.get("dependency")
@@ -1353,15 +1293,8 @@ def launch_rl_job(exp_args: dict, hpc) -> Optional[str]:
         if dependency:
             print(f"  Would submit with dependency: {dependency}")
 
-        # Show command preview
-        rl_config_path = exp_args.get("rl_config")
-        if rl_config_path:
-            parsed = parse_rl_config(rl_config_path)
-            hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc)
-            skyrl_overrides = exp_args.get("skyrl_override") or []
-            hydra_args.extend(skyrl_overrides)
-            print("\nSkyRL command preview:")
-            print(get_skyrl_command_preview(parsed.entrypoint, hydra_args))
+        print("\nSkyRL command preview:")
+        print(get_skyrl_command_preview(artifacts.skyrl_entrypoint, list(artifacts.hydra_args)))
 
         return None
 

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -27,8 +27,19 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 
 from hpc.hf_utils import is_hf_dataset_path
 from hpc.launch_utils import get_daytona_api_key_override
-from hpc.rl_config_utils import get_skyrl_command_preview
-from hpc.rl_paths import LATEST_CHECKPOINT_FILE, RLPathManager, RLRunPaths, hydra_override_values
+from hpc.rl_config_utils import (
+    build_skyrl_hydra_args,
+    extract_terminal_bench_agent_env,
+    get_skyrl_command_preview,
+    parse_rl_config,
+)
+from hpc.rl_paths import (
+    LATEST_CHECKPOINT_FILE,
+    RLLaunchIntent,
+    RLPathManager,
+    RLRunPaths,
+    hydra_override_values,
+)
 
 
 # Default Apptainer bind mounts for the RL container runtime mode.
@@ -948,7 +959,6 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         build_sbatch_directives,
         resolve_conda_activate,
     )
-    from hpc.rl_config_utils import parse_rl_config, build_skyrl_hydra_args, extract_terminal_bench_agent_env
 
     print("\n=== RL MODE (Universal Launcher) ===")
 
@@ -1081,7 +1091,11 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         trainer_config=parsed.trainer,
         terminal_bench_config=parsed.terminal_bench or {},
         skyrl_overrides=skyrl_overrides,
-        fresh_start_requested=bool(exp_args.get("overwrite_output_dir") or exp_args.get("allow_overwrite")),
+        launch_intent=(
+            RLLaunchIntent.FRESH
+            if exp_args.get("overwrite_output_dir") or exp_args.get("allow_overwrite")
+            else RLLaunchIntent.AUTO
+        ),
     )
     print(run_paths.describe())
 
@@ -1456,11 +1470,11 @@ class RLJobRunner:
             if upload_exit_code == 0:
                 print(f"[RLJobRunner] Trace upload completed successfully.", flush=True)
                 if self.config.trace_upload_cleanup:
-                    trace_jobs_dir = Path(self.config.trials_dir)
-                    if trace_jobs_dir.exists():
+                    trials_dir = Path(self.config.trials_dir)
+                    if trials_dir.exists():
                         import shutil
-                        print(f"[RLJobRunner] Cleaning up traces directory: {trace_jobs_dir}", flush=True)
-                        shutil.rmtree(trace_jobs_dir, ignore_errors=True)
+                        print(f"[RLJobRunner] Cleaning up traces directory: {trials_dir}", flush=True)
+                        shutil.rmtree(trials_dir, ignore_errors=True)
                         print(f"[RLJobRunner] Traces directory removed.", flush=True)
             else:
                 print(f"[RLJobRunner] Trace upload failed with exit code {upload_exit_code}.", flush=True)
@@ -1540,9 +1554,9 @@ class RLJobRunner:
             print(f"[RLJobRunner] Trace upload disabled, skipping.", flush=True)
             return None
 
-        trace_jobs_dir = Path(self.config.trials_dir)
-        if not trace_jobs_dir.exists():
-            print(f"[RLJobRunner] No trace_jobs directory found at {trace_jobs_dir}, skipping upload.", flush=True)
+        trials_dir = Path(self.config.trials_dir)
+        if not trials_dir.exists():
+            print(f"[RLJobRunner] No trials directory found at {trials_dir}, skipping upload.", flush=True)
             return None
 
         repo_id = f"{self.config.trace_upload_repo_org}/{self.config.job_name}"
@@ -1554,7 +1568,7 @@ class RLJobRunner:
 
         cmd = [
             sys.executable, "-m", "scripts.harbor.make_and_upload_trace_dataset",
-            "--job_dir", str(trace_jobs_dir),
+            "--job_dir", str(trials_dir),
             "--repo_id", repo_id,
             "--episodes", self.config.trace_upload_episodes,
             "--dataset_type", self.config.trace_upload_dataset_type,
@@ -1562,7 +1576,7 @@ class RLJobRunner:
 
         print(f"[RLJobRunner] Launching trace upload (training exit code: {training_exit_code}):", flush=True)
         print(f"  repo_id: {repo_id}", flush=True)
-        print(f"  trials_dir: {trace_jobs_dir}", flush=True)
+        print(f"  trials_dir: {trials_dir}", flush=True)
         print(f"  episodes: {self.config.trace_upload_episodes}", flush=True)
         print(f"  log: {log_path}", flush=True)
 

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -11,9 +11,10 @@ from typing import Mapping, Sequence
 
 CHECKPOINTS_SUBDIR = "checkpoints"
 EXPORTS_SUBDIR = "exports"
-TRIALS_SUBDIR = "trace_jobs"
+TRACE_JOBS_SUBDIR = "trace_jobs"
 LATEST_CHECKPOINT_FILE = "latest_ckpt_global_step.txt"
-GLOBAL_STEP_PATTERN = re.compile(r"global_step_(\d+)$")
+GLOBAL_STEP_PREFIX = "global_step_"
+GLOBAL_STEP_PATTERN = re.compile(rf"{GLOBAL_STEP_PREFIX}(\d+)$")
 HYDRA_NULL_VALUES = frozenset({"", "null", "None", "~"})
 CKPT_PATH_KEY = "trainer.ckpt_path"
 EXPORT_PATH_KEY = "trainer.export_path"
@@ -313,13 +314,13 @@ class RLPathManager:
         except (OSError, ValueError) as error:
             raise CheckpointLayoutError(f"Invalid checkpoint marker: {marker_path}") from error
 
-        checkpoint_path = checkpoint_dir / f"global_step_{step}"
+        checkpoint_path = checkpoint_dir / f"{GLOBAL_STEP_PREFIX}{step}"
         if not checkpoint_path.is_dir():
             raise CheckpointLayoutError(f"Checkpoint marker {marker_path} names missing {checkpoint_path.name}")
         if step_dirs and max(step_dirs) != step:
             raise CheckpointLayoutError(
-                f"Checkpoint marker {marker_path} names global_step_{step}, "
-                f"but global_step_{max(step_dirs)} also exists"
+                f"Checkpoint marker {marker_path} names {GLOBAL_STEP_PREFIX}{step}, "
+                f"but {GLOBAL_STEP_PREFIX}{max(step_dirs)} also exists"
             )
         return CheckpointCandidate(state_root, checkpoint_dir, checkpoint_path, step)
 
@@ -360,7 +361,7 @@ class RLPathManager:
         trials_dir = (
             _absolute_path(overrides[TRIALS_DIR_KEY])
             if TRIALS_DIR_KEY in overrides
-            else trainer_root / TRIALS_SUBDIR
+            else trainer_root / TRACE_JOBS_SUBDIR
         )
         return RLRunPaths(
             job_name=self.job_name,

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -10,6 +10,8 @@ from typing import Mapping, Sequence
 
 
 CHECKPOINTS_SUBDIR = "checkpoints"
+EXPORTS_SUBDIR = "exports"
+TRIALS_SUBDIR = "trace_jobs"
 LATEST_CHECKPOINT_FILE = "latest_ckpt_global_step.txt"
 GLOBAL_STEP_PATTERN = re.compile(r"global_step_(\d+)$")
 HYDRA_NULL_VALUES = frozenset({"", "null", "None", "~"})
@@ -39,12 +41,6 @@ class RLLaunchIntent(StrEnum):
     FRESH = "fresh"
 
 
-class RLPathDecision(StrEnum):
-    NEW = "new"
-    RESUME = "resume"
-    EXPLICIT_FRESH = "explicit-fresh"
-
-
 @dataclass(frozen=True)
 class CheckpointCandidate:
     state_root: Path
@@ -63,15 +59,12 @@ class RLRunPaths:
     trials_dir: Path
     resume_mode: RLResumeMode
     resume_path: Path | None
-    decision: RLPathDecision
 
     def describe(self) -> str:
         if self.resume_path is not None:
             action = f"RESUME from {self.resume_path}"
-        elif self.decision is RLPathDecision.EXPLICIT_FRESH:
-            action = "EXPLICIT FRESH START"
         else:
-            action = "NEW RUN (no checkpoint found)"
+            action = "FRESH START (no checkpoint selected)"
         return (
             f"[rl_paths] {action}; resume_mode={self.resume_mode.value}; "
             f"checkpoints={self.checkpoint_dir}; exports={self.export_dir}; trials={self.trials_dir}"
@@ -142,7 +135,7 @@ class RLPathManager:
 
         state_root = self.launch_root if launch_intent is RLLaunchIntent.FRESH else self.canonical_root
         checkpoint_dir = self._configured_checkpoint_dir(overrides, state_root)
-        state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
+        state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root, overrides)
 
         explicit = self._resolve_explicit_request(
             requested_mode,
@@ -168,7 +161,6 @@ class RLPathManager:
                 overrides,
                 resume_mode=RLResumeMode.NONE,
                 resume_path=None,
-                decision=RLPathDecision.NEW,
             )
 
         highest_step = max(candidate.step for candidate in candidates)
@@ -187,7 +179,6 @@ class RLPathManager:
             overrides,
             resume_mode=RLResumeMode.FROM_PATH,
             resume_path=selected.checkpoint_path,
-            decision=RLPathDecision.RESUME,
         )
 
     @staticmethod
@@ -218,6 +209,8 @@ class RLPathManager:
         checkpoint_dir: Path,
         overrides: dict[str, str],
     ) -> RLRunPaths | None:
+        """Resolve a user-selected mode, or return None for automatic discovery."""
+
         if launch_intent is RLLaunchIntent.FRESH or requested_mode == RLResumeMode.NONE.value:
             return self._resolved_paths(
                 state_root,
@@ -225,7 +218,6 @@ class RLPathManager:
                 overrides,
                 resume_mode=RLResumeMode.NONE,
                 resume_path=None,
-                decision=RLPathDecision.EXPLICIT_FRESH,
             )
         if requested_mode == RLResumeMode.LATEST.value:
             candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=True)
@@ -236,7 +228,6 @@ class RLPathManager:
                 overrides,
                 resume_mode=RLResumeMode.LATEST,
                 resume_path=candidate.checkpoint_path,
-                decision=RLPathDecision.RESUME,
             )
         if requested_mode != RLResumeMode.FROM_PATH.value:
             return None
@@ -249,14 +240,13 @@ class RLPathManager:
                 f"trainer.resume_path {resume_path} is not under trainer.ckpt_path {checkpoint_dir}"
             )
         checkpoint_dir = resume_path.parent
-        state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
+        state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root, overrides)
         return self._resolved_paths(
             state_root,
             checkpoint_dir,
             overrides,
             resume_mode=RLResumeMode.FROM_PATH,
             resume_path=resume_path,
-            decision=RLPathDecision.RESUME,
         )
 
     def _configured_checkpoint_dir(self, overrides: dict[str, str], state_root: Path) -> Path:
@@ -265,9 +255,17 @@ class RLPathManager:
             return _absolute_path(configured)
         return state_root / self.job_name / CHECKPOINTS_SUBDIR
 
-    def _state_root_for_checkpoint_dir(self, checkpoint_dir: Path, fallback: Path) -> Path:
+    def _state_root_for_checkpoint_dir(
+        self, checkpoint_dir: Path, fallback: Path, overrides: dict[str, str]
+    ) -> Path:
         if checkpoint_dir.name == CHECKPOINTS_SUBDIR and checkpoint_dir.parent.name == self.job_name:
             return checkpoint_dir.parent.parent
+        missing = [key for key in (EXPORT_PATH_KEY, TRIALS_DIR_KEY) if key not in overrides]
+        if missing:
+            raise CheckpointLayoutError(
+                f"Nonstandard checkpoint directory {checkpoint_dir} requires explicit values for "
+                f"{', '.join(missing)}"
+            )
         return fallback
 
     def _checkpoint_candidates(self) -> list[CheckpointCandidate]:
@@ -352,18 +350,17 @@ class RLPathManager:
         *,
         resume_mode: RLResumeMode,
         resume_path: Path | None,
-        decision: RLPathDecision,
     ) -> RLRunPaths:
         trainer_root = state_root / self.job_name
         export_dir = (
             _absolute_path(overrides[EXPORT_PATH_KEY])
             if EXPORT_PATH_KEY in overrides
-            else trainer_root / "exports"
+            else trainer_root / EXPORTS_SUBDIR
         )
         trials_dir = (
             _absolute_path(overrides[TRIALS_DIR_KEY])
             if TRIALS_DIR_KEY in overrides
-            else trainer_root / "trace_jobs"
+            else trainer_root / TRIALS_SUBDIR
         )
         return RLRunPaths(
             job_name=self.job_name,
@@ -372,5 +369,4 @@ class RLPathManager:
             trials_dir=trials_dir,
             resume_mode=resume_mode,
             resume_path=resume_path,
-            decision=decision,
         )

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -8,6 +8,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from hpc.experiment_path_names import numbered_experiment_fork_pattern
+
 
 CHECKPOINTS_SUBDIR = "checkpoints"
 EXPORTS_SUBDIR = "exports"
@@ -45,7 +47,6 @@ class RLLaunchIntent(StrEnum):
 @dataclass(frozen=True)
 class CheckpointCandidate:
     state_root: Path
-    checkpoint_dir: Path
     checkpoint_path: Path
     step: int
 
@@ -150,7 +151,7 @@ class RLPathManager:
             return explicit
 
         if CKPT_PATH_KEY in overrides:
-            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=False)
+            candidate = self._checkpoint_candidate(state_root, checkpoint_dir)
             candidates = [candidate] if candidate is not None else []
         else:
             candidates = self._checkpoint_candidates()
@@ -176,9 +177,9 @@ class RLPathManager:
         selected = highest[0]
         return self._resolved_paths(
             selected.state_root,
-            selected.checkpoint_dir,
+            selected.checkpoint_path.parent,
             overrides,
-            resume_mode=RLResumeMode.FROM_PATH,
+            resume_mode=RLResumeMode.LATEST,
             resume_path=selected.checkpoint_path,
         )
 
@@ -221,8 +222,7 @@ class RLPathManager:
                 resume_path=None,
             )
         if requested_mode == RLResumeMode.LATEST.value:
-            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=True)
-            assert candidate is not None
+            candidate = self._required_checkpoint_candidate(state_root, checkpoint_dir)
             return self._resolved_paths(
                 state_root,
                 checkpoint_dir,
@@ -273,7 +273,7 @@ class RLPathManager:
         candidates: list[CheckpointCandidate] = []
         for state_root in self._candidate_state_roots():
             checkpoint_dir = state_root / self.job_name / CHECKPOINTS_SUBDIR
-            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=False)
+            candidate = self._checkpoint_candidate(state_root, checkpoint_dir)
             if candidate is not None:
                 candidates.append(candidate)
         return candidates
@@ -283,7 +283,7 @@ class RLPathManager:
         parent = self.canonical_root.parent
         if not parent.is_dir():
             return roots
-        fork_pattern = re.compile(rf"{re.escape(self.canonical_root.name)}_(\d+)$")
+        fork_pattern = numbered_experiment_fork_pattern(self.canonical_root.name)
         roots.extend(
             path.resolve() for path in parent.iterdir() if path.is_dir() and fork_pattern.fullmatch(path.name)
         )
@@ -293,19 +293,13 @@ class RLPathManager:
         self,
         state_root: Path,
         checkpoint_dir: Path,
-        *,
-        required: bool,
     ) -> CheckpointCandidate | None:
         marker_path = checkpoint_dir / LATEST_CHECKPOINT_FILE
-        step_dirs = self._step_directories(checkpoint_dir)
+        checkpoint_steps = self._checkpoint_steps(checkpoint_dir)
         if not marker_path.is_file():
-            if step_dirs:
+            if checkpoint_steps:
                 raise CheckpointLayoutError(
                     f"Checkpoint directories exist under {checkpoint_dir}, but {LATEST_CHECKPOINT_FILE} is missing"
-                )
-            if required:
-                raise CheckpointLayoutError(
-                    f"trainer.resume_mode=latest requires a usable checkpoint under {checkpoint_dir}"
                 )
             return None
 
@@ -317,15 +311,25 @@ class RLPathManager:
         checkpoint_path = checkpoint_dir / f"{GLOBAL_STEP_PREFIX}{step}"
         if not checkpoint_path.is_dir():
             raise CheckpointLayoutError(f"Checkpoint marker {marker_path} names missing {checkpoint_path.name}")
-        if step_dirs and max(step_dirs) != step:
+        if checkpoint_steps and max(checkpoint_steps) != step:
             raise CheckpointLayoutError(
                 f"Checkpoint marker {marker_path} names {GLOBAL_STEP_PREFIX}{step}, "
-                f"but {GLOBAL_STEP_PREFIX}{max(step_dirs)} also exists"
+                f"but {GLOBAL_STEP_PREFIX}{max(checkpoint_steps)} also exists"
             )
-        return CheckpointCandidate(state_root, checkpoint_dir, checkpoint_path, step)
+        return CheckpointCandidate(state_root, checkpoint_path, step)
+
+    def _required_checkpoint_candidate(
+        self, state_root: Path, checkpoint_dir: Path
+    ) -> CheckpointCandidate:
+        candidate = self._checkpoint_candidate(state_root, checkpoint_dir)
+        if candidate is None:
+            raise CheckpointLayoutError(
+                f"trainer.resume_mode=latest requires a usable checkpoint under {checkpoint_dir}"
+            )
+        return candidate
 
     @staticmethod
-    def _step_directories(checkpoint_dir: Path) -> list[int]:
+    def _checkpoint_steps(checkpoint_dir: Path) -> list[int]:
         if not checkpoint_dir.is_dir():
             return []
         steps: list[int] = []

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -6,9 +6,10 @@ import re
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
 
 
+CHECKPOINTS_SUBDIR = "checkpoints"
 LATEST_CHECKPOINT_FILE = "latest_ckpt_global_step.txt"
 GLOBAL_STEP_PATTERN = re.compile(r"global_step_(\d+)$")
 
@@ -67,7 +68,9 @@ class RLRunPaths:
         )
 
 
-def _override_values(overrides: Sequence[str]) -> dict[str, str]:
+def hydra_override_values(overrides: Sequence[str]) -> dict[str, str]:
+    """Return Hydra override values using its last-value-wins convention."""
+
     values: dict[str, str] = {}
     for override in overrides:
         key, separator, value = override.partition("=")
@@ -78,6 +81,27 @@ def _override_values(overrides: Sequence[str]) -> dict[str, str]:
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
             value = value[1:-1]
         values[key] = value
+    return values
+
+
+def _configured_path_values(
+    trainer_config: Mapping[str, object],
+    terminal_bench_config: Mapping[str, object],
+) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for config_key, hydra_key in (
+        ("ckpt_path", "trainer.ckpt_path"),
+        ("export_path", "trainer.export_path"),
+        ("resume_mode", "trainer.resume_mode"),
+        ("resume_path", "trainer.resume_path"),
+    ):
+        value = trainer_config.get(config_key)
+        if value is not None:
+            values[hydra_key] = str(value)
+
+    trials_dir = terminal_bench_config.get("trials_dir")
+    if trials_dir is not None:
+        values["terminal_bench_config.trials_dir"] = str(trials_dir)
     return values
 
 
@@ -96,16 +120,25 @@ class RLPathManager:
     def resolve(
         self,
         *,
+        trainer_config: Mapping[str, object] | None = None,
+        terminal_bench_config: Mapping[str, object] | None = None,
         skyrl_overrides: Sequence[str] = (),
         fresh_start_requested: bool = False,
     ) -> RLRunPaths:
-        overrides = _override_values(skyrl_overrides)
+        cli_values = hydra_override_values(skyrl_overrides)
+        overrides = _configured_path_values(trainer_config or {}, terminal_bench_config or {})
+        overrides.update(cli_values)
         requested_mode = overrides.get("trainer.resume_mode")
         requested_resume_path = overrides.get("trainer.resume_path")
         if requested_mode in {"", "null", "None", "~"}:
             requested_mode = RLResumeMode.NONE.value
         if requested_resume_path in {"", "null", "None", "~"}:
             requested_resume_path = None
+        if requested_mode == RLResumeMode.LATEST.value and "trainer.resume_mode" not in cli_values:
+            # YAML configs commonly use latest as an automatic preference. The
+            # manager still validates and selects the exact newest checkpoint,
+            # but an empty first run remains an explicit NEW decision.
+            requested_mode = None
 
         if fresh_start_requested and requested_mode not in (None, RLResumeMode.NONE.value):
             raise CheckpointLayoutError("A fresh start cannot also request checkpoint resume")
@@ -199,17 +232,17 @@ class RLPathManager:
         configured = overrides.get("trainer.ckpt_path")
         if configured:
             return _absolute_path(configured)
-        return state_root / self.job_name / "checkpoints"
+        return state_root / self.job_name / CHECKPOINTS_SUBDIR
 
     def _state_root_for_checkpoint_dir(self, checkpoint_dir: Path, fallback: Path) -> Path:
-        if checkpoint_dir.name == "checkpoints" and checkpoint_dir.parent.name == self.job_name:
+        if checkpoint_dir.name == CHECKPOINTS_SUBDIR and checkpoint_dir.parent.name == self.job_name:
             return checkpoint_dir.parent.parent
         return fallback
 
     def _checkpoint_candidates(self) -> list[CheckpointCandidate]:
         candidates: list[CheckpointCandidate] = []
         for state_root in self._candidate_state_roots():
-            checkpoint_dir = state_root / self.job_name / "checkpoints"
+            checkpoint_dir = state_root / self.job_name / CHECKPOINTS_SUBDIR
             candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=False)
             if candidate is not None:
                 candidates.append(candidate)

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -34,6 +34,11 @@ class RLResumeMode(StrEnum):
     FROM_PATH = "from_path"
 
 
+class RLLaunchIntent(StrEnum):
+    AUTO = "auto"
+    FRESH = "fresh"
+
+
 class RLPathDecision(StrEnum):
     NEW = "new"
     RESUME = "resume"
@@ -53,7 +58,6 @@ class RLRunPaths:
     """Resolved paths consumed by the launcher and SkyRL configuration."""
 
     job_name: str
-    state_root: Path
     checkpoint_dir: Path
     export_dir: Path
     trials_dir: Path
@@ -129,21 +133,21 @@ class RLPathManager:
         trainer_config: Mapping[str, object] | None = None,
         terminal_bench_config: Mapping[str, object] | None = None,
         skyrl_overrides: Sequence[str] = (),
-        fresh_start_requested: bool = False,
+        launch_intent: RLLaunchIntent = RLLaunchIntent.AUTO,
     ) -> RLRunPaths:
         cli_values = hydra_override_values(skyrl_overrides)
         overrides = _configured_path_values(trainer_config or {}, terminal_bench_config or {})
         overrides.update(cli_values)
-        requested_mode, requested_resume_path = self._requested_resume(overrides, fresh_start_requested)
+        requested_mode, requested_resume_path = self._requested_resume(overrides, launch_intent)
 
-        state_root = self.launch_root if fresh_start_requested else self.canonical_root
+        state_root = self.launch_root if launch_intent is RLLaunchIntent.FRESH else self.canonical_root
         checkpoint_dir = self._configured_checkpoint_dir(overrides, state_root)
         state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
 
         explicit = self._resolve_explicit_request(
             requested_mode,
             requested_resume_path,
-            fresh_start_requested,
+            launch_intent,
             state_root,
             checkpoint_dir,
             overrides,
@@ -188,7 +192,7 @@ class RLPathManager:
 
     @staticmethod
     def _requested_resume(
-        overrides: dict[str, str], fresh_start_requested: bool
+        overrides: dict[str, str], launch_intent: RLLaunchIntent
     ) -> tuple[str | None, str | None]:
         requested_mode = overrides.get(RESUME_MODE_KEY)
         requested_resume_path = overrides.get(RESUME_PATH_KEY)
@@ -197,7 +201,7 @@ class RLPathManager:
         if requested_resume_path in HYDRA_NULL_VALUES:
             requested_resume_path = None
 
-        if fresh_start_requested and requested_mode not in (None, RLResumeMode.NONE.value):
+        if launch_intent is RLLaunchIntent.FRESH and requested_mode not in (None, RLResumeMode.NONE.value):
             raise CheckpointLayoutError("A fresh start cannot also request checkpoint resume")
         if requested_resume_path and requested_mode != RLResumeMode.FROM_PATH.value:
             raise CheckpointLayoutError("trainer.resume_path requires trainer.resume_mode=from_path")
@@ -209,12 +213,12 @@ class RLPathManager:
         self,
         requested_mode: str | None,
         requested_resume_path: str | None,
-        fresh_start_requested: bool,
+        launch_intent: RLLaunchIntent,
         state_root: Path,
         checkpoint_dir: Path,
         overrides: dict[str, str],
     ) -> RLRunPaths | None:
-        if fresh_start_requested or requested_mode == RLResumeMode.NONE.value:
+        if launch_intent is RLLaunchIntent.FRESH or requested_mode == RLResumeMode.NONE.value:
             return self._resolved_paths(
                 state_root,
                 checkpoint_dir,
@@ -363,7 +367,6 @@ class RLPathManager:
         )
         return RLRunPaths(
             job_name=self.job_name,
-            state_root=state_root,
             checkpoint_dir=checkpoint_dir,
             export_dir=export_dir,
             trials_dir=trials_dir,

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -12,6 +12,12 @@ from typing import Mapping, Sequence
 CHECKPOINTS_SUBDIR = "checkpoints"
 LATEST_CHECKPOINT_FILE = "latest_ckpt_global_step.txt"
 GLOBAL_STEP_PATTERN = re.compile(r"global_step_(\d+)$")
+HYDRA_NULL_VALUES = frozenset({"", "null", "None", "~"})
+CKPT_PATH_KEY = "trainer.ckpt_path"
+EXPORT_PATH_KEY = "trainer.export_path"
+RESUME_MODE_KEY = "trainer.resume_mode"
+RESUME_PATH_KEY = "trainer.resume_path"
+TRIALS_DIR_KEY = "terminal_bench_config.trials_dir"
 
 
 class CheckpointLayoutError(ValueError):
@@ -90,10 +96,10 @@ def _configured_path_values(
 ) -> dict[str, str]:
     values: dict[str, str] = {}
     for config_key, hydra_key in (
-        ("ckpt_path", "trainer.ckpt_path"),
-        ("export_path", "trainer.export_path"),
-        ("resume_mode", "trainer.resume_mode"),
-        ("resume_path", "trainer.resume_path"),
+        ("ckpt_path", CKPT_PATH_KEY),
+        ("export_path", EXPORT_PATH_KEY),
+        ("resume_mode", RESUME_MODE_KEY),
+        ("resume_path", RESUME_PATH_KEY),
     ):
         value = trainer_config.get(config_key)
         if value is not None:
@@ -101,7 +107,7 @@ def _configured_path_values(
 
     trials_dir = terminal_bench_config.get("trials_dir")
     if trials_dir is not None:
-        values["terminal_bench_config.trials_dir"] = str(trials_dir)
+        values[TRIALS_DIR_KEY] = str(trials_dir)
     return values
 
 
@@ -128,72 +134,24 @@ class RLPathManager:
         cli_values = hydra_override_values(skyrl_overrides)
         overrides = _configured_path_values(trainer_config or {}, terminal_bench_config or {})
         overrides.update(cli_values)
-        requested_mode = overrides.get("trainer.resume_mode")
-        requested_resume_path = overrides.get("trainer.resume_path")
-        if requested_mode in {"", "null", "None", "~"}:
-            requested_mode = RLResumeMode.NONE.value
-        if requested_resume_path in {"", "null", "None", "~"}:
-            requested_resume_path = None
-        if requested_mode == RLResumeMode.LATEST.value and "trainer.resume_mode" not in cli_values:
-            # YAML configs commonly use latest as an automatic preference. The
-            # manager still validates and selects the exact newest checkpoint,
-            # but an empty first run remains an explicit NEW decision.
-            requested_mode = None
-
-        if fresh_start_requested and requested_mode not in (None, RLResumeMode.NONE.value):
-            raise CheckpointLayoutError("A fresh start cannot also request checkpoint resume")
-        if requested_resume_path and requested_mode != RLResumeMode.FROM_PATH.value:
-            raise CheckpointLayoutError("trainer.resume_path requires trainer.resume_mode=from_path")
+        requested_mode, requested_resume_path = self._requested_resume(overrides, fresh_start_requested)
 
         state_root = self.launch_root if fresh_start_requested else self.canonical_root
         checkpoint_dir = self._configured_checkpoint_dir(overrides, state_root)
         state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
 
-        if fresh_start_requested or requested_mode == RLResumeMode.NONE.value:
-            return self._resolved_paths(
-                state_root,
-                checkpoint_dir,
-                overrides,
-                resume_mode=RLResumeMode.NONE,
-                resume_path=None,
-                decision=RLPathDecision.EXPLICIT_FRESH,
-            )
+        explicit = self._resolve_explicit_request(
+            requested_mode,
+            requested_resume_path,
+            fresh_start_requested,
+            state_root,
+            checkpoint_dir,
+            overrides,
+        )
+        if explicit is not None:
+            return explicit
 
-        if requested_mode == RLResumeMode.LATEST.value:
-            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=True)
-            assert candidate is not None
-            return self._resolved_paths(
-                state_root,
-                checkpoint_dir,
-                overrides,
-                resume_mode=RLResumeMode.LATEST,
-                resume_path=candidate.checkpoint_path,
-                decision=RLPathDecision.RESUME,
-            )
-
-        if requested_mode == RLResumeMode.FROM_PATH.value:
-            if not requested_resume_path:
-                raise CheckpointLayoutError("trainer.resume_mode=from_path requires trainer.resume_path")
-            resume_path = self._validate_explicit_resume_path(_absolute_path(requested_resume_path))
-            if "trainer.ckpt_path" in overrides and checkpoint_dir != resume_path.parent:
-                raise CheckpointLayoutError(
-                    f"trainer.resume_path {resume_path} is not under trainer.ckpt_path {checkpoint_dir}"
-                )
-            checkpoint_dir = resume_path.parent
-            state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
-            return self._resolved_paths(
-                state_root,
-                checkpoint_dir,
-                overrides,
-                resume_mode=RLResumeMode.FROM_PATH,
-                resume_path=resume_path,
-                decision=RLPathDecision.RESUME,
-            )
-
-        if requested_mode is not None:
-            raise CheckpointLayoutError(f"Unknown trainer.resume_mode: {requested_mode}")
-
-        if "trainer.ckpt_path" in overrides:
+        if CKPT_PATH_KEY in overrides:
             candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=False)
             candidates = [candidate] if candidate is not None else []
         else:
@@ -228,8 +186,77 @@ class RLPathManager:
             decision=RLPathDecision.RESUME,
         )
 
+    @staticmethod
+    def _requested_resume(
+        overrides: dict[str, str], fresh_start_requested: bool
+    ) -> tuple[str | None, str | None]:
+        requested_mode = overrides.get(RESUME_MODE_KEY)
+        requested_resume_path = overrides.get(RESUME_PATH_KEY)
+        if requested_mode in HYDRA_NULL_VALUES:
+            requested_mode = None
+        if requested_resume_path in HYDRA_NULL_VALUES:
+            requested_resume_path = None
+
+        if fresh_start_requested and requested_mode not in (None, RLResumeMode.NONE.value):
+            raise CheckpointLayoutError("A fresh start cannot also request checkpoint resume")
+        if requested_resume_path and requested_mode != RLResumeMode.FROM_PATH.value:
+            raise CheckpointLayoutError("trainer.resume_path requires trainer.resume_mode=from_path")
+        if requested_mode not in {None, *(mode.value for mode in RLResumeMode)}:
+            raise CheckpointLayoutError(f"Unknown trainer.resume_mode: {requested_mode}")
+        return requested_mode, requested_resume_path
+
+    def _resolve_explicit_request(
+        self,
+        requested_mode: str | None,
+        requested_resume_path: str | None,
+        fresh_start_requested: bool,
+        state_root: Path,
+        checkpoint_dir: Path,
+        overrides: dict[str, str],
+    ) -> RLRunPaths | None:
+        if fresh_start_requested or requested_mode == RLResumeMode.NONE.value:
+            return self._resolved_paths(
+                state_root,
+                checkpoint_dir,
+                overrides,
+                resume_mode=RLResumeMode.NONE,
+                resume_path=None,
+                decision=RLPathDecision.EXPLICIT_FRESH,
+            )
+        if requested_mode == RLResumeMode.LATEST.value:
+            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=True)
+            assert candidate is not None
+            return self._resolved_paths(
+                state_root,
+                checkpoint_dir,
+                overrides,
+                resume_mode=RLResumeMode.LATEST,
+                resume_path=candidate.checkpoint_path,
+                decision=RLPathDecision.RESUME,
+            )
+        if requested_mode != RLResumeMode.FROM_PATH.value:
+            return None
+
+        if not requested_resume_path:
+            raise CheckpointLayoutError("trainer.resume_mode=from_path requires trainer.resume_path")
+        resume_path = self._validate_explicit_resume_path(_absolute_path(requested_resume_path))
+        if CKPT_PATH_KEY in overrides and checkpoint_dir != resume_path.parent:
+            raise CheckpointLayoutError(
+                f"trainer.resume_path {resume_path} is not under trainer.ckpt_path {checkpoint_dir}"
+            )
+        checkpoint_dir = resume_path.parent
+        state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
+        return self._resolved_paths(
+            state_root,
+            checkpoint_dir,
+            overrides,
+            resume_mode=RLResumeMode.FROM_PATH,
+            resume_path=resume_path,
+            decision=RLPathDecision.RESUME,
+        )
+
     def _configured_checkpoint_dir(self, overrides: dict[str, str], state_root: Path) -> Path:
-        configured = overrides.get("trainer.ckpt_path")
+        configured = overrides.get(CKPT_PATH_KEY)
         if configured:
             return _absolute_path(configured)
         return state_root / self.job_name / CHECKPOINTS_SUBDIR
@@ -325,13 +352,13 @@ class RLPathManager:
     ) -> RLRunPaths:
         trainer_root = state_root / self.job_name
         export_dir = (
-            _absolute_path(overrides["trainer.export_path"])
-            if "trainer.export_path" in overrides
+            _absolute_path(overrides[EXPORT_PATH_KEY])
+            if EXPORT_PATH_KEY in overrides
             else trainer_root / "exports"
         )
         trials_dir = (
-            _absolute_path(overrides["terminal_bench_config.trials_dir"])
-            if "terminal_bench_config.trials_dir" in overrides
+            _absolute_path(overrides[TRIALS_DIR_KEY])
+            if TRIALS_DIR_KEY in overrides
             else trainer_root / "trace_jobs"
         )
         return RLRunPaths(

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -1,0 +1,313 @@
+"""Resolve durable RL state paths and validate checkpoint resume contracts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Sequence
+
+
+LATEST_CHECKPOINT_FILE = "latest_ckpt_global_step.txt"
+GLOBAL_STEP_PATTERN = re.compile(r"global_step_(\d+)$")
+
+
+class CheckpointLayoutError(ValueError):
+    """A checkpoint path cannot satisfy the requested resume contract."""
+
+
+class AmbiguousCheckpointError(CheckpointLayoutError):
+    """Multiple run roots contain the same highest checkpoint step."""
+
+
+class RLResumeMode(StrEnum):
+    NONE = "none"
+    LATEST = "latest"
+    FROM_PATH = "from_path"
+
+
+class RLPathDecision(StrEnum):
+    NEW = "new"
+    RESUME = "resume"
+    EXPLICIT_FRESH = "explicit-fresh"
+
+
+@dataclass(frozen=True)
+class CheckpointCandidate:
+    state_root: Path
+    checkpoint_dir: Path
+    checkpoint_path: Path
+    step: int
+
+
+@dataclass(frozen=True)
+class RLRunPaths:
+    """Resolved paths consumed by the launcher and SkyRL configuration."""
+
+    job_name: str
+    state_root: Path
+    checkpoint_dir: Path
+    export_dir: Path
+    trials_dir: Path
+    resume_mode: RLResumeMode
+    resume_path: Path | None
+    decision: RLPathDecision
+
+    def describe(self) -> str:
+        if self.resume_path is not None:
+            action = f"RESUME from {self.resume_path}"
+        elif self.decision is RLPathDecision.EXPLICIT_FRESH:
+            action = "EXPLICIT FRESH START"
+        else:
+            action = "NEW RUN (no checkpoint found)"
+        return (
+            f"[rl_paths] {action}; resume_mode={self.resume_mode.value}; "
+            f"checkpoints={self.checkpoint_dir}; exports={self.export_dir}; trials={self.trials_dir}"
+        )
+
+
+def _override_values(overrides: Sequence[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for override in overrides:
+        key, separator, value = override.partition("=")
+        if not separator:
+            continue
+        key = key.lstrip("+").strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def _absolute_path(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+class RLPathManager:
+    """Own checkpoint discovery and all durable RL path resolution."""
+
+    def __init__(self, job_name: str, canonical_root: Path, launch_root: Path):
+        self.job_name = job_name
+        self.canonical_root = canonical_root.expanduser().resolve()
+        self.launch_root = launch_root.expanduser().resolve()
+
+    def resolve(
+        self,
+        *,
+        skyrl_overrides: Sequence[str] = (),
+        fresh_start_requested: bool = False,
+    ) -> RLRunPaths:
+        overrides = _override_values(skyrl_overrides)
+        requested_mode = overrides.get("trainer.resume_mode")
+        requested_resume_path = overrides.get("trainer.resume_path")
+        if requested_mode in {"", "null", "None", "~"}:
+            requested_mode = RLResumeMode.NONE.value
+        if requested_resume_path in {"", "null", "None", "~"}:
+            requested_resume_path = None
+
+        if fresh_start_requested and requested_mode not in (None, RLResumeMode.NONE.value):
+            raise CheckpointLayoutError("A fresh start cannot also request checkpoint resume")
+        if requested_resume_path and requested_mode != RLResumeMode.FROM_PATH.value:
+            raise CheckpointLayoutError("trainer.resume_path requires trainer.resume_mode=from_path")
+
+        state_root = self.launch_root if fresh_start_requested else self.canonical_root
+        checkpoint_dir = self._configured_checkpoint_dir(overrides, state_root)
+        state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
+
+        if fresh_start_requested or requested_mode == RLResumeMode.NONE.value:
+            return self._resolved_paths(
+                state_root,
+                checkpoint_dir,
+                overrides,
+                resume_mode=RLResumeMode.NONE,
+                resume_path=None,
+                decision=RLPathDecision.EXPLICIT_FRESH,
+            )
+
+        if requested_mode == RLResumeMode.LATEST.value:
+            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=True)
+            assert candidate is not None
+            return self._resolved_paths(
+                state_root,
+                checkpoint_dir,
+                overrides,
+                resume_mode=RLResumeMode.LATEST,
+                resume_path=candidate.checkpoint_path,
+                decision=RLPathDecision.RESUME,
+            )
+
+        if requested_mode == RLResumeMode.FROM_PATH.value:
+            if not requested_resume_path:
+                raise CheckpointLayoutError("trainer.resume_mode=from_path requires trainer.resume_path")
+            resume_path = self._validate_explicit_resume_path(_absolute_path(requested_resume_path))
+            if "trainer.ckpt_path" in overrides and checkpoint_dir != resume_path.parent:
+                raise CheckpointLayoutError(
+                    f"trainer.resume_path {resume_path} is not under trainer.ckpt_path {checkpoint_dir}"
+                )
+            checkpoint_dir = resume_path.parent
+            state_root = self._state_root_for_checkpoint_dir(checkpoint_dir, state_root)
+            return self._resolved_paths(
+                state_root,
+                checkpoint_dir,
+                overrides,
+                resume_mode=RLResumeMode.FROM_PATH,
+                resume_path=resume_path,
+                decision=RLPathDecision.RESUME,
+            )
+
+        if requested_mode is not None:
+            raise CheckpointLayoutError(f"Unknown trainer.resume_mode: {requested_mode}")
+
+        if "trainer.ckpt_path" in overrides:
+            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=False)
+            candidates = [candidate] if candidate is not None else []
+        else:
+            candidates = self._checkpoint_candidates()
+
+        if not candidates:
+            return self._resolved_paths(
+                state_root,
+                checkpoint_dir,
+                overrides,
+                resume_mode=RLResumeMode.NONE,
+                resume_path=None,
+                decision=RLPathDecision.NEW,
+            )
+
+        highest_step = max(candidate.step for candidate in candidates)
+        highest = [candidate for candidate in candidates if candidate.step == highest_step]
+        if len(highest) != 1:
+            paths = ", ".join(str(candidate.checkpoint_path) for candidate in highest)
+            raise AmbiguousCheckpointError(
+                f"Multiple run roots contain global_step_{highest_step}: {paths}. "
+                "Set trainer.resume_mode=from_path and trainer.resume_path explicitly."
+            )
+
+        selected = highest[0]
+        return self._resolved_paths(
+            selected.state_root,
+            selected.checkpoint_dir,
+            overrides,
+            resume_mode=RLResumeMode.FROM_PATH,
+            resume_path=selected.checkpoint_path,
+            decision=RLPathDecision.RESUME,
+        )
+
+    def _configured_checkpoint_dir(self, overrides: dict[str, str], state_root: Path) -> Path:
+        configured = overrides.get("trainer.ckpt_path")
+        if configured:
+            return _absolute_path(configured)
+        return state_root / self.job_name / "checkpoints"
+
+    def _state_root_for_checkpoint_dir(self, checkpoint_dir: Path, fallback: Path) -> Path:
+        if checkpoint_dir.name == "checkpoints" and checkpoint_dir.parent.name == self.job_name:
+            return checkpoint_dir.parent.parent
+        return fallback
+
+    def _checkpoint_candidates(self) -> list[CheckpointCandidate]:
+        candidates: list[CheckpointCandidate] = []
+        for state_root in self._candidate_state_roots():
+            checkpoint_dir = state_root / self.job_name / "checkpoints"
+            candidate = self._checkpoint_candidate(state_root, checkpoint_dir, required=False)
+            if candidate is not None:
+                candidates.append(candidate)
+        return candidates
+
+    def _candidate_state_roots(self) -> list[Path]:
+        roots = [self.canonical_root]
+        parent = self.canonical_root.parent
+        if not parent.is_dir():
+            return roots
+        fork_pattern = re.compile(rf"{re.escape(self.canonical_root.name)}_(\d+)$")
+        roots.extend(
+            path.resolve() for path in parent.iterdir() if path.is_dir() and fork_pattern.fullmatch(path.name)
+        )
+        return roots
+
+    def _checkpoint_candidate(
+        self,
+        state_root: Path,
+        checkpoint_dir: Path,
+        *,
+        required: bool,
+    ) -> CheckpointCandidate | None:
+        marker_path = checkpoint_dir / LATEST_CHECKPOINT_FILE
+        step_dirs = self._step_directories(checkpoint_dir)
+        if not marker_path.is_file():
+            if step_dirs:
+                raise CheckpointLayoutError(
+                    f"Checkpoint directories exist under {checkpoint_dir}, but {LATEST_CHECKPOINT_FILE} is missing"
+                )
+            if required:
+                raise CheckpointLayoutError(
+                    f"trainer.resume_mode=latest requires a usable checkpoint under {checkpoint_dir}"
+                )
+            return None
+
+        try:
+            step = int(marker_path.read_text().strip())
+        except (OSError, ValueError) as error:
+            raise CheckpointLayoutError(f"Invalid checkpoint marker: {marker_path}") from error
+
+        checkpoint_path = checkpoint_dir / f"global_step_{step}"
+        if not checkpoint_path.is_dir():
+            raise CheckpointLayoutError(f"Checkpoint marker {marker_path} names missing {checkpoint_path.name}")
+        if step_dirs and max(step_dirs) != step:
+            raise CheckpointLayoutError(
+                f"Checkpoint marker {marker_path} names global_step_{step}, "
+                f"but global_step_{max(step_dirs)} also exists"
+            )
+        return CheckpointCandidate(state_root, checkpoint_dir, checkpoint_path, step)
+
+    @staticmethod
+    def _step_directories(checkpoint_dir: Path) -> list[int]:
+        if not checkpoint_dir.is_dir():
+            return []
+        steps: list[int] = []
+        for path in checkpoint_dir.iterdir():
+            match = GLOBAL_STEP_PATTERN.fullmatch(path.name)
+            if path.is_dir() and match:
+                steps.append(int(match.group(1)))
+        return steps
+
+    @staticmethod
+    def _validate_explicit_resume_path(resume_path: Path) -> Path:
+        if not resume_path.is_dir() or GLOBAL_STEP_PATTERN.fullmatch(resume_path.name) is None:
+            raise CheckpointLayoutError(
+                f"trainer.resume_path must be an existing global_step_<N> directory: {resume_path}"
+            )
+        return resume_path
+
+    def _resolved_paths(
+        self,
+        state_root: Path,
+        checkpoint_dir: Path,
+        overrides: dict[str, str],
+        *,
+        resume_mode: RLResumeMode,
+        resume_path: Path | None,
+        decision: RLPathDecision,
+    ) -> RLRunPaths:
+        trainer_root = state_root / self.job_name
+        export_dir = (
+            _absolute_path(overrides["trainer.export_path"])
+            if "trainer.export_path" in overrides
+            else trainer_root / "exports"
+        )
+        trials_dir = (
+            _absolute_path(overrides["terminal_bench_config.trials_dir"])
+            if "terminal_bench_config.trials_dir" in overrides
+            else trainer_root / "trace_jobs"
+        )
+        return RLRunPaths(
+            job_name=self.job_name,
+            state_root=state_root,
+            checkpoint_dir=checkpoint_dir,
+            export_dir=export_dir,
+            trials_dir=trials_dir,
+            resume_mode=resume_mode,
+            resume_path=resume_path,
+            decision=decision,
+        )

--- a/hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml
+++ b/hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml
@@ -111,7 +111,7 @@ trainer:
   eval_interval: 999999
   eval_before_train: false
   ckpt_interval: 5
-  resume_mode: latest
+  resume_mode: null
   hf_save_interval: 5
   hf_hub_repo_id: null
   hf_hub_private: false

--- a/hpc/skyrl_yaml/jupiter/56GPU_qwen3_8b.yaml
+++ b/hpc/skyrl_yaml/jupiter/56GPU_qwen3_8b.yaml
@@ -110,7 +110,7 @@ trainer:
   eval_interval: 999999
   eval_before_train: false
   ckpt_interval: 2
-  resume_mode: latest
+  resume_mode: null
   hf_save_interval: 5
   hf_hub_repo_id: null
   hf_hub_private: false

--- a/hpc/skyrl_yaml/jupiter/64GPU_qwen3_32b.yaml
+++ b/hpc/skyrl_yaml/jupiter/64GPU_qwen3_32b.yaml
@@ -109,7 +109,7 @@ trainer:
   eval_interval: 999999
   eval_before_train: false
   ckpt_interval: 1
-  resume_mode: latest
+  resume_mode: null
   hf_save_interval: 5
   hf_hub_repo_id: null
   hf_hub_private: false

--- a/rl/local/run_rl.py
+++ b/rl/local/run_rl.py
@@ -228,6 +228,8 @@ class LocalRLRunner:
         )
         experiments_root = Path(self.config.experiments_dir)
         run_paths = RLPathManager(self.config.job_name, experiments_root, experiments_root).resolve(
+            trainer_config=parsed.trainer,
+            terminal_bench_config=parsed.terminal_bench or {},
             skyrl_overrides=self.config.skyrl_overrides,
         )
         print(run_paths.describe())

--- a/rl/local/run_rl.py
+++ b/rl/local/run_rl.py
@@ -53,8 +53,8 @@ from hpc.rl_launch_utils import (
     check_rl_environment,
     resolve_rl_train_data,
     compute_num_inference_engines,
-    derive_skyrl_export_path,
 )
+from hpc.rl_paths import RLPathManager, RLRunPaths
 
 
 @dataclass
@@ -226,7 +226,12 @@ class LocalRLRunner:
             gpus_per_node=self.config.gpus,
             cpus_per_node=self.config.cpus,
         )
-        hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc_stub)
+        experiments_root = Path(self.config.experiments_dir)
+        run_paths = RLPathManager(self.config.job_name, experiments_root, experiments_root).resolve(
+            skyrl_overrides=self.config.skyrl_overrides,
+        )
+        print(run_paths.describe())
+        hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc_stub, run_paths=run_paths)
 
         # Add CLI overrides
         if self.config.skyrl_overrides:
@@ -238,7 +243,7 @@ class LocalRLRunner:
             return 0
 
         # Set up environment
-        self._setup_environment(exp_args)
+        self._setup_environment(exp_args, run_paths)
 
         # Start Ray and run SkyRL
         return self._run_with_ray(parsed.entrypoint, hydra_args)
@@ -263,7 +268,7 @@ class LocalRLRunner:
             "master_port": self.config.master_port,
         }
 
-    def _setup_environment(self, exp_args: Dict[str, Any]) -> None:
+    def _setup_environment(self, exp_args: Dict[str, Any], run_paths: RLRunPaths) -> None:
         """Configure environment variables for RL training."""
         # Tensor parallelism and inference engines
         os.environ["TENSOR_PARALLEL_SIZE"] = str(self.config.tensor_parallel_size)
@@ -277,10 +282,7 @@ class LocalRLRunner:
         os.environ["POLICY_NUM_NODES"] = str(self.config.num_nodes)
 
         # Export path
-        export_path = derive_skyrl_export_path(
-            self.config.experiments_dir,
-            self.config.job_name,
-        )
+        export_path = str(run_paths.export_dir)
         os.environ["SKYRL_EXPORT_PATH"] = export_path
 
         # vLLM settings

--- a/rl/local/run_rl.py
+++ b/rl/local/run_rl.py
@@ -245,7 +245,7 @@ class LocalRLRunner:
             return 0
 
         # Set up environment
-        self._setup_environment(exp_args, run_paths)
+        self._setup_environment(run_paths)
 
         # Start Ray and run SkyRL
         return self._run_with_ray(parsed.entrypoint, hydra_args)
@@ -270,7 +270,7 @@ class LocalRLRunner:
             "master_port": self.config.master_port,
         }
 
-    def _setup_environment(self, exp_args: Dict[str, Any], run_paths: RLRunPaths) -> None:
+    def _setup_environment(self, run_paths: RLRunPaths) -> None:
         """Configure environment variables for RL training."""
         # Tensor parallelism and inference engines
         os.environ["TENSOR_PARALLEL_SIZE"] = str(self.config.tensor_parallel_size)

--- a/tests/hpc/test_launch_utils_collision.py
+++ b/tests/hpc/test_launch_utils_collision.py
@@ -1,17 +1,7 @@
-"""Regression tests for ``hpc/launch_utils.py:setup_experiments_dir``.
+"""Regression tests for launcher artifact collision handling.
 
-Specifically covers the collision-rename path. The bug this guards
-against is documented in
-``notes/ot-agent/agent_logs/2026-05-26_launcher_trials_dir_collision_bug.md``:
-when the experiments dir already exists with a different run's
-configs, the launcher appends ``_N`` to land at a fresh dir, but
-prior to this fix the renamed path was NOT propagated back into
-``exp_args["experiments_dir"]``. Downstream consumers
-(``hpc/rl_config_utils.py`` deriving trainer.trials_dir / ckpt_path
-/ export_path; ``hpc/launch.py`` deriving wandb_dir) then used the
-un-suffixed canonical path, causing concurrent renamed chains to
-share the same inner trainer dirs → data corruption / write-race
-hazards.
+Collision-renamed directories own launch artifacts such as configs, logs, and
+sbatch scripts. Durable RL state is resolved separately by ``RLPathManager``.
 
 Run from the OT-Agent repo root with:
     .venv/bin/python -m pytest tests/hpc/test_launch_utils_collision.py -v
@@ -82,37 +72,6 @@ def test_collision_chain_increments_to_3(tmp_path: Path) -> None:
     expected_renamed = tmp_path / "ot-baf" / "myjob_3"
     assert paths.root == expected_renamed
     assert exp_args["experiments_dir"] == str(expected_renamed)
-
-
-def test_renamed_path_feeds_downstream_derivations(tmp_path: Path) -> None:
-    """End-to-end: after a collision rename, the rl_config_utils-style
-    derivation ``f"{experiments_dir}/{job_name}/trace_jobs"`` MUST land
-    inside the renamed dir, not the canonical one.
-
-    This is the exact pattern in
-    ``hpc/rl_config_utils.py:build_skyrl_hydra_args`` for
-    trials_dir / ckpt_path / export_path. The bug report's evidence
-    showed trials_dir pointing at the un-suffixed canonical dir
-    (``<D>/<job_name>/<job_name>/trace_jobs``) while
-    experiments_dir in the same config JSON was the ``_3`` form.
-    """
-    job_name = "myjob"
-    canonical = tmp_path / "ot-baf" / job_name
-    _seed_existing_experiment(canonical)
-
-    exp_args = {"experiments_dir": str(canonical), "job_type": "rl"}
-    setup_experiments_dir(exp_args, job_name=job_name)
-
-    # Replay rl_config_utils.build_skyrl_hydra_args' path derivation.
-    experiments_dir_after = exp_args["experiments_dir"]
-    derived_trials = f"{experiments_dir_after}/{job_name}/trace_jobs"
-    derived_ckpt = f"{experiments_dir_after}/{job_name}/checkpoints"
-    derived_export = f"{experiments_dir_after}/{job_name}/exports"
-
-    renamed_root = str(tmp_path / "ot-baf" / "myjob_2")
-    assert derived_trials.startswith(renamed_root + "/")
-    assert derived_ckpt.startswith(renamed_root + "/")
-    assert derived_export.startswith(renamed_root + "/")
 
 
 def test_disable_dedup_skips_rename_and_still_writes_back(tmp_path: Path) -> None:

--- a/tests/hpc/test_rl_chain_overshoot_guard.py
+++ b/tests/hpc/test_rl_chain_overshoot_guard.py
@@ -22,22 +22,21 @@ import types
 
 
 from hpc.rl_launch_utils import RLJobRunner
+from hpc.rl_paths import hydra_override_values
 
 
 # ---------------------------------------------------------------------------
-# _hydra_arg_value: last-wins dotted lookup with +/++ marker + quote handling
+# Hydra override parsing: last-wins dotted lookup with marker and quote handling
 # ---------------------------------------------------------------------------
 
 
 def test_hydra_arg_value_basic():
     args = ["trainer.max_steps=80", "trainer.epochs=2"]
-    assert RLJobRunner._hydra_arg_value(args, "trainer.max_steps") == "80"
+    assert hydra_override_values(args).get("trainer.max_steps") == "80"
 
 
 def test_hydra_arg_value_missing_returns_none():
-    assert (
-        RLJobRunner._hydra_arg_value(["trainer.epochs=2"], "trainer.max_steps") is None
-    )
+    assert hydra_override_values(["trainer.epochs=2"]).get("trainer.max_steps") is None
 
 
 def test_hydra_arg_value_last_wins():
@@ -48,32 +47,31 @@ def test_hydra_arg_value_last_wins():
         "trainer.ckpt_path=/canonical/checkpoints",
     ]
     assert (
-        RLJobRunner._hydra_arg_value(args, "trainer.ckpt_path")
-        == "/canonical/checkpoints"
+        hydra_override_values(args).get("trainer.ckpt_path") == "/canonical/checkpoints"
     )
 
 
 def test_hydra_arg_value_strips_override_markers():
     assert (
-        RLJobRunner._hydra_arg_value(["++trainer.max_steps=80"], "trainer.max_steps")
+        hydra_override_values(["++trainer.max_steps=80"]).get("trainer.max_steps")
         == "80"
     )
     assert (
-        RLJobRunner._hydra_arg_value(["+trainer.max_steps=80"], "trainer.max_steps")
+        hydra_override_values(["+trainer.max_steps=80"]).get("trainer.max_steps")
         == "80"
     )
 
 
 def test_hydra_arg_value_strips_surrounding_quotes():
     assert (
-        RLJobRunner._hydra_arg_value(
-            ["trainer.ckpt_path='/a path/ckpts'"], "trainer.ckpt_path"
+        hydra_override_values(["trainer.ckpt_path='/a path/ckpts'"]).get(
+            "trainer.ckpt_path"
         )
         == "/a path/ckpts"
     )
     assert (
-        RLJobRunner._hydra_arg_value(
-            ['trainer.ckpt_path="/a:b/ckpts"'], "trainer.ckpt_path"
+        hydra_override_values(['trainer.ckpt_path="/a:b/ckpts"']).get(
+            "trainer.ckpt_path"
         )
         == "/a:b/ckpts"
     )

--- a/tests/hpc/test_rl_chain_overshoot_guard.py
+++ b/tests/hpc/test_rl_chain_overshoot_guard.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import types
 
+import pytest
+
 
 from hpc.rl_launch_utils import RLJobRunner
 from hpc.rl_paths import hydra_override_values
@@ -30,51 +32,27 @@ from hpc.rl_paths import hydra_override_values
 # ---------------------------------------------------------------------------
 
 
-def test_hydra_arg_value_basic():
-    args = ["trainer.max_steps=80", "trainer.epochs=2"]
-    assert hydra_override_values(args).get("trainer.max_steps") == "80"
-
-
-def test_hydra_arg_value_missing_returns_none():
-    assert hydra_override_values(["trainer.epochs=2"]).get("trainer.max_steps") is None
-
-
-def test_hydra_arg_value_last_wins():
-    # The launcher's auto-resume guard appends a second trainer.ckpt_path pinned
-    # to the canonical dir; last-wins must pick the canonical one.
-    args = [
-        "trainer.ckpt_path=/redirected/_dryrun/checkpoints",
-        "trainer.ckpt_path=/canonical/checkpoints",
-    ]
-    assert (
-        hydra_override_values(args).get("trainer.ckpt_path") == "/canonical/checkpoints"
-    )
-
-
-def test_hydra_arg_value_strips_override_markers():
-    assert (
-        hydra_override_values(["++trainer.max_steps=80"]).get("trainer.max_steps")
-        == "80"
-    )
-    assert (
-        hydra_override_values(["+trainer.max_steps=80"]).get("trainer.max_steps")
-        == "80"
-    )
-
-
-def test_hydra_arg_value_strips_surrounding_quotes():
-    assert (
-        hydra_override_values(["trainer.ckpt_path='/a path/ckpts'"]).get(
-            "trainer.ckpt_path"
-        )
-        == "/a path/ckpts"
-    )
-    assert (
-        hydra_override_values(['trainer.ckpt_path="/a:b/ckpts"']).get(
-            "trainer.ckpt_path"
-        )
-        == "/a:b/ckpts"
-    )
+@pytest.mark.parametrize(
+    ("arguments", "key", "expected"),
+    [
+        (["trainer.max_steps=80", "trainer.epochs=2"], "trainer.max_steps", "80"),
+        (["trainer.epochs=2"], "trainer.max_steps", None),
+        (
+            [
+                "trainer.ckpt_path=/first/checkpoints",
+                "trainer.ckpt_path=/latest/checkpoints",
+            ],
+            "trainer.ckpt_path",
+            "/latest/checkpoints",
+        ),
+        (["++trainer.max_steps=80"], "trainer.max_steps", "80"),
+        (["+trainer.max_steps=80"], "trainer.max_steps", "80"),
+        (["trainer.ckpt_path='/a path/ckpts'"], "trainer.ckpt_path", "/a path/ckpts"),
+        (['trainer.ckpt_path="/a:b/ckpts"'], "trainer.ckpt_path", "/a:b/ckpts"),
+    ],
+)
+def test_hydra_override_values_normalize_and_use_last_value(arguments, key, expected):
+    assert hydra_override_values(arguments).get(key) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -37,7 +37,7 @@ def test_forked_checkpoint_becomes_the_single_durable_run_root(tmp_path: Path) -
 
     resolved = RLPathManager(JOB_NAME, canonical_root, launch_root).resolve()
 
-    assert resolved.resume_mode is RLResumeMode.FROM_PATH
+    assert resolved.resume_mode is RLResumeMode.LATEST
     assert resolved.resume_path == checkpoint_path
     assert resolved.checkpoint_dir == checkpoint_root / JOB_NAME / "checkpoints"
     assert resolved.export_dir == checkpoint_root / JOB_NAME / "exports"
@@ -213,7 +213,7 @@ def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> No
 
     assert _hydra_value(arguments, "trainer.ckpt_path") == str(run_paths.checkpoint_dir)
     assert _hydra_value(arguments, "trainer.export_path") == str(run_paths.export_dir)
-    assert _hydra_value(arguments, "trainer.resume_mode") == "from_path"
+    assert _hydra_value(arguments, "trainer.resume_mode") == "latest"
     assert _hydra_value(arguments, "trainer.resume_path") == str(checkpoint_path)
     assert _hydra_value(arguments, "terminal_bench_config.trials_dir") == str(
         run_paths.trials_dir

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -164,7 +164,7 @@ def test_duplicate_highest_steps_require_explicit_resume_path(tmp_path: Path) ->
         RLPathManager(JOB_NAME, canonical_root, launch_root).resolve()
 
 
-def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> None:
+def test_yaml_path_settings_feed_the_manager_contract(tmp_path: Path) -> None:
     root = tmp_path / JOB_NAME
     configured_root = tmp_path / "configured"
     checkpoint_path = _write_checkpoint(configured_root, 7)
@@ -183,6 +183,28 @@ def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> No
         trainer_config=parsed.trainer,
         terminal_bench_config=parsed.terminal_bench,
     )
+
+    assert run_paths.checkpoint_dir == checkpoint_path.parent
+    assert run_paths.export_dir == configured_root / JOB_NAME / "model_exports"
+    assert run_paths.trials_dir == configured_root / JOB_NAME / "trials"
+    assert run_paths.resume_path == checkpoint_path
+
+
+def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> None:
+    root = tmp_path / JOB_NAME
+    checkpoint_path = _write_checkpoint(root, 7)
+    run_paths = RLPathManager(JOB_NAME, root, root).resolve()
+    parsed = ParsedRLConfig(
+        config_path=tmp_path / "config.yaml",
+        raw={},
+        entrypoint="skyrl_train.entrypoints.main_base",
+        trainer={
+            "resume_mode": "latest",
+            "ckpt_path": "/stale/checkpoints",
+            "export_path": "/stale/exports",
+        },
+        terminal_bench={"trials_dir": "/stale/trials"},
+    )
     hpc = type("HPC", (), {"gpus_per_node": 4})()
 
     arguments = build_skyrl_hydra_args(
@@ -191,7 +213,7 @@ def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> No
 
     assert _hydra_value(arguments, "trainer.ckpt_path") == str(run_paths.checkpoint_dir)
     assert _hydra_value(arguments, "trainer.export_path") == str(run_paths.export_dir)
-    assert _hydra_value(arguments, "trainer.resume_mode") == "latest"
+    assert _hydra_value(arguments, "trainer.resume_mode") == "from_path"
     assert _hydra_value(arguments, "trainer.resume_path") == str(checkpoint_path)
     assert _hydra_value(arguments, "terminal_bench_config.trials_dir") == str(
         run_paths.trials_dir

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -5,6 +5,7 @@ import pytest
 from hpc.rl_paths import (
     AmbiguousCheckpointError,
     CheckpointLayoutError,
+    RLLaunchIntent,
     RLPathManager,
     RLResumeMode,
 )
@@ -42,7 +43,6 @@ def test_forked_checkpoint_becomes_the_single_durable_run_root(tmp_path: Path) -
 
     assert resolved.resume_mode is RLResumeMode.FROM_PATH
     assert resolved.resume_path == checkpoint_path
-    assert resolved.state_root == checkpoint_root
     assert resolved.checkpoint_dir == checkpoint_root / JOB_NAME / "checkpoints"
     assert resolved.export_dir == checkpoint_root / JOB_NAME / "exports"
     assert resolved.trials_dir == checkpoint_root / JOB_NAME / "trace_jobs"
@@ -72,8 +72,21 @@ def test_new_run_uses_canonical_state_root_after_artifact_collision(
 
     assert resolved.resume_mode is RLResumeMode.NONE
     assert resolved.resume_path is None
-    assert resolved.state_root == canonical_root
     assert resolved.checkpoint_dir == canonical_root / JOB_NAME / "checkpoints"
+
+
+def test_explicit_fresh_launch_uses_the_launch_root(tmp_path: Path) -> None:
+    canonical_root = tmp_path / JOB_NAME
+    launch_root = tmp_path / f"{JOB_NAME}_2"
+    _write_checkpoint(canonical_root, 8)
+
+    resolved = RLPathManager(JOB_NAME, canonical_root, launch_root).resolve(
+        launch_intent=RLLaunchIntent.FRESH,
+    )
+
+    assert resolved.resume_mode is RLResumeMode.NONE
+    assert resolved.resume_path is None
+    assert resolved.checkpoint_dir == launch_root / JOB_NAME / "checkpoints"
 
 
 def test_explicit_latest_rejects_empty_checkpoint_directory(tmp_path: Path) -> None:
@@ -104,7 +117,7 @@ def test_explicit_resume_path_becomes_the_checkpoint_write_directory(
 
     assert resolved.resume_path == checkpoint_path
     assert resolved.checkpoint_dir == checkpoint_path.parent
-    assert resolved.state_root == tmp_path / f"{JOB_NAME}_3"
+    assert resolved.export_dir == tmp_path / f"{JOB_NAME}_3" / JOB_NAME / "exports"
 
 
 def test_explicit_resume_path_rejects_a_different_checkpoint_write_directory(

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -9,6 +9,7 @@ from hpc.rl_paths import (
     RLResumeMode,
 )
 from hpc.rl_config_utils import ParsedRLConfig, build_skyrl_hydra_args
+from hpc.rl_launch_utils import RLJobConfig, RLJobRunner
 
 
 JOB_NAME = "tasktrove-arm"
@@ -145,14 +146,22 @@ def test_duplicate_highest_steps_require_explicit_resume_path(tmp_path: Path) ->
 
 def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> None:
     root = tmp_path / JOB_NAME
-    checkpoint_path = _write_checkpoint(root, 7)
-    run_paths = RLPathManager(JOB_NAME, root, root).resolve()
+    configured_root = tmp_path / "configured"
+    checkpoint_path = _write_checkpoint(configured_root, 7)
     parsed = ParsedRLConfig(
         config_path=tmp_path / "config.yaml",
         raw={},
         entrypoint="skyrl_train.entrypoints.main_base",
-        trainer={"resume_mode": "latest", "ckpt_path": "/stale/checkpoints"},
-        terminal_bench={"trials_dir": "/stale/traces"},
+        trainer={
+            "resume_mode": "latest",
+            "ckpt_path": str(checkpoint_path.parent),
+            "export_path": str(configured_root / JOB_NAME / "model_exports"),
+        },
+        terminal_bench={"trials_dir": str(configured_root / JOB_NAME / "trials")},
+    )
+    run_paths = RLPathManager(JOB_NAME, root, root).resolve(
+        trainer_config=parsed.trainer,
+        terminal_bench_config=parsed.terminal_bench,
     )
     hpc = type("HPC", (), {"gpus_per_node": 4})()
 
@@ -167,3 +176,44 @@ def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> No
     assert _hydra_value(arguments, "terminal_bench_config.trials_dir") == str(
         run_paths.trials_dir
     )
+
+
+def test_yaml_latest_without_a_checkpoint_becomes_a_new_run(tmp_path: Path) -> None:
+    root = tmp_path / JOB_NAME
+
+    resolved = RLPathManager(JOB_NAME, root, root).resolve(
+        trainer_config={"resume_mode": "latest"},
+    )
+
+    assert resolved.resume_mode is RLResumeMode.NONE
+    assert resolved.resume_path is None
+
+
+def test_trace_upload_consumes_the_manager_resolved_trials_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trials_dir = tmp_path / "durable" / "custom-trials"
+    trials_dir.mkdir(parents=True)
+    launch_root = tmp_path / "launch-artifacts"
+    config = RLJobConfig(
+        job_name=JOB_NAME,
+        experiments_dir=str(launch_root),
+        cluster_name="test",
+        skyrl_entrypoint="skyrl_train.entrypoints.main_base",
+        trials_dir=str(trials_dir),
+        trace_upload_enabled=True,
+    )
+    captured: dict[str, list[str]] = {}
+
+    def fake_popen(command: list[str], *, stdout, stderr):
+        captured["command"] = command
+        stdout.close()
+        return object()
+
+    monkeypatch.setattr("hpc.rl_launch_utils.subprocess.Popen", fake_popen)
+
+    process = RLJobRunner(config)._launch_trace_upload(training_exit_code=0)
+
+    assert process is not None
+    command = captured["command"]
+    assert command[command.index("--job_dir") + 1] == str(trials_dir)

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -8,6 +8,7 @@ from hpc.rl_paths import (
     RLLaunchIntent,
     RLPathManager,
     RLResumeMode,
+    hydra_override_values,
 )
 from hpc.rl_config_utils import ParsedRLConfig, build_skyrl_hydra_args
 from hpc.rl_launch_utils import RLJobConfig, RLJobRunner
@@ -25,12 +26,7 @@ def _write_checkpoint(state_root: Path, step: int) -> Path:
 
 
 def _hydra_value(arguments: list[str], key: str) -> str | None:
-    value = None
-    for argument in arguments:
-        argument_key, separator, argument_value = argument.partition("=")
-        if separator and argument_key.lstrip("+") == key:
-            value = argument_value.strip("'\"")
-    return value
+    return hydra_override_values(arguments).get(key)
 
 
 def test_forked_checkpoint_becomes_the_single_durable_run_root(tmp_path: Path) -> None:
@@ -133,6 +129,17 @@ def test_explicit_resume_path_rejects_a_different_checkpoint_write_directory(
                 "trainer.resume_mode=from_path",
                 f"trainer.resume_path={checkpoint_path}",
             )
+        )
+
+
+def test_nonstandard_checkpoint_path_requires_explicit_sibling_destinations(
+    tmp_path: Path,
+) -> None:
+    checkpoint_dir = tmp_path / "standalone-checkpoints"
+
+    with pytest.raises(CheckpointLayoutError, match="requires explicit values"):
+        RLPathManager(JOB_NAME, tmp_path, tmp_path).resolve(
+            skyrl_overrides=(f"trainer.ckpt_path={checkpoint_dir}",),
         )
 
 

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -171,22 +171,20 @@ def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> No
 
     assert _hydra_value(arguments, "trainer.ckpt_path") == str(run_paths.checkpoint_dir)
     assert _hydra_value(arguments, "trainer.export_path") == str(run_paths.export_dir)
-    assert _hydra_value(arguments, "trainer.resume_mode") == "from_path"
+    assert _hydra_value(arguments, "trainer.resume_mode") == "latest"
     assert _hydra_value(arguments, "trainer.resume_path") == str(checkpoint_path)
     assert _hydra_value(arguments, "terminal_bench_config.trials_dir") == str(
         run_paths.trials_dir
     )
 
 
-def test_yaml_latest_without_a_checkpoint_becomes_a_new_run(tmp_path: Path) -> None:
+def test_yaml_latest_without_a_checkpoint_is_rejected(tmp_path: Path) -> None:
     root = tmp_path / JOB_NAME
 
-    resolved = RLPathManager(JOB_NAME, root, root).resolve(
-        trainer_config={"resume_mode": "latest"},
-    )
-
-    assert resolved.resume_mode is RLResumeMode.NONE
-    assert resolved.resume_path is None
+    with pytest.raises(CheckpointLayoutError, match="resume_mode=latest"):
+        RLPathManager(JOB_NAME, root, root).resolve(
+            trainer_config={"resume_mode": "latest"},
+        )
 
 
 def test_trace_upload_consumes_the_manager_resolved_trials_directory(

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+
+import pytest
+
+from hpc.rl_paths import (
+    AmbiguousCheckpointError,
+    CheckpointLayoutError,
+    RLPathManager,
+    RLResumeMode,
+)
+from hpc.rl_config_utils import ParsedRLConfig, build_skyrl_hydra_args
+
+
+JOB_NAME = "tasktrove-arm"
+
+
+def _write_checkpoint(state_root: Path, step: int) -> Path:
+    checkpoint_root = state_root / JOB_NAME / "checkpoints"
+    checkpoint_path = checkpoint_root / f"global_step_{step}"
+    checkpoint_path.mkdir(parents=True)
+    (checkpoint_root / "latest_ckpt_global_step.txt").write_text(str(step))
+    return checkpoint_path
+
+
+def _hydra_value(arguments: list[str], key: str) -> str | None:
+    value = None
+    for argument in arguments:
+        argument_key, separator, argument_value = argument.partition("=")
+        if separator and argument_key.lstrip("+") == key:
+            value = argument_value.strip("'\"")
+    return value
+
+
+def test_forked_checkpoint_becomes_the_single_durable_run_root(tmp_path: Path) -> None:
+    canonical_root = tmp_path / JOB_NAME
+    launch_root = tmp_path / f"{JOB_NAME}_4"
+    checkpoint_root = tmp_path / f"{JOB_NAME}_3"
+    checkpoint_path = _write_checkpoint(checkpoint_root, 10)
+
+    resolved = RLPathManager(JOB_NAME, canonical_root, launch_root).resolve()
+
+    assert resolved.resume_mode is RLResumeMode.FROM_PATH
+    assert resolved.resume_path == checkpoint_path
+    assert resolved.state_root == checkpoint_root
+    assert resolved.checkpoint_dir == checkpoint_root / JOB_NAME / "checkpoints"
+    assert resolved.export_dir == checkpoint_root / JOB_NAME / "exports"
+    assert resolved.trials_dir == checkpoint_root / JOB_NAME / "trace_jobs"
+
+
+def test_highest_checkpoint_wins_across_canonical_and_forked_roots(
+    tmp_path: Path,
+) -> None:
+    canonical_root = tmp_path / JOB_NAME
+    launch_root = tmp_path / f"{JOB_NAME}_4"
+    _write_checkpoint(canonical_root, 6)
+    checkpoint_path = _write_checkpoint(tmp_path / f"{JOB_NAME}_3", 10)
+
+    resolved = RLPathManager(JOB_NAME, canonical_root, launch_root).resolve()
+
+    assert resolved.resume_path == checkpoint_path
+    assert resolved.checkpoint_dir == checkpoint_path.parent
+
+
+def test_new_run_uses_canonical_state_root_after_artifact_collision(
+    tmp_path: Path,
+) -> None:
+    canonical_root = tmp_path / JOB_NAME
+    launch_root = tmp_path / f"{JOB_NAME}_2"
+
+    resolved = RLPathManager(JOB_NAME, canonical_root, launch_root).resolve()
+
+    assert resolved.resume_mode is RLResumeMode.NONE
+    assert resolved.resume_path is None
+    assert resolved.state_root == canonical_root
+    assert resolved.checkpoint_dir == canonical_root / JOB_NAME / "checkpoints"
+
+
+def test_explicit_latest_rejects_empty_checkpoint_directory(tmp_path: Path) -> None:
+    root = tmp_path / JOB_NAME
+    checkpoint_dir = root / JOB_NAME / "checkpoints"
+
+    with pytest.raises(CheckpointLayoutError, match="resume_mode=latest"):
+        RLPathManager(JOB_NAME, root, root).resolve(
+            skyrl_overrides=(
+                f"trainer.ckpt_path={checkpoint_dir}",
+                "trainer.resume_mode=latest",
+            )
+        )
+
+
+def test_explicit_resume_path_becomes_the_checkpoint_write_directory(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / JOB_NAME
+    checkpoint_path = _write_checkpoint(tmp_path / f"{JOB_NAME}_3", 10)
+
+    resolved = RLPathManager(JOB_NAME, root, root).resolve(
+        skyrl_overrides=(
+            "trainer.resume_mode=from_path",
+            f"trainer.resume_path={checkpoint_path}",
+        )
+    )
+
+    assert resolved.resume_path == checkpoint_path
+    assert resolved.checkpoint_dir == checkpoint_path.parent
+    assert resolved.state_root == tmp_path / f"{JOB_NAME}_3"
+
+
+def test_explicit_resume_path_rejects_a_different_checkpoint_write_directory(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / JOB_NAME
+    checkpoint_path = _write_checkpoint(tmp_path / f"{JOB_NAME}_3", 10)
+
+    with pytest.raises(CheckpointLayoutError, match="is not under trainer.ckpt_path"):
+        RLPathManager(JOB_NAME, root, root).resolve(
+            skyrl_overrides=(
+                f"trainer.ckpt_path={root / JOB_NAME / 'checkpoints'}",
+                "trainer.resume_mode=from_path",
+                f"trainer.resume_path={checkpoint_path}",
+            )
+        )
+
+
+def test_checkpoint_marker_must_name_an_existing_step(tmp_path: Path) -> None:
+    root = tmp_path / JOB_NAME
+    checkpoint_root = root / JOB_NAME / "checkpoints"
+    checkpoint_root.mkdir(parents=True)
+    (checkpoint_root / "global_step_4").mkdir()
+    (checkpoint_root / "latest_ckpt_global_step.txt").write_text("5")
+
+    with pytest.raises(CheckpointLayoutError, match="global_step_5"):
+        RLPathManager(JOB_NAME, root, root).resolve()
+
+
+def test_duplicate_highest_steps_require_explicit_resume_path(tmp_path: Path) -> None:
+    canonical_root = tmp_path / JOB_NAME
+    launch_root = tmp_path / f"{JOB_NAME}_4"
+    _write_checkpoint(canonical_root, 10)
+    _write_checkpoint(tmp_path / f"{JOB_NAME}_3", 10)
+
+    with pytest.raises(AmbiguousCheckpointError, match="global_step_10"):
+        RLPathManager(JOB_NAME, canonical_root, launch_root).resolve()
+
+
+def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> None:
+    root = tmp_path / JOB_NAME
+    checkpoint_path = _write_checkpoint(root, 7)
+    run_paths = RLPathManager(JOB_NAME, root, root).resolve()
+    parsed = ParsedRLConfig(
+        config_path=tmp_path / "config.yaml",
+        raw={},
+        entrypoint="skyrl_train.entrypoints.main_base",
+        trainer={"resume_mode": "latest", "ckpt_path": "/stale/checkpoints"},
+        terminal_bench={"trials_dir": "/stale/traces"},
+    )
+    hpc = type("HPC", (), {"gpus_per_node": 4})()
+
+    arguments = build_skyrl_hydra_args(
+        parsed, {"job_name": JOB_NAME}, hpc, run_paths=run_paths
+    )
+
+    assert _hydra_value(arguments, "trainer.ckpt_path") == str(run_paths.checkpoint_dir)
+    assert _hydra_value(arguments, "trainer.export_path") == str(run_paths.export_dir)
+    assert _hydra_value(arguments, "trainer.resume_mode") == "from_path"
+    assert _hydra_value(arguments, "trainer.resume_path") == str(checkpoint_path)
+    assert _hydra_value(arguments, "terminal_bench_config.trials_dir") == str(
+        run_paths.trials_dir
+    )


### PR DESCRIPTION
Centralize RL checkpoint, export, and Harbor trial paths in one validated path manager. Discover usable checkpoints across canonical and numbered fork roots, select the unique newest lineage, and fail loudly on missing, ambiguous, malformed, or split explicit resume contracts instead of silently restarting at step zero.

Thread the resolved contract through Hydra generation, local and HPC launch paths, serialized jobs, trace upload, and cleanup. Automatic resumes use `latest` within the fixed selected checkpoint directory so every `afterany` restart observes checkpoints written after submission; explicit YAML or CLI resume requests remain strict and WYSIWYG.

Leave built-in first-launch configs in automatic discovery mode and share collision-fork and checkpoint naming rules so launcher artifact renames cannot independently mutate durable trainer state.
