### PR TITLE
[RL] Require explicit Hugging Face export repositories

### DIFF
--- a/docs/RL_PIPELINE.md
+++ b/docs/RL_PIPELINE.md
@@ -524,7 +524,7 @@ trainer.max_steps=80
 data.train_data=["/path/to/tasks"]
 data.val_data=["open-thoughts/OpenThoughts-TB-dev"]
 generator.num_inference_engines=16
-++trainer.hf_hub_repo_id=laion/{job_name}
+++trainer.hf_hub_repo_id=open-thoughts/explicit-repository
 ```
 
 ---
@@ -825,7 +825,7 @@ SkyRL has two automatic callbacks that handle model upload:
 Config (in YAML or via `--skyrl_override`):
 ```yaml
 trainer:
-  hf_hub_repo_id: laion/{job_name}  # Auto-derived from job_name if null
+  hf_hub_repo_id: open-thoughts/explicit-repository  # Required to enable export
   hf_hub_private: false
   hf_hub_revision: main
   hf_save_interval: 10              # Export every 10 steps (deployed value)
@@ -835,6 +835,8 @@ trainer:
 Upload goes to: `{repo_id}/checkpoints/step_{N}/` on HuggingFace Hub.
 
 **Requires**: `HF_TOKEN` env var or `huggingface-cli login`.
+
+Checkpoint export is disabled when `hf_hub_repo_id` is null or omitted. A job name never enables publication implicitly; set the repository ID explicitly only on clusters where the model source can be materialized by the export job.
 
 ### 8.2 Manual Model Upload
 

--- a/docs/debug-log-explicit-hf-export.md
+++ b/docs/debug-log-explicit-hf-export.md
@@ -1,0 +1,27 @@
+# Debugging log for explicit Hugging Face export
+
+Prevent offline compute jobs from enabling Hugging Face checkpoint export unless a repository ID is explicitly configured.
+
+## Initial status
+
+`build_skyrl_hydra_args` replaces an absent `hf_hub_repo_id` with `laion/{job_name}`. On Jupiter, this installs the periodic export callback even though task-local model paths cannot be materialized by a later export job. The resulting `ModelLocatorError` terminates training at the first export interval.
+
+## Hypothesis 1
+
+The unconditional job-name-derived repository ID is the only launcher behavior that turns an otherwise disabled export into an enabled export.
+
+## Changes to make
+
+Add regression coverage at the Hydra configuration boundary for both an omitted repository ID and an explicitly configured repository ID.
+
+## Results
+
+The new regression failed before the fix: the generated Hydra arguments contained `trainer.hf_hub_repo_id=laion/tasktrove-arm`. This confirms that the launcher-derived repository ID enabled the callback.
+
+Removed the derivation. A repository ID is now forwarded only when the caller explicitly supplies one; an absent ID remains absent. Documentation now describes checkpoint export as opt-in.
+
+The focused configuration test passed after the fix. The full HPC unit suite passed with 315 tests. The first repo-wide collection picked up an incompatible local Marin checkout and failed while importing `rigging.telemetry`; forcing the tests to use the locked Iris package produced 554 passing tests and 2 skips.
+
+## Future work
+
+- [ ] Consider startup validation for explicitly requested exports whose model source cannot be materialized.

--- a/hpc/rl_config_utils.py
+++ b/hpc/rl_config_utils.py
@@ -685,7 +685,9 @@ def build_skyrl_hydra_args(
     trainer["export_path"] = str(run_paths.export_dir)
     trainer["ckpt_path"] = str(run_paths.checkpoint_dir)
     trainer["resume_mode"] = run_paths.resume_mode.value
-    trainer["resume_path"] = str(run_paths.resume_path) if run_paths.resume_path is not None else None
+    trainer["resume_path"] = (
+        str(run_paths.resume_path) if run_paths.resume_path is not None else None
+    )
 
     # Derive placement from num_nodes
     num_nodes = int(exp_args.get("num_nodes", 1))
@@ -772,17 +774,12 @@ def build_skyrl_hydra_args(
             served_model_name
         )
 
-    # HuggingFace Hub upload settings (for automatic checkpoint uploads)
-    # Default to laion/<job_name> if not explicitly provided
+    # HuggingFace Hub upload settings (for automatic checkpoint uploads).
+    # Publication is opt-in: a job name must never imply a public repository.
     hf_hub_repo_id = exp_args.get("hf_hub_repo_id")
-    if not hf_hub_repo_id and job_name:
-        hf_hub_repo_id = f"laion/{job_name}"
-        print(f"HF Hub upload auto-defaulted to: {hf_hub_repo_id}")
     if hf_hub_repo_id:
         trainer["hf_hub_repo_id"] = hf_hub_repo_id
-        if exp_args.get("hf_hub_repo_id"):
-            # Only print "enabled" if user explicitly provided the repo ID
-            print(f"HF Hub upload enabled: {hf_hub_repo_id}")
+        print(f"HF Hub upload enabled: {hf_hub_repo_id}")
     hf_hub_private = exp_args.get("hf_hub_private", False)
     if hf_hub_private:
         trainer["hf_hub_private"] = True

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -223,6 +223,53 @@ def test_hydra_builder_consumes_the_resolved_path_contract(tmp_path: Path) -> No
     )
 
 
+def test_hydra_builder_does_not_enable_hf_export_without_a_repository(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / JOB_NAME
+    run_paths = RLPathManager(JOB_NAME, root, root).resolve()
+    parsed = ParsedRLConfig(
+        config_path=tmp_path / "config.yaml",
+        raw={},
+        entrypoint="skyrl_train.entrypoints.main_base",
+        trainer={"hf_save_interval": 6},
+    )
+    hpc = type("HPC", (), {"gpus_per_node": 4})()
+
+    arguments = build_skyrl_hydra_args(
+        parsed, {"job_name": JOB_NAME}, hpc, run_paths=run_paths
+    )
+
+    assert _hydra_value(arguments, "trainer.hf_save_interval") == "6"
+    assert _hydra_value(arguments, "trainer.hf_hub_repo_id") is None
+
+
+def test_hydra_builder_enables_hf_export_for_an_explicit_repository(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / JOB_NAME
+    run_paths = RLPathManager(JOB_NAME, root, root).resolve()
+    parsed = ParsedRLConfig(
+        config_path=tmp_path / "config.yaml",
+        raw={},
+        entrypoint="skyrl_train.entrypoints.main_base",
+        trainer={"hf_save_interval": 6},
+    )
+    hpc = type("HPC", (), {"gpus_per_node": 4})()
+
+    arguments = build_skyrl_hydra_args(
+        parsed,
+        {"job_name": JOB_NAME, "hf_hub_repo_id": "open-thoughts/explicit-run"},
+        hpc,
+        run_paths=run_paths,
+    )
+
+    assert (
+        _hydra_value(arguments, "trainer.hf_hub_repo_id")
+        == "open-thoughts/explicit-run"
+    )
+
+
 def test_yaml_latest_without_a_checkpoint_is_rejected(tmp_path: Path) -> None:
     root = tmp_path / JOB_NAME
 


### PR DESCRIPTION
Require `hf_hub_repo_id` before enabling periodic Hugging Face checkpoint export. Job names no longer derive public `laion/{job_name}` repositories, so Jupiter and other offline jobs keep training across `hf_save_interval` boundaries when publication was not requested.

Explicit repository IDs still pass through unchanged. The regression covers both disabled-by-default and explicitly enabled export configuration.
