### PR TITLE
[iris] Repair late eval Harbor identity

### DIFF
--- a/docs/debug-log-watch-iris-harbor-eval-identity.md
+++ b/docs/debug-log-watch-iris-harbor-eval-identity.md
@@ -1,0 +1,35 @@
+# Debug log: Iris Harbor eval identity loss
+
+## Goal
+
+Make resumed eval trial counts and means reliable when Finelog delivers the early Harbor identity record after a watcher's incremental cursor has passed it.
+
+## Initial status
+
+- The watcher advances a local wall-clock cursor and appends only later Finelog records.
+- Resumed eval aggregation depends on a one-time `starting Harbor job ... jobs_dir=...` record.
+- A clean full-history read recovers all affected identities, while the incremental cache can permanently miss them.
+- Missing identity silently falls back to lifecycle counts rendered as `N/?`, which can look authoritative.
+
+## Hypotheses
+
+1. A bounded overlap plus exact-line deduplication prevents records delivered slightly late from being lost.
+2. An earliest-first full-history repair when identity is absent recovers records delivered outside that overlap.
+3. Reusing identity from the durable bundle manifest prevents regressions on later watcher runs.
+4. Explicit lifecycle-only trial and health labels prevent fallback counts from being mistaken for Harbor aggregates.
+
+## Changes and results
+
+- Added a five-minute overlap to incremental Finelog reads and deduplicate exact lines when merging into the local cache.
+- Capture the next cursor before issuing the read, so records created during the request cannot fall between cursors.
+- If a callable eval still lacks Harbor identity, reread its job tree from submission time; Iris does not expose a parent-task-only log endpoint.
+- Persist the recovered identity and Finelog cursor in the bundle manifest, and reuse that identity on later watcher runs.
+- Prefer a newly observed Finelog identity over the manifest, allowing a newer resume identity to replace stale persisted state.
+- Label fallback trial counts as `(lifecycle only)` and use `lifecycle-only` health states instead of presenting them as normal Harbor advancement.
+- Record `completion_source` in both `latest.json` state and bundle manifests.
+- Regression tests started with three failures, then passed after the implementation. The late-record test proves the repaired identity selects the resumed S3 prefix and restores `76/300` with mean reward `0.671`.
+- Validation: Ruff check and format passed; focused watcher tests passed (`26 passed`); repository tests passed (`556 passed, 2 skipped`).
+
+## Future work
+
+- If Iris gains a parent-task-only log API, replace the full job-tree repair read with that narrower query.

--- a/scripts/iris/watch_iris_harbor.py
+++ b/scripts/iris/watch_iris_harbor.py
@@ -56,6 +56,7 @@ from scripts.iris.iris_ops import (  # noqa: E402
     format_duration,
     job_bundle,
     job_id_parts,
+    load_bundle_manifest,
     parse_regex_filters,
     run_iris_command,
     write_error_report,
@@ -66,6 +67,7 @@ from scripts.iris.iris_ops import (  # noqa: E402
 USER = "benjaminfeuer"
 DEFAULT_STALL_MINUTES = 120
 TRACE_TREND_HOURS = 2
+FINELOG_OVERLAP_MS = 5 * 60 * 1000
 STARTUP_OUTPUT_GRACE = timedelta(hours=2)
 MEAN_PARSE_TAIL_BYTES = 8 * 1024 * 1024
 JOB_STATE_NAMES = {
@@ -383,9 +385,11 @@ def fetch_finelog(
     bundle_root: Path,
     since_ms: int,
 ) -> tuple[Path | None, str | None, int | None]:
-    """Synchronize Finelog history, appending only the interval since the prior tick."""
+    """Synchronize Finelog with an overlap and exact-line deduplication."""
     destination = finelog_path(job, bundle_root)
     destination.parent.mkdir(parents=True, exist_ok=True)
+    sync_started_at_ms = int(datetime.now(UTC).timestamp() * 1000)
+    query_since_ms = max(job.submitted_at_ms, since_ms - FINELOG_OVERLAP_MS)
     result = run_iris(
         job.cluster,
         [
@@ -393,7 +397,7 @@ def fetch_finelog(
             "logs",
             job.job_id,
             "--since-ms",
-            str(since_ms),
+            str(query_since_ms),
             "--max-lines",
             "500000",
             "--no-tail",
@@ -403,10 +407,50 @@ def fetch_finelog(
     if result.returncode:
         message = (result.stderr or result.stdout).strip().replace("\n", " ")
         return None, f"Finelog sync failed: {message[-180:]}", None
-    write_mode = "a" if destination.exists() and since_ms > job.submitted_at_ms else "w"
-    with destination.open(write_mode) as output:
-        output.write(result.stdout)
-    return destination, None, int(datetime.now(UTC).timestamp() * 1000)
+    existing_lines = (
+        destination.read_text(errors="replace").splitlines()
+        if destination.exists()
+        else []
+    )
+    seen = set(existing_lines)
+    merged_lines = list(existing_lines)
+    for line in result.stdout.splitlines():
+        if line not in seen:
+            merged_lines.append(line)
+            seen.add(line)
+    destination.write_text("\n".join(merged_lines) + ("\n" if merged_lines else ""))
+    return destination, None, sync_started_at_ms
+
+
+def sync_finelog(
+    job: HarborJob,
+    bundle_root: Path,
+    since_ms: int,
+) -> tuple[Path | None, str | None, int | None]:
+    """Sync logs and repair a callable eval whose early identity was missed."""
+    result = fetch_finelog(job, bundle_root, since_ms)
+    local_log, error, _synced_at_ms = result
+    if (
+        error
+        or job.kind != "eval"
+        or (job.jobs_dir is not None and job.harbor_job_name is not None)
+    ):
+        return result
+    if eval_job_with_finelog_harbor_identity(job, local_log).jobs_dir is not None:
+        return result
+    try:
+        if (
+            eval_job_with_manifest_harbor_identity(job, bundle_root).jobs_dir
+            is not None
+        ):
+            return result
+    except (OSError, ValueError):
+        pass
+
+    # Finelog's tree stream can deliver an early parent record after a local
+    # wall-clock cursor has passed it. Iris has no parent-task-only log query,
+    # so reread the job tree earliest-first when the required identity is absent.
+    return fetch_finelog(job, bundle_root, job.submitted_at_ms)
 
 
 def fetch_ray_vllm_logs(job: HarborJob, bundle_root: Path) -> tuple[str, str | None]:
@@ -849,6 +893,30 @@ def eval_job_with_finelog_harbor_identity(
     )
 
 
+def eval_job_with_manifest_harbor_identity(
+    job: HarborJob, bundle_root: Path
+) -> HarborJob:
+    """Reuse a previously recovered callable eval identity from its bundle."""
+    if job.kind != "eval" or (
+        job.jobs_dir is not None and job.harbor_job_name is not None
+    ):
+        return job
+    manifest = load_bundle_manifest(
+        job_bundle(bundle_root, job.cluster.name, job.job_id)
+    )
+    jobs_dir = manifest.get("jobs_dir")
+    harbor_job_name = manifest.get("harbor_job_name")
+    if not isinstance(jobs_dir, str) or not isinstance(harbor_job_name, str):
+        return job
+    if not jobs_dir or not harbor_job_name:
+        return job
+    return replace(job, jobs_dir=jobs_dir, harbor_job_name=harbor_job_name)
+
+
+def is_lifecycle_fallback(progress: Progress) -> bool:
+    return progress.completion_source == "finelog lifecycle fallback"
+
+
 def progress_from_eval_finelog(
     job: HarborJob, local_log: Path | None, checked_at: datetime
 ) -> Progress:
@@ -1057,6 +1125,29 @@ def health_label(
         return f"terminal ({terminal_status(job.state)})", prior.get(
             "last_advanced_at", checked_at.isoformat()
         )
+    if is_lifecycle_fallback(progress):
+        if (
+            progress.recent_completed is not None
+            and progress.recent_errored is not None
+        ):
+            if progress.recent_completed:
+                return (
+                    f"lifecycle-only ({recent_detail(progress)})",
+                    checked_at.isoformat(),
+                )
+            job_age = checked_at - datetime.fromtimestamp(
+                job.submitted_at_ms / 1000, UTC
+            )
+            prefix = (
+                "stalled; lifecycle-only"
+                if job.state == "running"
+                and job_age >= timedelta(hours=TRACE_TREND_HOURS)
+                else "warming up; lifecycle-only"
+            )
+            return f"{prefix} (+0 traces/2h)", prior.get(
+                "last_advanced_at", checked_at.isoformat()
+            )
+        return "lifecycle-only", prior.get("last_advanced_at", checked_at.isoformat())
     if progress.completed is None:
         return "awaiting output", prior.get("last_advanced_at", checked_at.isoformat())
     if progress.recent_completed is not None and progress.recent_errored is not None:
@@ -1227,12 +1318,15 @@ def report_row(
         mean = "—"
     trial_errors = format_error_counts(progress)
     evidence = f"Finelog {'synced' if local_log is not None else 'unavailable'}; Ray/vLLM {ray_vllm_status}"
+    trials = f"{completed}/{total}"
+    if is_lifecycle_fallback(progress):
+        trials += " (lifecycle only)"
     return [
         f"{job.cluster.name}/{job.kind}",
         job.job_id.rsplit("/", 1)[-1],
         job.dataset,
         _state_cell(effective_state(job)),
-        f"{completed}/{total}",
+        trials,
         mean,
         StyledCell(
             trial_errors,
@@ -1302,6 +1396,11 @@ def main() -> int:
         try:
             prior = previous.get("jobs", {}).get(job.job_id, {})
             prior_sync = prior.get("finelog_synced_at_ms")
+            if prior_sync is None:
+                manifest = load_bundle_manifest(
+                    job_bundle(args.bundle_root, job.cluster.name, job.job_id)
+                )
+                prior_sync = manifest.get("finelog_synced_at_ms")
             destination = finelog_path(job, args.bundle_root)
             if (
                 prior_sync is None
@@ -1311,7 +1410,7 @@ def main() -> int:
                 prior_sync = int(
                     datetime.fromisoformat(previous["checked_at"]).timestamp() * 1000
                 )
-            result = fetch_finelog(
+            result = sync_finelog(
                 job,
                 args.bundle_root,
                 int(prior_sync) if prior_sync is not None else job.submitted_at_ms,
@@ -1353,6 +1452,16 @@ def main() -> int:
         key = (job.cluster.name, job.job_id)
         local_log, _log_error, _synced_at = local_logs[key]
         job = eval_job_with_finelog_harbor_identity(job, local_log)
+        try:
+            job = eval_job_with_manifest_harbor_identity(job, args.bundle_root)
+        except Exception as error:
+            errors.append(
+                _monitor_error(
+                    f"{job.cluster.name}/{job.job_id}",
+                    "bundle manifest identity",
+                    error,
+                )
+            )
         state = effective_state(job)
         try:
             artifact_dir = (
@@ -1463,6 +1572,7 @@ def main() -> int:
             "completed": progress.completed,
             "total": progress.total,
             "mean_reward": progress.mean_reward,
+            "completion_source": progress.completion_source,
             "error_counts": progress.error_counts,
             "exception_file_count": progress.exception_file_count,
             "recent_completed_2h": progress.recent_completed,
@@ -1492,11 +1602,13 @@ def main() -> int:
                     "controller_state": job.state,
                     "task_state": job.task_state,
                     "submitted_at_ms": job.submitted_at_ms,
+                    "finelog_synced_at_ms": finelog_synced_at_ms,
                     "last_synced_at": checked_at.isoformat(),
                     "progress": {
                         "completed": progress.completed,
                         "total": progress.total,
                         "mean_reward": progress.mean_reward,
+                        "completion_source": progress.completion_source,
                         "error_counts": progress.error_counts,
                         "exception_file_count": progress.exception_file_count,
                         "recent_completed_2h": progress.recent_completed,

--- a/tests/analysis/test_watch_iris_harbor.py
+++ b/tests/analysis/test_watch_iris_harbor.py
@@ -250,6 +250,122 @@ def test_resumed_eval_reads_cumulative_harbor_progress_from_finelog_identity(
     assert progress.mean_reward == 0.625
 
 
+def test_finelog_sync_repairs_late_eval_identity_and_deduplicates(
+    monkeypatch, tmp_path
+):
+    job = _job(kind="eval", jobs_dir=None, harbor_job_name=None)
+    prior_sync = job.submitted_at_ms + watcher.FINELOG_OVERLAP_MS * 2
+    lifecycle = "[10:00:00] task=/owner/eval/0 | Trial alpha__a1: completed\n"
+    identity = (
+        "starting Harbor job resumed-run "
+        "(dataset=current jobs_dir=s3://bucket/results/resumed-run)\n"
+    )
+    calls: list[list[str]] = []
+
+    def fake_run_iris(_cluster, args, timeout):
+        assert timeout == 600
+        calls.append(args)
+        stdout = lifecycle if len(calls) == 1 else identity + lifecycle
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(watcher, "run_iris", fake_run_iris)
+
+    log, error, _cursor = watcher.sync_finelog(job, tmp_path, prior_sync)
+
+    assert error is None
+    assert log is not None
+    assert calls[0][calls[0].index("--since-ms") + 1] == str(
+        prior_sync - watcher.FINELOG_OVERLAP_MS
+    )
+    assert calls[1][calls[1].index("--since-ms") + 1] == str(job.submitted_at_ms)
+    assert log.read_text().count(lifecycle) == 1
+    resolved = watcher.eval_job_with_finelog_harbor_identity(job, log)
+    assert resolved.jobs_dir == "s3://bucket/results"
+    assert resolved.harbor_job_name == "resumed-run"
+    monkeypatch.setattr(
+        watcher,
+        "iter_objects",
+        lambda *_args: [
+            {
+                "Key": f"results/resumed-run/trial-{index}/result.json",
+                "LastModified": NOW,
+            }
+            for index in range(76)
+        ],
+    )
+
+    class Client:
+        def get_object(self, *, Bucket, Key):  # noqa: N803
+            assert Bucket == "bucket"
+            assert Key == "results/resumed-run/result.json"
+            aggregate = {
+                "n_total_trials": 300,
+                "stats": {
+                    "n_completed_trials": 76,
+                    "n_errored_trials": 0,
+                    "evals": {
+                        "reward": {
+                            "n_trials": 76,
+                            "metrics": [{"mean": 0.671}],
+                        }
+                    },
+                },
+            }
+            return {"Body": io.BytesIO(json.dumps(aggregate).encode())}
+
+    progress = watcher.read_s3_progress(resolved, Client(), tmp_path, CUTOFF)
+    assert progress.completion_source == "direct result.json"
+    assert progress.completed == 76
+    assert progress.total == 300
+    assert progress.mean_reward == 0.671
+
+
+def test_eval_identity_is_reused_from_bundle_manifest(monkeypatch, tmp_path):
+    job = _job(kind="eval", jobs_dir=None, harbor_job_name=None)
+    watcher.write_bundle_manifest(
+        watcher.job_bundle(tmp_path, job.cluster.name, job.job_id),
+        {
+            "jobs_dir": "s3://bucket/results",
+            "harbor_job_name": "resumed-run",
+        },
+    )
+
+    resolved = watcher.eval_job_with_manifest_harbor_identity(job, tmp_path)
+
+    assert resolved.jobs_dir == "s3://bucket/results"
+    assert resolved.harbor_job_name == "resumed-run"
+
+    calls = 0
+
+    def fake_run_iris(_cluster, _args, timeout):
+        nonlocal calls
+        assert timeout == 600
+        calls += 1
+        return SimpleNamespace(returncode=0, stdout="lifecycle only\n", stderr="")
+
+    monkeypatch.setattr(watcher, "run_iris", fake_run_iris)
+    _log, error, _cursor = watcher.sync_finelog(job, tmp_path, job.submitted_at_ms)
+    assert error is None
+    assert calls == 1
+
+
+def test_lifecycle_fallback_is_explicit_in_trials_and_health():
+    job = _job(kind="eval", jobs_dir=None, harbor_job_name=None)
+    progress = watcher.Progress(
+        5,
+        None,
+        "finelog lifecycle fallback",
+        recent_completed=2,
+        recent_errored=0,
+    )
+
+    health, _ = watcher.health_label(job, progress, {}, NOW, 120)
+    row = watcher.report_row(job, progress, health, None, "not applicable (eval)")
+
+    assert health == "lifecycle-only (+2/2h; 0 errors)"
+    assert row[4] == "5/? (lifecycle only)"
+
+
 def _job(
     *,
     state: str = "running",


### PR DESCRIPTION
Summary
- make Finelog synchronization overlap-safe and repair missing callable-eval identity with an earliest-first read
- persist and reuse recovered Harbor identity and cursor while preferring newer Finelog evidence
- label lifecycle-only fallback counts explicitly in reports and health

Test plan
- `/Users/benjaminfeuer/miniconda3/envs/otagent/bin/python -m ruff check scripts/iris/watch_iris_harbor.py tests/analysis/test_watch_iris_harbor.py`
- `/Users/benjaminfeuer/miniconda3/envs/otagent/bin/python -m ruff format --check scripts/iris/watch_iris_harbor.py tests/analysis/test_watch_iris_harbor.py`
- `/Users/benjaminfeuer/miniconda3/envs/otagent/bin/python -m pytest tests/analysis/test_watch_iris_harbor.py -q`
- `/Users/benjaminfeuer/miniconda3/envs/otagent/bin/python -m pytest tests/ -q`