### PR TITLE
[RL] Preserve NCCL flight recorder dumps

### DIFF
--- a/hpc/sbatch_rl/universal_rl.sbatch
+++ b/hpc/sbatch_rl/universal_rl.sbatch
@@ -158,13 +158,6 @@ export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800
 # real failure point (often a peer-node HSN socket close on Perlmutter)
 # instead of a downstream SIGABRT in a NCCL destructor.
 export NCCL_BLOCKING_WAIT=1
-# TORCH_NCCL_TRACE_BUFFER_SIZE > 0 enables PyTorch's NCCL FlightRecorder,
-# which captures rank-by-rank stack traces of the most recent N collective
-# operations. On crash, ProcessGroupNCCL.cpp emits these traces — the
-# "Stack trace of the failed collective not found, potentially because
-# FlightRecorder is disabled" line in prior Perlmutter crashes goes away
-# and we get the actual offending collective + stack frames.
-export TORCH_NCCL_TRACE_BUFFER_SIZE=2000
 export OMP_NUM_THREADS=1
 export PYTHONPATH="$WORKDIR:${PYTHONPATH:-}"
 
@@ -208,6 +201,11 @@ mkdir -p "{experiments_dir}"
 mkdir -p "{experiments_dir}/logs"
 mkdir -p "{experiments_dir}/exports"
 mkdir -p "{experiments_dir}/ray_logs"
+
+# Preserve rank-by-rank collective history on the shared experiment filesystem.
+# PyTorch appends the global rank to this prefix when its NCCL watchdog fires.
+source "$WORKDIR/hpc/shell_utils/nccl_flight_recorder.sh"
+setup_nccl_flight_recorder "{experiments_dir}" || exit $?
 
 # --- Cleanup trap to preserve Ray logs ---
 # Ray uses /tmp by default for logs/sockets. This trap copies them to the

--- a/hpc/shell_utils/nccl_flight_recorder.sh
+++ b/hpc/shell_utils/nccl_flight_recorder.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+setup_nccl_flight_recorder() {
+    local experiments_dir="$1"
+    if [[ -z "$experiments_dir" ]]; then
+        echo "Usage: setup_nccl_flight_recorder <experiments_dir>" >&2
+        return 1
+    fi
+
+    if [[ -n "${TORCH_FR_DUMP_TEMP_FILE:-}" &&
+          -n "${TORCH_NCCL_DEBUG_INFO_TEMP_FILE:-}" &&
+          "$TORCH_FR_DUMP_TEMP_FILE" != "$TORCH_NCCL_DEBUG_INFO_TEMP_FILE" ]]; then
+        echo "TORCH_FR_DUMP_TEMP_FILE and TORCH_NCCL_DEBUG_INFO_TEMP_FILE must use the same prefix" >&2
+        return 1
+    fi
+
+    local job_id="${SLURM_JOB_ID:-manual}"
+    local default_dump_dir="${experiments_dir}/nccl_fr/${job_id}"
+    local dump_prefix="${TORCH_FR_DUMP_TEMP_FILE:-${TORCH_NCCL_DEBUG_INFO_TEMP_FILE:-${default_dump_dir}/nccl_fr_rank_}}"
+    local dump_dir="${dump_prefix%/*}"
+    if [[ "$dump_dir" == "$dump_prefix" ]]; then
+        dump_dir="."
+    fi
+    mkdir -p "$dump_dir"
+
+    export TORCH_NCCL_TRACE_BUFFER_SIZE="${TORCH_NCCL_TRACE_BUFFER_SIZE:-20000}"
+    export TORCH_NCCL_DUMP_ON_TIMEOUT="${TORCH_NCCL_DUMP_ON_TIMEOUT:-1}"
+    export TORCH_NCCL_DEBUG_INFO_TEMP_FILE="$dump_prefix"
+    export TORCH_FR_DUMP_TEMP_FILE="$dump_prefix"
+
+    echo "NCCL flight recorder: prefix=$dump_prefix buffer=$TORCH_NCCL_TRACE_BUFFER_SIZE"
+}

--- a/tests/analysis/test_watch_iris_harbor.py
+++ b/tests/analysis/test_watch_iris_harbor.py
@@ -862,7 +862,9 @@ def test_read_evalchemy_progress_counts_marin_evals_benchmarks(monkeypatch, tmp_
     class Client:
         def get_object(self, *, Bucket, Key):  # noqa: N803
             return {
-                "Body": io.BytesIO(json.dumps({"results": {"x": {"acc": 0.5}}}).encode())
+                "Body": io.BytesIO(
+                    json.dumps({"results": {"x": {"acc": 0.5}}}).encode()
+                )
             }
 
     progress = watcher.read_evalchemy_progress(job, log, {"test": Client()}, tmp_path)

--- a/tests/hpc/test_nccl_flight_recorder.py
+++ b/tests/hpc/test_nccl_flight_recorder.py
@@ -1,0 +1,71 @@
+import shlex
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETUP_SCRIPT = REPO_ROOT / "hpc" / "shell_utils" / "nccl_flight_recorder.sh"
+
+
+def run_setup(
+    experiments_dir: Path, *, environment: dict[str, str] | None = None
+) -> dict[str, str]:
+    command = f"""
+source {shlex.quote(str(SETUP_SCRIPT))}
+setup_nccl_flight_recorder {shlex.quote(str(experiments_dir))}
+printf 'buffer=%s\n' "$TORCH_NCCL_TRACE_BUFFER_SIZE"
+printf 'dump_on_timeout=%s\n' "$TORCH_NCCL_DUMP_ON_TIMEOUT"
+printf 'debug_prefix=%s\n' "$TORCH_NCCL_DEBUG_INFO_TEMP_FILE"
+printf 'fr_prefix=%s\n' "$TORCH_FR_DUMP_TEMP_FILE"
+"""
+    result = subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    names = {"buffer", "dump_on_timeout", "debug_prefix", "fr_prefix"}
+    return dict(
+        entry
+        for line in result.stdout.splitlines()
+        if "=" in line and (entry := line.split("=", 1))[0] in names
+    )
+
+
+def test_setup_creates_job_scoped_durable_dump_destination(tmp_path: Path) -> None:
+    experiments_dir = tmp_path / "experiment"
+
+    values = run_setup(experiments_dir, environment={"SLURM_JOB_ID": "1390513"})
+
+    dump_dir = experiments_dir / "nccl_fr" / "1390513"
+    expected_prefix = str(dump_dir / "nccl_fr_rank_")
+    assert dump_dir.is_dir()
+    assert values == {
+        "buffer": "20000",
+        "dump_on_timeout": "1",
+        "debug_prefix": expected_prefix,
+        "fr_prefix": expected_prefix,
+    }
+
+
+def test_setup_preserves_explicit_recorder_settings(tmp_path: Path) -> None:
+    experiments_dir = tmp_path / "experiment"
+    configured_prefix = tmp_path / "custom" / "trace_rank_"
+
+    values = run_setup(
+        experiments_dir,
+        environment={
+            "TORCH_NCCL_DEBUG_INFO_TEMP_FILE": str(configured_prefix),
+            "TORCH_NCCL_DUMP_ON_TIMEOUT": "0",
+            "TORCH_NCCL_TRACE_BUFFER_SIZE": "4096",
+        },
+    )
+
+    assert configured_prefix.parent.is_dir()
+    assert values == {
+        "buffer": "4096",
+        "dump_on_timeout": "0",
+        "debug_prefix": str(configured_prefix),
+        "fr_prefix": str(configured_prefix),
+    }


### PR DESCRIPTION
Persist NCCL flight-recorder timeout dumps under
`<experiment>/nccl_fr/<Slurm job ID>/` instead of leaving them in node-local
`/tmp`, where Jupiter allocation teardown discards them. Configure both PyTorch
dump-prefix names and create the destination before Ray starts so cross-rank
traces survive the failed job.

Raise the default history from 2,000 to 20,000 collectives. Explicit cluster or
run settings still take precedence.
