### PR TITLE
[eval] Add Snowball TaskTrove v3.42 configs

### DIFF
--- a/hpc/datagen_yaml/extra/snowball_tasktrove_v342_external.yaml
+++ b/hpc/datagen_yaml/extra/snowball_tasktrove_v342_external.yaml
@@ -1,0 +1,13 @@
+engine:
+  type: openai
+  model: vllm/laion/snowball-67b-a2b-sft-s3-nemotron-terminal-step1888
+  max_output_tokens: 8192
+  healthcheck_interval: 300
+  openai:
+    api_key_env: EXTERNAL_AGENT_API_KEY
+backend:
+  type: none
+vllm_server: null
+extra_agent_kwargs:
+  api_base: ${oc.env:EXTERNAL_AGENT_API_BASE}
+  api_key: capability-url-no-auth-header

--- a/hpc/harbor_yaml/eval/snowball_tasktrove_v342_terminus2.yaml
+++ b/hpc/harbor_yaml/eval/snowball_tasktrove_v342_terminus2.yaml
@@ -1,0 +1,60 @@
+n_attempts: 1
+timeout_multiplier: 1.0
+trial_attempt_timeout_sec: 23400
+trial_cleanup_grace_sec: 30
+orchestrator:
+  type: local
+  n_concurrent_trials: 32
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    exclude_exceptions:
+      - AgentTimeoutError
+      - ContextLengthExceededError
+      - ContextManagementInfrastructureError
+      - TrialTimeoutError
+      - VerifierTimeoutError
+    wait_multiplier: 2.0
+    min_wait_sec: 1.0
+    max_wait_sec: 90.0
+environment:
+  type: daytona
+  force_build: true
+  delete: true
+  override_cpus: 2
+  override_memory_mb: 4096
+  override_storage_mb: 4096
+  kwargs:
+    auto_snapshot: true
+verifier:
+  override_timeout_sec: 14400
+  max_timeout_sec: 14400
+agents:
+  - name: terminus-2
+    model_name: placeholder/override-at-runtime
+    override_timeout_sec: 7200
+    max_timeout_sec: 7200
+    kwargs:
+      temperature: 0.6
+      record_terminal_session: false
+      enable_episode_logging: false
+      enable_pane_logging: false
+      collect_rollout_details: false
+      collect_engine_metrics: false
+      trajectory_config:
+        raw_content: true
+        linear_history: true
+      model_info:
+        max_input_tokens: 24576
+        max_output_tokens: 8192
+        input_cost_per_token: 0.0
+        output_cost_per_token: 0.0
+      max_tokens: 8192
+      extra_body:
+        skip_special_tokens: false
+        repetition_penalty: 1.1
+      enable_summarize: true
+      proactive_summarization_threshold: 2048
+datasets: []
+tasks: []


### PR DESCRIPTION
Add the Terminus-2 Harbor and OA-federated external inference configs for the Snowball TaskTrove v3.42 campaign.

Set 32 concurrent Harbor trials with the campaign’s two-hour agent and four-hour verifier limits. Bound each admitted attempt at 6h30m and exclude terminal agent, context, verifier, and whole-attempt timeouts from retries.

The live campaign’s older PR #84 pin left 31 e2egit-large trials in verifier cleanup for up to 4h49m after verification began. Current main pins Harbor d7337ccc, which includes PR #88’s admission-scoped timeout handling.
