### PR TITLE
[eval] Restore TaskTrove Pi timeout contract

### DIFF
--- a/hpc/harbor_yaml/eval/tasktrove_pi_ctx32k.yaml
+++ b/hpc/harbor_yaml/eval/tasktrove_pi_ctx32k.yaml
@@ -23,11 +23,11 @@ environment:
   kwargs:
     auto_snapshot: true
 verifier:
-  max_timeout_sec: 14400
+  max_timeout_sec: 7200
 agents:
   - name: pi
     model_name: placeholder/override-at-runtime
-    max_timeout_sec: 7200
+    max_timeout_sec: 14400
     kwargs:
       version: "0.73.1"
       thinking: high


### PR DESCRIPTION
The TaskTrove Pi evaluation config inverted the campaign timeout contract: agents received two hours while verifiers received four. Restore four-hour agent and two-hour verifier limits. Concurrency remains 32, and agent timeouts remain excluded from retry.

Validated by loading the YAML and asserting the two timeout values, concurrency, and retry exclusion.