### PR TITLE
[hpc] Keep JSC NCCL IB timeouts finite

### DIFF
--- a/hpc/hpc.py
+++ b/hpc/hpc.py
@@ -792,6 +792,10 @@ echo "[proxy] ✓ Proxy environment configured"'''
         return "\n".join(lines)
 
 
+# NCCL treats 0 and values >=32 as infinite, not seconds. Keep JSC at 23; do not raise it to lengthen waits.
+JSC_NCCL_IB_TIMEOUT = "23"
+
+
 jureca = HPC(
     name="jureca",
     hostname_pattern=r"jr.*?.jureca",
@@ -816,7 +820,7 @@ jureca = HPC(
     nccl_settings={
         "NCCL_NET_GDR_LEVEL": "0",
         "NCCL_SOCKET_IFNAME": "ib0",
-        "NCCL_IB_TIMEOUT": "60",
+        "NCCL_IB_TIMEOUT": JSC_NCCL_IB_TIMEOUT,
     },
     training_launcher="accelerate",
     # JSC shared SOCKS5 proxy (more reliable than SSH tunnels)
@@ -959,7 +963,7 @@ jupiter = HPC(
         "NCCL_DEBUG": "WARN",
         "NCCL_NET_GDR_LEVEL": "0",
         "NCCL_SOCKET_IFNAME": "ib0",
-        "NCCL_IB_TIMEOUT": "60",
+        "NCCL_IB_TIMEOUT": JSC_NCCL_IB_TIMEOUT,
     },
     training_launcher="accelerate",
     needs_ssh_tunnel=True,
@@ -1052,7 +1056,7 @@ juwels = HPC(
     nccl_settings={
         "NCCL_NET_GDR_LEVEL": "0",
         "NCCL_SOCKET_IFNAME": "ib0",
-        "NCCL_IB_TIMEOUT": "60",
+        "NCCL_IB_TIMEOUT": JSC_NCCL_IB_TIMEOUT,
     },
     training_launcher="accelerate",
     # JSC shared SOCKS5 proxy (more reliable than SSH tunnels)

--- a/tests/hpc/test_nccl_settings.py
+++ b/tests/hpc/test_nccl_settings.py
@@ -1,0 +1,16 @@
+import pytest
+
+from hpc.hpc import HPC, clusters
+
+
+@pytest.mark.parametrize(
+    "cluster",
+    [cluster for cluster in clusters if "NCCL_IB_TIMEOUT" in cluster.nccl_settings],
+    ids=lambda cluster: cluster.name,
+)
+def test_cluster_nccl_ib_timeout_remains_finite(cluster: HPC) -> None:
+    timeout = cluster.nccl_settings["NCCL_IB_TIMEOUT"]
+
+    assert 1 <= int(timeout) <= 31, (
+        f"{cluster.name} sets NCCL_IB_TIMEOUT={timeout}; NCCL treats values outside 1..31 as infinite"
+    )


### PR DESCRIPTION
Set registered JSC clusters to `NCCL_IB_TIMEOUT=23`. NCCL 2.28 treats 0 and values at least 32 as infinite, so the previous value of 60 removed the transport-level deadline from stuck InfiniBand operations.

Share one value across JURECA, Jupiter, and JUWELS, and reject out-of-range values in registered cluster configurations. This restores the intended finite transport timeout without claiming that the setting caused the current RL wedges.
