### PR TITLE
[rl] Re-evaluate automatic resume at each chain link

### DIFF
--- a/docs/debug-log-jupiter-chain-resume.md
+++ b/docs/debug-log-jupiter-chain-resume.md
@@ -1,0 +1,31 @@
+# Debugging log for Jupiter chain resume
+
+Make a from-scratch Jupiter dependency chain consume checkpoints banked by earlier links.
+
+## Initial status
+
+AUTO resume discovery ran once during submission. With no checkpoint present, the launcher serialized
+`trainer.resume_mode=none` into the JSON shared by every Slurm link. Later links therefore restarted at step 0
+even after an earlier link wrote `latest_ckpt_global_step.txt`.
+
+## Hypothesis 1
+
+The durable resume intent is lost when `RLPathManager.resolve()` converts AUTO into the current concrete mode.
+Preserving that intent in `RLJobConfig` would let each link repeat the same validated discovery after Slurm starts
+it and before Ray or the trainer starts.
+
+## Changes to make
+
+Add a resume policy to the resolved path contract and serialized job config. Mark implicit AUTO launches for
+link-start discovery; keep explicit `none`, `latest`, `from_path`, and forced-fresh launches fixed. At link start,
+replace only the concrete resume mode and path in the Hydra argument list.
+
+## Results
+
+The regression runs the same serialized job twice. With an empty checkpoint directory the first run keeps
+`resume_mode=none`. After the test banks `global_step_6`, the second run resolves `resume_mode=latest` and the
+exact checkpoint path. The checkpoint-path and chain-guard suite passes (32 tests).
+
+## Future work
+
+- [ ] Confirm the first replacement campaign link logs `Resuming from global_step: 6` or later.

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -32,6 +32,7 @@ from hpc.rl_paths import (
     LATEST_CHECKPOINT_FILE,
     RLLaunchIntent,
     RLPathManager,
+    RLResumePolicy,
     RLRunPaths,
     hydra_override_values,
 )
@@ -784,6 +785,7 @@ class RLJobConfig:
     skyrl_entrypoint: str
     trials_dir: str
     skyrl_hydra_args: List[str] = field(default_factory=list)
+    resume_policy: str = RLResumePolicy.FIXED.value
 
     # Model and data
     model_path: str = ""
@@ -1122,6 +1124,7 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         cluster_name=hpc.name,
         skyrl_entrypoint=parsed.entrypoint,
         skyrl_hydra_args=hydra_args,
+        resume_policy=run_paths.resume_policy.value,
         model_path=exp_args.get("model_path", ""),
         train_data=exp_args.get("train_data", []),
         val_data=exp_args.get("val_data", []),
@@ -1448,6 +1451,7 @@ class RLJobRunner:
         # short-circuits the whole remaining chain at ~zero cost. afterany fires
         # the successor regardless of the predecessor's exit status, so the marker
         # check — not the exit code — is what actually terminates the chain.
+        self._resolve_resume_for_link()
         if self._already_complete_on_disk():
             print(
                 "[RLJobRunner] Canonical checkpoint already at/past max_steps — "
@@ -1494,6 +1498,35 @@ class RLJobRunner:
                 print(f"[RLJobRunner] Trace upload failed with exit code {upload_exit_code}.", flush=True)
 
         return training_exit_code
+
+    def _resolve_resume_for_link(self) -> None:
+        """Re-evaluate automatic resume after a dependency-chain link starts."""
+        if self.config.resume_policy != RLResumePolicy.AT_LINK_START.value:
+            return
+
+        values = hydra_override_values(self.config.skyrl_hydra_args)
+        checkpoint_dir = Path(values["trainer.ckpt_path"])
+        state_root = checkpoint_dir.parent.parent
+        resolved = RLPathManager(self.config.job_name, state_root, state_root).resolve(
+            trainer_config={
+                "ckpt_path": str(checkpoint_dir),
+                "export_path": values["trainer.export_path"],
+            },
+            terminal_bench_config={"trials_dir": self.config.trials_dir},
+        )
+        replacements = {
+            "trainer.resume_mode": resolved.resume_mode.value,
+            "trainer.resume_path": str(resolved.resume_path) if resolved.resume_path is not None else "null",
+        }
+        retained = [
+            argument
+            for argument in self.config.skyrl_hydra_args
+            if argument.lstrip("+").partition("=")[0] not in replacements
+        ]
+        self.config.skyrl_hydra_args = [
+            *retained,
+            *(f"{key}={value}" for key, value in replacements.items()),
+        ]
 
     def _preserve_ray_logs_on_crash(self) -> None:
         """Best-effort: preserve Ray logs immediately after a training crash,

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -39,6 +39,11 @@ class RLResumeMode(StrEnum):
     FROM_PATH = "from_path"
 
 
+class RLResumePolicy(StrEnum):
+    FIXED = "fixed"
+    AT_LINK_START = "at_link_start"
+
+
 class RLLaunchIntent(StrEnum):
     AUTO = "auto"
     FRESH = "fresh"
@@ -61,6 +66,7 @@ class RLRunPaths:
     trials_dir: Path
     resume_mode: RLResumeMode
     resume_path: Path | None
+    resume_policy: RLResumePolicy
 
     def describe(self) -> str:
         if self.resume_path is not None:
@@ -134,6 +140,11 @@ class RLPathManager:
         overrides = _configured_path_values(trainer_config or {}, terminal_bench_config or {})
         overrides.update(cli_values)
         requested_mode, requested_resume_path = self._requested_resume(overrides, launch_intent)
+        resume_policy = (
+            RLResumePolicy.AT_LINK_START
+            if launch_intent is RLLaunchIntent.AUTO and requested_mode is None
+            else RLResumePolicy.FIXED
+        )
 
         state_root = self.launch_root if launch_intent is RLLaunchIntent.FRESH else self.canonical_root
         checkpoint_dir = self._configured_checkpoint_dir(overrides, state_root)
@@ -146,6 +157,7 @@ class RLPathManager:
             state_root,
             checkpoint_dir,
             overrides,
+            resume_policy,
         )
         if explicit is not None:
             return explicit
@@ -163,6 +175,7 @@ class RLPathManager:
                 overrides,
                 resume_mode=RLResumeMode.NONE,
                 resume_path=None,
+                resume_policy=resume_policy,
             )
 
         highest_step = max(candidate.step for candidate in candidates)
@@ -181,6 +194,7 @@ class RLPathManager:
             overrides,
             resume_mode=RLResumeMode.LATEST,
             resume_path=selected.checkpoint_path,
+            resume_policy=resume_policy,
         )
 
     @staticmethod
@@ -210,6 +224,7 @@ class RLPathManager:
         state_root: Path,
         checkpoint_dir: Path,
         overrides: dict[str, str],
+        resume_policy: RLResumePolicy,
     ) -> RLRunPaths | None:
         """Resolve a user-selected mode, or return None for automatic discovery."""
 
@@ -220,6 +235,7 @@ class RLPathManager:
                 overrides,
                 resume_mode=RLResumeMode.NONE,
                 resume_path=None,
+                resume_policy=resume_policy,
             )
         if requested_mode == RLResumeMode.LATEST.value:
             candidate = self._required_checkpoint_candidate(state_root, checkpoint_dir)
@@ -229,6 +245,7 @@ class RLPathManager:
                 overrides,
                 resume_mode=RLResumeMode.LATEST,
                 resume_path=candidate.checkpoint_path,
+                resume_policy=resume_policy,
             )
         if requested_mode != RLResumeMode.FROM_PATH.value:
             return None
@@ -248,6 +265,7 @@ class RLPathManager:
             overrides,
             resume_mode=RLResumeMode.FROM_PATH,
             resume_path=resume_path,
+            resume_policy=resume_policy,
         )
 
     def _configured_checkpoint_dir(self, overrides: dict[str, str], state_root: Path) -> Path:
@@ -355,6 +373,7 @@ class RLPathManager:
         *,
         resume_mode: RLResumeMode,
         resume_path: Path | None,
+        resume_policy: RLResumePolicy,
     ) -> RLRunPaths:
         trainer_root = state_root / self.job_name
         export_dir = (
@@ -374,4 +393,5 @@ class RLPathManager:
             trials_dir=trials_dir,
             resume_mode=resume_mode,
             resume_path=resume_path,
+            resume_policy=resume_policy,
         )

--- a/tests/hpc/test_rl_chain_overshoot_guard.py
+++ b/tests/hpc/test_rl_chain_overshoot_guard.py
@@ -63,7 +63,13 @@ def test_hydra_override_values_normalize_and_use_last_value(arguments, key, expe
 def _runner_with(args):
     """Bare RLJobRunner carrying only skyrl_hydra_args (no heavy __init__)."""
     runner = RLJobRunner.__new__(RLJobRunner)
-    runner.config = types.SimpleNamespace(skyrl_hydra_args=list(args))
+    runner.config = types.SimpleNamespace(
+        job_name="chain-arm",
+        experiments_dir="/unused",
+        trials_dir="/unused/trials",
+        resume_policy="fixed",
+        skyrl_hydra_args=list(args),
+    )
     return runner
 
 
@@ -174,3 +180,35 @@ def test_run_proceeds_for_incomplete_link(tmp_path):
     assert calls["setup"] == 1 and calls["ray"] == 1, (
         "incomplete link must train normally"
     )
+
+
+def test_auto_resume_is_re_evaluated_for_each_chain_link(tmp_path):
+    ckpt = tmp_path / "checkpoints"
+    runner = _runner_with(
+        [
+            f"trainer.ckpt_path={ckpt}",
+            f"trainer.export_path={tmp_path / 'exports'}",
+            "trainer.resume_mode=none",
+            "trainer.resume_path=null",
+            "trainer.max_steps=80",
+        ]
+    )
+    runner.config.resume_policy = "at_link_start"
+    runner.config.trials_dir = str(tmp_path / "trials")
+    runner._setup_environment = lambda: None
+    runner._run_with_ray = lambda: 0
+    runner._launch_trace_upload = lambda *args, **kwargs: None
+
+    assert runner.run() == 0
+    first_link = hydra_override_values(runner.config.skyrl_hydra_args)
+    assert first_link["trainer.resume_mode"] == "none"
+    assert first_link["trainer.resume_path"] == "null"
+
+    checkpoint = ckpt / "global_step_6"
+    checkpoint.mkdir(parents=True)
+    _write_marker(ckpt, 6)
+
+    assert runner.run() == 0
+    second_link = hydra_override_values(runner.config.skyrl_hydra_args)
+    assert second_link["trainer.resume_mode"] == "latest"
+    assert second_link["trainer.resume_path"] == str(checkpoint)

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -7,6 +7,7 @@ from hpc.rl_paths import (
     CheckpointLayoutError,
     RLLaunchIntent,
     RLPathManager,
+    RLResumePolicy,
     RLResumeMode,
     hydra_override_values,
 )
@@ -67,6 +68,7 @@ def test_new_run_uses_canonical_state_root_after_artifact_collision(
     resolved = RLPathManager(JOB_NAME, canonical_root, launch_root).resolve()
 
     assert resolved.resume_mode is RLResumeMode.NONE
+    assert resolved.resume_policy is RLResumePolicy.AT_LINK_START
     assert resolved.resume_path is None
     assert resolved.checkpoint_dir == canonical_root / JOB_NAME / "checkpoints"
 
@@ -81,6 +83,7 @@ def test_explicit_fresh_launch_uses_the_launch_root(tmp_path: Path) -> None:
     )
 
     assert resolved.resume_mode is RLResumeMode.NONE
+    assert resolved.resume_policy is RLResumePolicy.FIXED
     assert resolved.resume_path is None
     assert resolved.checkpoint_dir == launch_root / JOB_NAME / "checkpoints"
 


### PR DESCRIPTION
Re-evaluate automatic checkpoint discovery when each Jupiter dependency-chain link starts. A new arm still launches with `resume_mode=none` when its checkpoint directory is empty; after a link banks a checkpoint, its successor resolves `resume_mode=latest` and the exact `global_step_N` path before Ray starts.

The serialized job now retains whether resume was implicit AUTO or an explicit fixed choice. Explicit `none`, `latest`, `from_path`, and overwrite/fresh launches keep their existing behavior.

A two-link regression starts with an empty directory, writes `global_step_6`, and verifies that the same serialized runner resumes it on the next invocation. The checkpoint-path and chain-guard suite passes (32 tests), and Ruff 0.15.14 passes over all tests.
