### PR TITLE
[eval] Serve cached models in single-node runs

### DIFF
--- a/hpc/local_runner_utils.py
+++ b/hpc/local_runner_utils.py
@@ -1336,7 +1336,7 @@ class LocalHarborRunner:
 
             # Start vLLM controller
             vllm_proc = start_vllm_controller(
-                model=args.model,
+                model=getattr(args, "vllm_model_uri", None) or args.model,
                 host=args.host,
                 ray_port=args.ray_port,
                 api_port=args.api_port,


### PR DESCRIPTION
Use `vllm_model_uri` when a single-node eval starts its local vLLM controller. Iris offline precaching already passes the region-local mirror URI, but this branch discarded it and launched with the Hugging Face repository ID. With offline mode enabled, vLLM then exited with `LocalEntryNotFoundError` before RunAI streaming began.

The multi-node Iris controller path already selects the mirror URI. The same selection now applies to single-node GPU evals. The failure and diagnostic signature are recorded in https://echo.oa.dev/wiki/207.
