### PR TITLE
[iris] Restore cumulative progress for resumed evals

### DIFF
--- a/scripts/iris/watch_iris_harbor.py
+++ b/scripts/iris/watch_iris_harbor.py
@@ -22,7 +22,7 @@ import re
 import subprocess
 import sys
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -109,11 +109,16 @@ EVAL_TRIAL_EVENT_PATTERN = re.compile(
 )
 EVAL_TRIAL_FAILURE_PATTERN = re.compile(r"^failed \((?P<error>[^)]+)\)$")
 EVAL_TRIAL_SUCCESS_PATTERN = re.compile(r"^(?:completed|succeeded|passed)\b")
+EVAL_HARBOR_IDENTITY_PATTERN = re.compile(
+    r"starting Harbor job (?P<job_name>[A-Za-z0-9._-]+).*?"
+    r"jobs_dir=(?P<jobs_dir>(?:s3|gs)://[^\s)]+)"
+)
 AGENT_TIMEOUT_ERROR = "AgentTimeoutError"
 AGENT_TIMEOUT_PATTERN = re.compile(r"\bAgentTimeoutError\b")
 RETRYABLE_TERMINAL_STATES = {"worker_failed", "unschedulable"}
 CALLABLE_RUNNER = "_callable_runner.py"
 EVAL_JOB_ID_PATTERN = re.compile(r"^/[^/]+/eval(?:-|$)")
+DEFAULT_S3_CREDENTIAL_CLUSTER = "cw-rno2a"
 
 
 @dataclass(frozen=True)
@@ -609,7 +614,12 @@ def read_gcs_progress(
 
 
 def coreweave_client(cluster: Cluster) -> Any:
-    config = COREWEAVE_CLUSTERS[cluster.name]
+    """Return an S3 client, including for Marin jobs writing to the CW store."""
+    config = COREWEAVE_CLUSTERS[
+        cluster.name
+        if cluster.name in COREWEAVE_CLUSTERS
+        else DEFAULT_S3_CREDENTIAL_CLUSTER
+    ]
     base = kubectl_base(config, SimpleNamespace(kubeconfig=None, kube_context=None))
     return object_store_client(base, config)
 
@@ -808,6 +818,35 @@ def finelog_activity(local_log: Path | None) -> str:
     if active_trials:
         return f"finelog ({len(active_trials)} recent trial ID{'s' if len(active_trials) != 1 else ''})"
     return "finelog (no current trial line)"
+
+
+def eval_job_with_finelog_harbor_identity(
+    job: HarborJob, local_log: Path | None
+) -> HarborJob:
+    """Recover a callable eval's exact Harbor output directory from Finelog."""
+    if (
+        job.kind != "eval"
+        or (job.jobs_dir is not None and job.harbor_job_name is not None)
+        or local_log is None
+    ):
+        return job
+
+    log_text = local_log.read_text(errors="replace")
+    matches = list(EVAL_HARBOR_IDENTITY_PATTERN.finditer(log_text))
+    if not matches:
+        return job
+
+    match = matches[-1]
+    job_name = match.group("job_name")
+    full_jobs_dir = match.group("jobs_dir").rstrip("/")
+    job_suffix = f"/{job_name}"
+    if not full_jobs_dir.endswith(job_suffix):
+        return job
+    return replace(
+        job,
+        jobs_dir=full_jobs_dir.removesuffix(job_suffix),
+        harbor_job_name=job_name,
+    )
 
 
 def progress_from_eval_finelog(
@@ -1312,6 +1351,8 @@ def main() -> int:
     current_jobs: dict[str, Any] = {}
     for job in sorted(jobs, key=lambda item: (item.cluster.name, item.job_id)):
         key = (job.cluster.name, job.job_id)
+        local_log, _log_error, _synced_at = local_logs[key]
+        job = eval_job_with_finelog_harbor_identity(job, local_log)
         state = effective_state(job)
         try:
             artifact_dir = (
@@ -1344,9 +1385,10 @@ def main() -> int:
                     local_log, _log_error, _synced_at = local_logs[key]
                     progress = Progress(None, None, finelog_activity(local_log))
             elif job.jobs_dir.startswith("s3://"):
-                client = s3_clients.setdefault(
-                    job.cluster.name, coreweave_client(job.cluster)
-                )
+                client = s3_clients.get(job.cluster.name)
+                if client is None:
+                    client = coreweave_client(job.cluster)
+                    s3_clients[job.cluster.name] = client
                 progress = read_s3_progress(job, client, artifact_dir, trace_cutoff)
             else:
                 if gcs_client is None:

--- a/tests/analysis/test_watch_iris_harbor.py
+++ b/tests/analysis/test_watch_iris_harbor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -183,6 +184,72 @@ def test_progress_from_eval_finelog_recovers_terminal_trials_and_errors(tmp_path
     assert progress.recent_benign_timeouts == 1
 
 
+def test_resumed_eval_reads_cumulative_harbor_progress_from_finelog_identity(
+    monkeypatch, tmp_path
+):
+    log = tmp_path / "finelog.log"
+    log.write_text(
+        "\n".join(
+            [
+                "starting Harbor job old-run (dataset=old jobs_dir=s3://bucket/results/old-run)",
+                "starting Harbor job resumed-run "
+                "(dataset=current jobs_dir=s3://bucket/results/resumed-run)",
+            ]
+        )
+        + "\n"
+    )
+    job = _job(
+        kind="eval",
+        jobs_dir=None,
+        harbor_job_name=None,
+    )
+
+    resolved = watcher.eval_job_with_finelog_harbor_identity(job, log)
+
+    assert resolved.jobs_dir == "s3://bucket/results"
+    assert resolved.harbor_job_name == "resumed-run"
+
+    monkeypatch.setattr(
+        watcher,
+        "iter_objects",
+        lambda *_args: [
+            {
+                "Key": "results/resumed-run/old-trial/result.json",
+                "LastModified": NOW - timedelta(days=1),
+            },
+            {
+                "Key": "results/resumed-run/new-trial/result.json",
+                "LastModified": NOW - timedelta(minutes=10),
+            },
+        ],
+    )
+    aggregate = {
+        "n_total_trials": 300,
+        "stats": {
+            "n_completed_trials": 2,
+            "n_errored_trials": 0,
+            "evals": {
+                "reward": {
+                    "n_trials": 2,
+                    "metrics": [{"mean": 0.625}],
+                }
+            },
+        },
+    }
+
+    class Client:
+        def get_object(self, *, Bucket, Key):  # noqa: N803
+            assert Bucket == "bucket"
+            assert Key == "results/resumed-run/result.json"
+            return {"Body": io.BytesIO(json.dumps(aggregate).encode())}
+
+    progress = watcher.read_s3_progress(resolved, Client(), tmp_path, CUTOFF)
+
+    assert progress.completed == 2
+    assert progress.total == 300
+    assert progress.mean_reward == 0.625
+
+
 def _job(
     *,
     state: str = "running",
@@ -191,6 +258,9 @@ def _job(
     job_id: str = "/owner/job",
     n_concurrent: int | None = None,
     gpu_count: int | None = None,
+    kind: str = "datagen",
+    jobs_dir: str | None = "s3://bucket/jobs",
+    harbor_job_name: str | None = "run",
 ) -> watcher.HarborJob:
     return watcher.HarborJob(
         cluster=watcher.Cluster("test", Path("/tmp/iris"), {}),
@@ -198,9 +268,9 @@ def _job(
         state=state,
         task_state=task_state,
         submitted_at_ms=int((NOW - timedelta(hours=age_hours)).timestamp() * 1000),
-        kind="datagen",
-        jobs_dir="s3://bucket/jobs",
-        harbor_job_name="run",
+        kind=kind,
+        jobs_dir=jobs_dir,
+        harbor_job_name=harbor_job_name,
         dataset="dataset",
         n_concurrent=n_concurrent,
         gpu_count=gpu_count,


### PR DESCRIPTION
Read cumulative Harbor aggregates for callable evals that resume an older results directory. The watcher recovers the exact Harbor job name and S3 or GCS directory recorded in Finelog, preserving prior trials, totals, means, and typed errors. Lifecycle events remain the fallback when no directory is recorded.

Two live resumed evals changed from `1/?` and `0/?` with no mean to `267/300` at `0.592` and `292/300` at `0.603`.
