### PR TITLE
[eval] Override TaskTrove Pi stage timeouts

### DIFF
--- a/hpc/harbor_yaml/eval/tasktrove_pi_ctx32k.yaml
+++ b/hpc/harbor_yaml/eval/tasktrove_pi_ctx32k.yaml
@@ -23,10 +23,12 @@ environment:
   kwargs:
     auto_snapshot: true
 verifier:
+  override_timeout_sec: 7200
   max_timeout_sec: 7200
 agents:
   - name: pi
     model_name: placeholder/override-at-runtime
+    override_timeout_sec: 14400
     max_timeout_sec: 14400
     kwargs:
       version: "0.73.1"


### PR DESCRIPTION
Override TaskTrove's per-task defaults so Pi receives 14,400 seconds and the verifier receives 7,200 seconds. The existing maximum-only fields preserved the task's lower timeout; production verifier traces still failed after 720 seconds.

Keep the matching maximums to bound task-provided values above the campaign contract.
