### PR TITLE
[eval] Pin Harbor context-overflow classification

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2521,7 +2521,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?rev=main#dba6728d50a86a4d2bb3bb724915785445e20392" }
+source = { git = "https://github.com/marin-community/harbor.git?rev=main#d7337ccc42f68789b2a9f612f01c326d137cc9e8" }
 dependencies = [
     { name = "dirhash" },
     { name = "fastapi" },


### PR DESCRIPTION
Pin Harbor at d7337ccc so Pi structured context-window failures become `ContextLengthExceededError`. The TaskTrove Pi configuration already excludes that exception from retry, avoiding up to ten retries per deterministic overflow while connection and unknown failures remain generic.

Production sampling found the same 32,768-token overflow signature in 48 of 49 inspected `NonZeroAgentExitCodeError` traces across Qwen and Gemma cells. The remaining trace exposed a separate leading-hyphen argument-boundary issue.
