### PR TITLE
[iris] Honor Harbor config in federated external evals

### DIFF
--- a/hpc/cloud_launch_utils.py
+++ b/hpc/cloud_launch_utils.py
@@ -90,9 +90,9 @@ DEFAULT_CLOUD_OUTPUT_PREFIX = (
     "trace_runs"  # Default output subdir prefix for cloud jobs
 )
 
-# Harbor git URL for cloud reinstalls (always fetch latest from branch)
+# Harbor git URL for cloud reinstalls.
 HARBOR_GIT_URL = (
-    "git+https://github.com/laude-institute/harbor.git@penfever/temp-override"
+    "git+https://github.com/marin-community/harbor.git@629b0c781426b9337f21e5aa3c2bbb246cb3336c"
 )
 
 

--- a/hpc/cloud_launch_utils.py
+++ b/hpc/cloud_launch_utils.py
@@ -90,9 +90,9 @@ DEFAULT_CLOUD_OUTPUT_PREFIX = (
     "trace_runs"  # Default output subdir prefix for cloud jobs
 )
 
-# Harbor git URL for cloud reinstalls.
+# Harbor git URL for cloud reinstalls (always fetch latest from branch)
 HARBOR_GIT_URL = (
-    "git+https://github.com/marin-community/harbor.git@629b0c781426b9337f21e5aa3c2bbb246cb3336c"
+    "git+https://github.com/laude-institute/harbor.git@penfever/temp-override"
 )
 
 

--- a/hpc/datagen_yaml/extra/tasktrove_external_endpoint_32k.yaml
+++ b/hpc/datagen_yaml/extra/tasktrove_external_endpoint_32k.yaml
@@ -1,0 +1,11 @@
+# External OA-federated endpoint used by installed-agent TaskTrove evaluations.
+engine:
+  type: openai
+  model: vllm/placeholder
+  max_output_tokens: 16384
+  healthcheck_interval: 300
+  openai:
+    api_key_env: EXTERNAL_AGENT_API_KEY
+backend:
+  type: none
+vllm_server: null

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -273,6 +273,11 @@ def build_worker_command(
         args.dataset_path,
     ]
     after_api_base = [
+        *(
+            argument
+            for value in getattr(args, "agent_kwarg", [])
+            for argument in ("--agent_kwarg", value)
+        ),
         "--n_concurrent",
         str(args.n_concurrent),
         "--n_attempts",
@@ -282,9 +287,13 @@ def build_worker_command(
         "--experiments_dir",
         work_dir,
         f"--harbor_extra_arg=--jobs-dir={durable_jobs_dir}",
-        "--upload_hf_repo",
-        args.upload_hf_repo,
+        *(
+            f"--harbor_extra_arg={value}"
+            for value in getattr(args, "harbor_extra_arg", [])
+        ),
     ]
+    if not getattr(args, "skip_hf_upload", False):
+        after_api_base.extend(["--upload_hf_repo", args.upload_hf_repo])
     return (
         "set -eu\n"
         'test -n "${EXTERNAL_AGENT_API_BASE:?missing minted endpoint URL}"\n'
@@ -303,6 +312,7 @@ def build_submit_command(
         "HF_TOKEN": require_secret(env, "HF_TOKEN"),
         "OPENAI_API_KEY": require_secret(env, "OPENAI_API_KEY"),
         "OPENCODE_DUMMY_KEY": DUMMY_API_KEY,
+        "EXTERNAL_AGENT_API_KEY": DUMMY_API_KEY,
         "EXTERNAL_AGENT_API_BASE": api_base,
     }
     task_env["OT_AGENT_CAPABILITY_TOKEN_DURATION_POLICY"] = (
@@ -349,6 +359,11 @@ def build_submit_command(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--job-name", default=default_job_name())
+    parser.add_argument(
+        "--agent",
+        default="opencode",
+        help="Installed Harbor agent used by the eval and token-duration policy.",
+    )
     parser.add_argument(
         "--existing-endpoint",
         help="Use an already-running federated endpoint instead of submitting a new serve.",
@@ -422,6 +437,18 @@ def main() -> int:
     parser.add_argument("--n-concurrent", type=int, default=256)
     parser.add_argument("--n-attempts", type=int, default=3)
     parser.add_argument(
+        "--agent-kwarg",
+        action="append",
+        default=[],
+        help="Additional key=value argument forwarded to the Harbor agent.",
+    )
+    parser.add_argument(
+        "--harbor-extra-arg",
+        action="append",
+        default=[],
+        help="Additional raw Harbor CLI argument. Repeat as needed.",
+    )
+    parser.add_argument(
         "--s3-output-dir",
         default=DEFAULT_S3_OUTPUT_ROOT,
         help=(
@@ -430,6 +457,11 @@ def main() -> int:
         ),
     )
     parser.add_argument("--upload-hf-repo", default=DEFAULT_HF_TRACE_REPO)
+    parser.add_argument(
+        "--skip-hf-upload",
+        action="store_true",
+        help="Keep durable Harbor artifacts in object storage without publishing to Hugging Face.",
+    )
     parser.add_argument("--cpu", type=float, default=32)
     parser.add_argument("--memory", default="128GB")
     parser.add_argument("--disk", default="128GB")
@@ -449,7 +481,7 @@ def main() -> int:
     )
     try:
         token_policy = resolve_token_duration_policy(
-            agent="opencode",
+            agent=args.agent,
             timeout_seconds=args.timeout,
             requested_token_ttl_seconds=requested_ttl_seconds,
         )

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -297,6 +297,7 @@ def build_worker_command(
     return (
         "set -eu\n"
         'test -n "${EXTERNAL_AGENT_API_BASE:?missing minted endpoint URL}"\n'
+        "uv pip install --python /app/.venv/bin/python s3fs==2026.2.0\n"
         f"exec {shlex.join(before_api_base)} "
         '--agent_kwarg "api_base=${EXTERNAL_AGENT_API_BASE}" '
         f"{shlex.join(after_api_base)}"

--- a/scripts/iris/launch_external_opencode_eval.py
+++ b/scripts/iris/launch_external_opencode_eval.py
@@ -278,8 +278,11 @@ def build_worker_command(
             for value in getattr(args, "agent_kwarg", [])
             for argument in ("--agent_kwarg", value)
         ),
-        "--n_concurrent",
-        str(args.n_concurrent),
+        *(
+            ("--n_concurrent", str(args.n_concurrent))
+            if args.n_concurrent is not None
+            else ()
+        ),
         "--n_attempts",
         str(args.n_attempts),
         "--job_name",
@@ -432,10 +435,12 @@ def main() -> int:
     )
     parser.add_argument("--model", help="Eval model id (default: vllm/<serve-model>).")
     parser.add_argument("--dataset-path", default=DEFAULT_DATASET_PATH)
-    # One coordinator is intentionally task-sharded; Iris GPU eval replicas are
-    # not.  A high Harbor concurrency feeds the separately served DP=8 model
-    # without launching duplicate full-dataset evaluations.
-    parser.add_argument("--n-concurrent", type=int, default=256)
+    parser.add_argument(
+        "--n-concurrent",
+        type=int,
+        default=None,
+        help="Override Harbor concurrency. Omit this option to use the Harbor YAML.",
+    )
     parser.add_argument("--n-attempts", type=int, default=3)
     parser.add_argument(
         "--agent-kwarg",

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -70,8 +70,11 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
         dataset_path="DCAgent/dev_set_v2",
         n_concurrent=256,
         n_attempts=3,
+        agent_kwarg=["thinking_format=chat-template"],
+        harbor_extra_arg=["--n-tasks=1"],
         s3_output_dir="s3://marin-us-east-02a/iris",
         upload_hf_repo="laion/traces",
+        skip_hf_upload=True,
     )
     command = _MODULE.build_submit_command(
         args,
@@ -87,6 +90,8 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
     assert "${EXTERNAL_AGENT_API_BASE:?missing minted endpoint URL}" in shell
     assert "api_base=${EXTERNAL_AGENT_API_BASE}" in shell
     assert "https://iris.oa.dev" not in shell
+    assert "thinking_format=chat-template" in shell
+    assert "--harbor_extra_arg=--n-tasks=1" in shell
     assert "--n_concurrent 256" in shell
     assert "--job_name eval-v2" in shell
     assert "--experiments_dir /tmp/ot-agent-runs/eval-v2" in shell
@@ -95,6 +100,8 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
         "--harbor_extra_arg=--jobs-dir=s3://marin-us-east-02a/iris/eval-v2/trace_jobs"
         in shell
     )
+    assert "--upload_hf_repo" not in shell
+    assert command[command.index("EXTERNAL_AGENT_API_KEY") + 1] == _MODULE.DUMMY_API_KEY
 
 
 def test_s3_harbor_jobs_dir_isolated_per_iris_job():

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -88,6 +88,7 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
     shell = command[-1]
     assert "set -eu" in shell
     assert "${EXTERNAL_AGENT_API_BASE:?missing minted endpoint URL}" in shell
+    assert "uv pip install --python /app/.venv/bin/python s3fs==2026.2.0" in shell
     assert "api_base=${EXTERNAL_AGENT_API_BASE}" in shell
     assert "https://iris.oa.dev" not in shell
     assert "thinking_format=chat-template" in shell

--- a/tests/iris/test_launch_external_opencode_eval.py
+++ b/tests/iris/test_launch_external_opencode_eval.py
@@ -105,6 +105,29 @@ def test_submit_uses_env_for_url_and_fails_fast_when_missing():
     assert command[command.index("EXTERNAL_AGENT_API_KEY") + 1] == _MODULE.DUMMY_API_KEY
 
 
+def test_submit_uses_harbor_config_concurrency_when_not_overridden():
+    args = argparse.Namespace(
+        harbor_config="config.yaml",
+        datagen_config="external.yaml",
+        model="vllm/model",
+        dataset_path="DCAgent/dev_set_v2",
+        n_concurrent=None,
+        n_attempts=1,
+        job_name="eval-v2",
+        agent_kwarg=[],
+        harbor_extra_arg=[],
+        skip_hf_upload=True,
+    )
+
+    command = _MODULE.build_worker_command(
+        args,
+        "s3://marin-us-east-02a/iris/eval-v2/trace_jobs",
+        "/tmp/ot-agent-runs/eval-v2",
+    )
+
+    assert "--n_concurrent" not in command
+
+
 def test_s3_harbor_jobs_dir_isolated_per_iris_job():
     assert (
         _MODULE.s3_harbor_jobs_dir("s3://marin-us-east-02a/iris/", "eval-v2")

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#1d7e5ffa8537d90a83e8a2681c93447c794d741b" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#629b0c781426b9337f21e5aa3c2bbb246cb3336c" }
 dependencies = [
     { name = "dirhash" },
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#a7502f1e3bd26f2a64db0a81cd2ebe46efa89aa1" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#922743ae4bd3097ddaa3f1dc54d4b29cc3b8220f" }
 dependencies = [
     { name = "dirhash" },
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#922743ae4bd3097ddaa3f1dc54d4b29cc3b8220f" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#dba6728d50a86a4d2bb3bb724915785445e20392" }
 dependencies = [
     { name = "dirhash" },
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#629b0c781426b9337f21e5aa3c2bbb246cb3336c" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#a7502f1e3bd26f2a64db0a81cd2ebe46efa89aa1" }
 dependencies = [
     { name = "dirhash" },
     { name = "fastapi" },


### PR DESCRIPTION
Generalize the federated external-eval launcher for installed agents that use
an OA-hosted endpoint. Forward agent arguments, support durable S3-only runs,
and provide a 32K external-endpoint config for TaskTrove.

Leave Harbor concurrency unset unless the caller supplies an explicit
override. The local runner then uses `orchestrator.n_concurrent_trials` from
the selected Harbor YAML. Pin Harbor `dba6728d` so new jobs include the PR 92
Pi authentication-classification fix.
