### PR TITLE
[rl] Keep colocated KL references out of host memory

### DIFF
--- a/docs/debug-log-kl-ref-host-oom.md
+++ b/docs/debug-log-kl-ref-host-oom.md
@@ -36,8 +36,10 @@ add a regression test for that campaign invariant.
 
 ## Results
 
-The regression test passes. It loads the shipped Jupiter configuration and verifies that policy/reference
-colocation cannot silently reintroduce reference CPU offload. Repository lint validation is recorded in the PR.
+The regression and adjacent RL path/chain tests pass (32 tests). The regression loads the shipped Jupiter
+configuration and verifies that policy/reference colocation cannot silently reintroduce reference CPU offload.
+Ruff passes over the complete `tests/` tree. The complete local pytest suite cannot collect three Iris watcher
+modules because the local Marin checkout lacks `rigging.telemetry`; GitHub CI installs the locked environment.
 
 ## Future work
 

--- a/docs/debug-log-kl-ref-host-oom.md
+++ b/docs/debug-log-kl-ref-host-oom.md
@@ -1,0 +1,44 @@
+# Debugging log for KL reference host OOM
+
+Prevent KL-enabled 30B TaskTrove arms from exhausting host memory at policy optimizer and checkpoint-load peaks.
+
+## Initial status
+
+All KL arms placed a 16-rank, CPU-offloaded reference model on the four policy nodes. Those nodes used 100–170
+GiB more memory than the no-KL arm and workers were killed during the first optimizer step or checkpoint load.
+
+## Hypothesis 1
+
+`colocate_all: false` was assumed to separate the policy and reference models, but the MarinSkyRL base setting
+`colocate_policy_ref: true` still puts both actor groups in one placement group.
+
+## Changes to make
+
+Inspect the resolved launcher geometry and MarinSkyRL actor placement.
+
+## Results
+
+Confirmed. The campaign reserves six GH200 nodes: four policy nodes and two rollout nodes. The inherited
+`colocate_policy_ref: true` assigns each policy actor 0.75 GPU and each reference actor 0.25 GPU in the same
+four-node placement group. Reserving a separate reference group would increase each arm from six to ten nodes.
+
+## Hypothesis 2
+
+Keeping reference parameters on GPU removes the measured reference-model host allocation while retaining the
+existing six-node topology. FSDP still shards the reference over all 16 ranks, while the policy remains CPU
+offloaded and can use the recovered host-memory headroom for Adam first-touch, grad-norm temporaries, and
+checkpoint restore.
+
+## Changes to make
+
+Disable CPU offload for the 30B Jupiter reference model, declare policy/reference colocation explicitly, and
+add a regression test for that campaign invariant.
+
+## Results
+
+The regression test passes. It loads the shipped Jupiter configuration and verifies that policy/reference
+colocation cannot silently reintroduce reference CPU offload. Repository lint validation is recorded in the PR.
+
+## Future work
+
+- [ ] Record the policy-node host-memory watermark on the next KL run through its first optimizer step.

--- a/hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml
+++ b/hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml
@@ -147,7 +147,10 @@ trainer:
     model:
       path: Qwen/Qwen3-30B-A3B-Thinking-2507
     fsdp_config:
-      cpu_offload: true
+      # The reference shares policy GPUs in the six-node Jupiter geometry. Keep
+      # its parameters on GPU so it does not consume the host-RAM headroom that
+      # the policy optimizer and checkpoint loader need for their transient peaks.
+      cpu_offload: false
       reshard_after_forward: true
       fsdp_size: 4
       expert_model_parallel_size: 4
@@ -157,6 +160,7 @@ trainer:
 
   placement:
     colocate_all: false
+    colocate_policy_ref: true
     policy_num_nodes: 4
     ref_num_nodes: 4
     policy_num_gpus_per_node: 4

--- a/tests/hpc/test_jupiter_rl_configs.py
+++ b/tests/hpc/test_jupiter_rl_configs.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_30b_kl_reference_does_not_share_policy_host_memory() -> None:
+    config_path = (
+        REPOSITORY_ROOT / "hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml"
+    )
+    config = yaml.safe_load(config_path.read_text())
+
+    assert config["trainer"]["placement"]["colocate_policy_ref"] is True
+    assert config["trainer"]["ref"]["fsdp_config"]["cpu_offload"] is False


### PR DESCRIPTION
Keep the 16-rank Qwen3-30B reference model on GH200 GPU memory when it shares the four policy nodes. The policy remains CPU-offloaded. This restores the 100–170 GiB of host headroom per policy node that KL-enabled TaskTrove arms lost before SIGKILLs during Adam first-touch and checkpoint restore.

The six-node campaign geometry has no spare nodes for a separate reference placement group; disaggregating the reference would increase each arm from six to ten GH200 nodes. The shipped config now declares policy/reference colocation explicitly and tests that a colocated reference cannot silently enable CPU offload.

The focused configuration, checkpoint-path, and chain tests pass (32 tests). Ruff 0.15.14 passes over all tests. The full local suite cannot collect three Iris watcher modules because the local Marin checkout lacks rigging.telemetry; GitHub CI installs the locked environment.
