### PR TITLE
[data] Make ToolScale execution fixture-backed

### DIFF
--- a/data/toolscale/deterministic_execution.py
+++ b/data/toolscale/deterministic_execution.py
@@ -1,0 +1,365 @@
+"""Deterministic ToolScale task construction.
+
+ToolScale v3 was reconstructed from TaskTrove v3.42 and the pinned NVIDIA
+source.  It selected the 4,048 source rows with at least one action and embedded
+a domain-wide tool catalog, but its runtime synthesized every tool result from
+the same per-task ``communicate_info`` strings.  It also had no discovery path
+for identifiers that appeared only in the reference actions.
+
+This module retains the v3 source pin and row-selection rule while defining the
+v4 execution contract.  The catalog remains domain-wide, ``inspect`` exposes
+candidate argument values without naming or grouping the reference calls, and
+``call`` accepts only fixture-backed calls.  The runtime and verifier share the
+same canonical call representation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import date, datetime
+from typing import Any
+
+SOURCE_REPO = "nvidia/ToolScale"
+SOURCE_REVISION = "1ff421d53450d22fc2779ff19ffc502ce5582dc8"
+SOURCE_FILE = "data/train-00000-of-00001.parquet"
+V3_TASKTROVE_REVISION = "3e96fe6464ce5ab6209e98801caab29b4a1fe87a"
+
+
+def json_value(value: Any) -> Any:
+    """Convert Arrow values into stable JSON values."""
+    if isinstance(value, (date, datetime)):
+        return value.strftime("%Y-%m-%d %H:%M:%S") if isinstance(value, datetime) else value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): json_value(item) for key, item in value.items() if item is not None}
+    if isinstance(value, (list, tuple)):
+        return [json_value(item) for item in value]
+    return value
+
+
+def clean_arguments(arguments: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Drop null Arrow fields from one ToolScale action."""
+    return dict(json_value(arguments or {}))
+
+
+def selected_by_v3(row: Mapping[str, Any]) -> bool:
+    """Return whether the exact v3 generator retained a source row."""
+    criteria = row.get("evaluation_criteria") or {}
+    return bool(criteria.get("actions"))
+
+
+def source_actions(row: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return canonical reference calls from a ToolScale source row."""
+    criteria = row.get("evaluation_criteria") or {}
+    calls = []
+    for action in criteria.get("actions") or []:
+        calls.append({"name": action["name"], "arguments": clean_arguments(action.get("arguments"))})
+    return calls
+
+
+def source_assertions(row: Mapping[str, Any]) -> list[str]:
+    """Return nonempty source assertions used as deterministic result evidence."""
+    criteria = row.get("evaluation_criteria") or {}
+    return [str(item).strip() for item in criteria.get("nl_assertions") or [] if str(item).strip()]
+
+
+def task_domain(row: Mapping[str, Any]) -> str:
+    scenario = row.get("user_scenario") or {}
+    instructions = scenario.get("instructions") or {}
+    return str(instructions.get("domain") or "general")
+
+
+def build_domain_catalog(rows: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, list[str]]]:
+    """Build domain-wide tool schemas without exposing per-task reference calls."""
+    catalog: dict[str, dict[str, set[str]]] = {}
+    for row in rows:
+        if not selected_by_v3(row):
+            continue
+        domain = task_domain(row)
+        domain_tools = catalog.setdefault(domain, {})
+        for call in source_actions(row):
+            domain_tools.setdefault(call["name"], set()).update(call["arguments"])
+    return {
+        domain: {name: sorted(arguments) for name, arguments in sorted(tools.items())}
+        for domain, tools in sorted(catalog.items())
+    }
+
+
+def canonical(value: Any) -> str:
+    return json.dumps(json_value(value), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def evidence_id(task_id: str, tool: str, arguments: Mapping[str, Any]) -> str:
+    payload = canonical({"arguments": arguments, "task_id": task_id, "tool": tool})
+    return "evidence-" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def expected_fixture(row: Mapping[str, Any], task_id: str) -> dict[str, Any]:
+    calls = source_actions(row)
+    return {
+        "assertions": source_assertions(row),
+        "calls": [
+            {
+                **call,
+                "evidence_id": evidence_id(task_id, call["name"], call["arguments"]),
+            }
+            for call in calls
+        ],
+        "domain": task_domain(row),
+        "task_id": task_id,
+    }
+
+
+def discovery_candidates(calls: Sequence[Mapping[str, Any]]) -> dict[str, list[Any]]:
+    """Flatten argument values without retaining their call grouping."""
+    candidates: dict[str, list[Any]] = {}
+    for call in calls:
+        for key, value in call["arguments"].items():
+            values = candidates.setdefault(key, [])
+            if value not in values:
+                values.append(value)
+    return candidates
+
+
+def render_instruction(row: Mapping[str, Any], task_id: str) -> str:
+    scenario = row.get("user_scenario") or {}
+    instructions = scenario.get("instructions") or {}
+    criteria = row.get("evaluation_criteria") or {}
+    lines = ["# ToolScale deterministic tool-use task", "", f"- **Domain:** {task_domain(row)}"]
+    if row.get("id"):
+        lines.append(f"- **Scenario ID:** {row['id']}")
+    headings = (
+        ("Task Instructions", "task_instructions"),
+        ("Reason for Request", "reason_for_call"),
+        ("Known Information", "known_info"),
+        ("Unknown Information", "unknown_info"),
+    )
+    for heading, key in headings:
+        value = str(instructions.get(key) or "").strip()
+        if value:
+            lines.extend(("", f"## {heading}", "", value))
+    assertions = source_assertions(row)
+    if assertions:
+        lines.extend(("", "## Success Criteria", ""))
+        lines.extend(f"- {assertion}" for assertion in assertions)
+    communicate_info = [str(item) for item in criteria.get("communicate_info") or []]
+    if communicate_info:
+        lines.extend(("", "## Information to Surface", ""))
+        lines.extend(f"- {item}" for item in communicate_info)
+    lines.extend(
+        (
+            "",
+            "## Available tools",
+            "",
+            f"Inspect the {task_domain(row)} tool catalog with:",
+            "",
+            f"`toolscale catalog --domain {task_domain(row)}`",
+            "",
+            "Discover scenario-specific candidate argument values with:",
+            "",
+            f"`toolscale inspect --task-id {task_id}`",
+            "",
+            "The inspection output does not identify or group the required calls. Use the scenario and catalog to choose tools.",
+            "",
+            "Invoke a tool with:",
+            "",
+            f"`toolscale call --task-id {task_id} --tool TOOL_NAME --arguments 'JSON_OBJECT'`",
+            "",
+            "Only fixture-backed calls succeed. Successful calls return deterministic, task-specific evidence.",
+            "",
+            "## Deliverable",
+            "",
+            "Write a concise client-ready answer to `/app/response.md`. Include each relevant returned fact and the `evidence_id` from every tool result you rely on. The verifier checks executed calls and the response; a call plan without execution does not pass.",
+        )
+    )
+    return "\n".join(lines).strip() + "\n"
+
+
+def render_runtime(fixture: Mapping[str, Any], domain_catalog: Mapping[str, Sequence[str]]) -> str:
+    fixture_json = json.dumps(fixture, ensure_ascii=False, sort_keys=True)
+    catalog_json = json.dumps(dict(domain_catalog), ensure_ascii=False, sort_keys=True)
+    candidates_json = json.dumps(discovery_candidates(fixture["calls"]), ensure_ascii=False, sort_keys=True)
+    return f'''#!/usr/bin/env python3
+"""Offline runtime for one ToolScale task."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+FIXTURE = {fixture_json}
+CATALOG = {catalog_json}
+CANDIDATES = {candidates_json}
+
+
+def canonical(value):
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def evidence_id(task_id, tool, arguments):
+    payload = canonical({{"arguments": arguments, "task_id": task_id, "tool": tool}})
+    return "evidence-" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def catalog_command(domain):
+    if domain != FIXTURE["domain"]:
+        raise SystemExit(f"catalog unavailable for domain: {{domain}}")
+    print(json.dumps({{name: {{"arguments": args}} for name, args in CATALOG.items()}}, indent=2, sort_keys=True))
+
+
+def inspect_command(task_id):
+    if task_id != FIXTURE["task_id"]:
+        raise SystemExit(f"unknown task id: {{task_id}}")
+    print(json.dumps({{"argument_candidates": CANDIDATES, "domain": FIXTURE["domain"], "task_id": task_id}}, indent=2, sort_keys=True))
+
+
+def call_command(task_id, tool, arguments_text):
+    if task_id != FIXTURE["task_id"]:
+        raise SystemExit(f"unknown task id: {{task_id}}")
+    arguments = json.loads(arguments_text)
+    if not isinstance(arguments, dict):
+        raise SystemExit("--arguments must decode to a JSON object")
+    matches = [call for call in FIXTURE["calls"] if call["name"] == tool and call["arguments"] == arguments]
+    if not matches:
+        raise SystemExit("no fixture-backed result for that tool and argument object")
+    call = matches[0]
+    assert call["evidence_id"] == evidence_id(task_id, tool, arguments)
+    index = FIXTURE["calls"].index(call)
+    result = {{
+        "arguments": arguments,
+        "evidence_id": call["evidence_id"],
+        "facts": {{"source_assertion": FIXTURE["assertions"][index]}} if index < len(FIXTURE["assertions"]) else {{}},
+        "operation": tool,
+        "status": "completed",
+        "task_id": task_id,
+    }}
+    log_path = Path(os.environ.get("TOOL_SCALE_LOG", "/app/toolscale_calls.jsonl"))
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(canonical(result) + "\\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    catalog_parser = subparsers.add_parser("catalog")
+    catalog_parser.add_argument("--domain", required=True)
+    inspect_parser = subparsers.add_parser("inspect")
+    inspect_parser.add_argument("--task-id", required=True)
+    call_parser = subparsers.add_parser("call")
+    call_parser.add_argument("--task-id", required=True)
+    call_parser.add_argument("--tool", required=True)
+    call_parser.add_argument("--arguments", required=True)
+    args = parser.parse_args()
+    if args.command == "catalog":
+        catalog_command(args.domain)
+    elif args.command == "inspect":
+        inspect_command(args.task_id)
+    else:
+        call_command(args.task_id, args.tool, args.arguments)
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def render_check() -> str:
+    return '''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+
+tests_dir = Path(os.environ.get("TOOL_SCALE_TESTS_DIR", "/tests"))
+app_dir = Path(os.environ.get("APP_DIR", "/app"))
+expected = json.loads((tests_dir / "expected.json").read_text())
+log_path = app_dir / "toolscale_calls.jsonl"
+response_path = app_dir / "response.md"
+assert log_path.is_file(), "no tool calls were executed"
+assert response_path.is_file(), "missing /app/response.md"
+logs = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+for wanted in expected["calls"]:
+    matches = [
+        item for item in logs
+        if item.get("task_id") == expected["task_id"]
+        and item.get("operation") == wanted["name"]
+        and item.get("arguments") == wanted["arguments"]
+        and item.get("evidence_id") == wanted["evidence_id"]
+    ]
+    assert matches, f"required fixture-backed call was not executed: {wanted['name']}"
+response = response_path.read_text().casefold()
+for wanted in expected["calls"]:
+    assert wanted["evidence_id"].casefold() in response, f"response omits {wanted['evidence_id']}"
+for assertion in expected["assertions"]:
+    assert assertion.casefold() in response, f"response omits source assertion: {assertion}"
+print(f"validated {len(expected['calls'])} fixture-backed calls")
+'''
+
+
+def render_test_sh() -> str:
+    return '''#!/bin/bash
+set -uo pipefail
+TESTS_DIR="${TOOL_SCALE_TESTS_DIR:-/tests}"
+LOGS_DIR="${TOOL_SCALE_LOGS_DIR:-/logs/verifier}"
+mkdir -p "$LOGS_DIR"
+echo 0 > "$LOGS_DIR/reward.txt"
+if python3 "$TESTS_DIR/check.py" 2>&1 | tee "$LOGS_DIR/test_output.txt"; then
+    echo 1 > "$LOGS_DIR/reward.txt"
+    exit 0
+fi
+exit 1
+'''
+
+
+def render_solution(fixture: Mapping[str, Any]) -> str:
+    lines = [
+        "#!/bin/bash",
+        "set -euo pipefail",
+        'APP_DIR="${APP_DIR:-/app}"',
+        'mkdir -p "$APP_DIR"',
+        'rm -f "$APP_DIR/toolscale_calls.jsonl"',
+        'response="$APP_DIR/response.md"',
+        ': > "$response"',
+        f"printf '%s\\n' {shlex.quote('# ToolScale result for ' + fixture['task_id'])} >> \"$response\"",
+    ]
+    for call in fixture["calls"]:
+        args = canonical(call["arguments"])
+        command = (
+            f"toolscale call --task-id {shlex.quote(fixture['task_id'])} "
+            f"--tool {shlex.quote(call['name'])} --arguments {shlex.quote(args)}"
+        )
+        lines.append(command + " > /tmp/toolscale-result.json")
+        lines.append(f"printf '%s\\n' {shlex.quote('- Evidence: ' + call['evidence_id'])} >> \"$response\"")
+    for assertion in fixture["assertions"]:
+        lines.append(f"printf '%s\\n' {shlex.quote('- ' + assertion)} >> \"$response\"")
+    return "\n".join(lines) + "\n"
+
+
+DOCKERFILE = '''FROM python:3.12-slim
+WORKDIR /app
+COPY toolscale_runtime.py /usr/local/bin/toolscale
+RUN chmod +x /usr/local/bin/toolscale
+CMD ["/bin/bash"]
+'''
+
+
+TASK_TOML = '''version = "1.0"
+
+[agent]
+timeout_sec = 900.0
+
+[metadata]
+author_name = "OpenThoughts-Agent"
+author_email = ""
+difficulty = "medium"
+category = "tool-use"
+tags = ["sandbox", "tool-use", "deterministic", "fixture-backed"]
+
+[verifier]
+restart_environment = false
+timeout_sec = 720.0
+'''

--- a/data/toolscale/generate.py
+++ b/data/toolscale/generate.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Generate Harbor-compatible tasks from the ToolScale dataset.
-"""
+"""Generate fixture-backed Harbor tasks from the pinned ToolScale source."""
 
 from __future__ import annotations
 
@@ -10,366 +8,119 @@ import json
 import sys
 import tempfile
 from pathlib import Path
-from textwrap import dedent
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Any
 
-from datasets import Dataset, load_dataset
+import pyarrow.parquet as pq
+from huggingface_hub import hf_hub_download
 
 if __package__ in (None, ""):
     sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from data.commons import (  # type: ignore  # pylint: disable=wrong-import-position
-    create_task_directory_unified,
-    finalize_dataset_output,
-    upload_tasks_to_hf,
+from data.commons import create_task_directory_unified, finalize_dataset_output, upload_tasks_to_hf
+from data.toolscale.deterministic_execution import (
+    DOCKERFILE,
+    SOURCE_FILE,
+    SOURCE_REPO,
+    SOURCE_REVISION,
+    TASK_TOML,
+    build_domain_catalog,
+    expected_fixture,
+    render_check,
+    render_instruction,
+    render_runtime,
+    render_solution,
+    render_test_sh,
+    selected_by_v3,
+    task_domain,
 )
 
-if __package__ in (None, ""):
-    from data.toolscale import DATASET_NAME  # type: ignore
-    from data.llm_verifier.utils import create_pytest_sh, create_test_state_py  # type: ignore
-else:
-    from . import DATASET_NAME
-    from ..llm_verifier.utils import create_pytest_sh, create_test_state_py
+BATCH_SIZE = 32
 
 
 def add_toolscale_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    parser.add_argument(
-        "--split", type=str, default="train", help="Dataset split to load."
-    )
-    parser.add_argument(
-        "--limit", type=int, default=100, help="Maximum number of tasks to generate."
-    )
-    parser.add_argument(
-        "--offset", type=int, default=0, help="Offset into the dataset split."
-    )
-    parser.add_argument(
-        "--dataset-prefix",
-        type=str,
-        default="toolscale",
-        help="Directory prefix for generated tasks.",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=str,
-        default=None,
-        help="Optional explicit output directory.",
-    )
-    parser.add_argument(
-        "--target-repo",
-        type=str,
-        default=None,
-        help="Optional Hugging Face repo for uploads (dataset).",
-    )
-    parser.add_argument(
-        "--hf-token", type=str, default=None, help="Hugging Face token for uploads."
-    )
-    parser.add_argument(
-        "--hf-private", action="store_true", help="Upload dataset as private."
-    )
-    parser.add_argument(
-        "--no-upload", action="store_true", help="Skip Hugging Face upload."
-    )
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--dataset-prefix", default="toolscale-v4")
+    parser.add_argument("--output-dir")
+    parser.add_argument("--source-parquet")
+    parser.add_argument("--target-repo")
+    parser.add_argument("--hf-token")
+    parser.add_argument("--hf-private", action="store_true")
+    parser.add_argument("--no-upload", action="store_true")
     return parser
 
 
-BASE_DOCKERFILE = """\
-FROM ubuntu:24.04
-
-WORKDIR /workspace
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-
-RUN apt-get update && \\
-    apt-get install -y --no-install-recommends \\
-        python3 \\
-        python3-pip \\
-        curl \\
-        jq \\
-        git \\
-    && rm -rf /var/lib/apt/lists/*
-
-CMD ["/bin/bash"]
-"""
-
-
-def _format_instruction_section(title: str, body: Optional[str]) -> List[str]:
-    if not body:
-        return []
-    cleaned = body.strip()
-    if not cleaned:
-        return []
-    return ["", f"## {title}", cleaned]
-
-
-def _render_instruction(row: Dict[str, object]) -> str:
-    scenario = row.get("user_scenario") or {}
-    scenario_instructions = (
-        scenario.get("instructions") if isinstance(scenario, dict) else {}
-    )
-    eval_criteria = row.get("evaluation_criteria") or {}
-
-    lines: List[str] = ["# ToolScale Bug Fix Task"]
-
-    domain = (
-        scenario_instructions.get("domain")
-        if isinstance(scenario_instructions, dict)
-        else None
-    )
-    if domain:
-        lines.append(f"- **Domain:** {domain}")
-    persona = scenario.get("persona") if isinstance(scenario, dict) else None
-    if persona:
-        lines.append(f"- **Persona:** {persona}")
-    if row.get("id"):
-        lines.append(f"- **Scenario ID:** {row['id']}")
-
-    if isinstance(scenario_instructions, dict):
-        lines.extend(
-            _format_instruction_section(
-                "Task Instructions", scenario_instructions.get("task_instructions")
-            )
+def source_path(explicit_path: str | None) -> Path:
+    if explicit_path:
+        return Path(explicit_path)
+    return Path(
+        hf_hub_download(
+            SOURCE_REPO,
+            SOURCE_FILE,
+            repo_type="dataset",
+            revision=SOURCE_REVISION,
         )
-        lines.extend(
-            _format_instruction_section(
-                "Reason for Request", scenario_instructions.get("reason_for_call")
-            )
-        )
-        lines.extend(
-            _format_instruction_section(
-                "Known Information", scenario_instructions.get("known_info")
-            )
-        )
-        lines.extend(
-            _format_instruction_section(
-                "Unknown Information", scenario_instructions.get("unknown_info")
-            )
-        )
-
-    initial_state = row.get("initial_state")
-    if initial_state:
-        lines.extend(
-            ["", "## Initial State", json.dumps(initial_state, indent=2, default=str)]
-        )
-
-    actions = eval_criteria.get("actions") if isinstance(eval_criteria, dict) else None
-    if isinstance(actions, Sequence) and actions:
-        lines.append("")
-        lines.append("## Recommended Tool Actions")
-        for action in actions:
-            name = action.get("name")
-            args = action.get("arguments")
-            summary = f"- `{name}`"
-            if isinstance(args, dict):
-                filtered = {
-                    k: v for k, v in args.items() if v not in (None, "", [], {}, 0)
-                }
-                if filtered:
-                    summary += f" with args {json.dumps(filtered, default=str)}"
-            lines.append(summary)
-
-    communicate_info = (
-        eval_criteria.get("communicate_info")
-        if isinstance(eval_criteria, dict)
-        else None
-    )
-    if communicate_info:
-        lines.extend(
-            [
-                "",
-                "## Information to Surface",
-                *[f"- {item}" for item in communicate_info],
-            ]
-        )
-
-    nl_assertions = (
-        eval_criteria.get("nl_assertions") if isinstance(eval_criteria, dict) else None
-    )
-    if nl_assertions:
-        lines.extend(
-            [
-                "",
-                "## Success Criteria (Natural Language Assertions)",
-                *[f"- {assertion}" for assertion in nl_assertions],
-            ]
-        )
-
-    lines.extend(
-        [
-            "",
-            "## Deliverable",
-            (
-                "Use available tools and reasoning to satisfy the scenario. "
-                "Write a concise client-ready summary to `/workspace/response.md`. "
-                "Explicitly cover the requested information and reference each assertion above."
-            ),
-            "",
-            "Verification is handled by an OpenAI-powered judge that reads your `response.md` "
-            "and the scenario assertions. Make sure your response stands alone, cites specific "
-            "details, and clearly answers all unknowns.",
-        ]
-    )
-    return "\n".join(lines).strip() + "\n"
-
-
-def _render_solution_script(row: Dict[str, object]) -> str:
-    eval_criteria = row.get("evaluation_criteria") or {}
-
-    summary_lines = ["This oracle response summarizes the key ToolScale requirements."]
-
-    actions = eval_criteria.get("actions") if isinstance(eval_criteria, dict) else None
-    if isinstance(actions, Sequence) and actions:
-        summary_lines.append("")
-        summary_lines.append("Actions referenced:")
-        for action in actions:
-            name = action.get("name", "unknown_action")
-            args = action.get("arguments")
-            if isinstance(args, dict):
-                filtered = {
-                    k: v for k, v in args.items() if v not in (None, "", [], {}, 0)
-                }
-            else:
-                filtered = {}
-            summary_lines.append(f"- {name} {json.dumps(filtered, default=str)}")
-
-    communicate_info = (
-        eval_criteria.get("communicate_info")
-        if isinstance(eval_criteria, dict)
-        else None
-    )
-    if communicate_info:
-        summary_lines.append("")
-        summary_lines.append("Information to communicate:")
-        for info in communicate_info:
-            summary_lines.append(f"- {info}")
-
-    nl_assertions = (
-        eval_criteria.get("nl_assertions") if isinstance(eval_criteria, dict) else None
-    )
-    if nl_assertions:
-        summary_lines.append("")
-        summary_lines.append("NL assertions to satisfy:")
-        for assertion in nl_assertions:
-            summary_lines.append(f"- {assertion}")
-
-    content = "\n".join(summary_lines).strip() + "\n"
-    escaped = content.replace("EOF", "EO F")
-
-    return dedent(
-        f"""\
-        #!/usr/bin/env bash
-        set -Eeuo pipefail
-
-        RESPONSE_PATH="/workspace/response.md"
-        mkdir -p "$(dirname "$RESPONSE_PATH")"
-
-        cat <<'EOF' > "$RESPONSE_PATH"
-        {escaped}
-        EOF
-        """
     )
 
 
-def _llm_verifier_instruction(instruction_md: str, nl_assertions: Sequence[str]) -> str:
-    assertions_list = [a.strip() for a in nl_assertions if a and a.strip()]
-    if not assertions_list:
-        return instruction_md
-
-    assertions_block = "\n".join(f"- {assertion}" for assertion in assertions_list)
-    combined_sections = [
-        instruction_md.rstrip(),
-        "",
-        "## Success Criteria",
-        assertions_block,
-    ]
-    return "\n".join(section for section in combined_sections if section).strip()
+def source_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for batch in pq.ParquetFile(path).iter_batches(batch_size=BATCH_SIZE):
+        rows.extend(row for row in batch.to_pylist() if selected_by_v3(row))
+    return rows
 
 
-def _select_rows(ds: Dataset, offset: int, limit: Optional[int]) -> List[int]:
-    total = len(ds)
-    if offset < 0:
-        offset = 0
-    if offset >= total:
-        return []
-    end = total if limit in (None, 0, -1) else min(total, offset + limit)
-    return list(range(offset, end))
-
-
-def generate_tasks(args: argparse.Namespace) -> Tuple[Path, Dict[str, object]]:
-    dataset = load_dataset(DATASET_NAME, split=args.split)
-    indices = _select_rows(dataset, args.offset, args.limit)
-
-    temp_root = Path(tempfile.mkdtemp(prefix="toolscale_tasks_"))
-    produced = 0
-    skipped: List[Dict[str, object]] = []
-
-    for idx in indices:
-        row = dataset[idx]
-        eval_criteria = row.get("evaluation_criteria") or {}
-        nl_assertions = (
-            eval_criteria.get("nl_assertions")
-            if isinstance(eval_criteria, dict)
-            else None
-        )
-        if not nl_assertions:
-            skipped.append(
-                {"index": idx, "reason": "missing nl_assertions", "id": row.get("id")}
-            )
-            continue
-
-        instruction_content = _render_instruction(row)
-        solution_content = _render_solution_script(row)
-        verifier_instruction = _llm_verifier_instruction(
-            instruction_content, nl_assertions
-        )
-        test_sh_content = create_pytest_sh()
-        test_py_content = create_test_state_py(verifier_instruction)
-
+def generate_tasks(args: argparse.Namespace) -> tuple[Path, dict[str, object]]:
+    rows = source_rows(source_path(args.source_parquet))
+    catalog = build_domain_catalog(rows)
+    start = max(0, args.offset)
+    selected = rows[start : None if args.limit <= 0 else start + args.limit]
+    output = Path(tempfile.mkdtemp(prefix="toolscale-v4-tasks-"))
+    for selected_index, row in enumerate(selected, start=start):
+        task_id = f"toolscale-v4-{selected_index:04d}"
+        fixture = expected_fixture(row, task_id)
         metadata = {
-            "source": DATASET_NAME,
-            "split": args.split,
             "id": row.get("id"),
-            "description": row.get("description"),
+            "repair": "fixture_backed_tool_execution_v4",
+            "source": f"{SOURCE_REPO}@{SOURCE_REVISION}",
+            "source_index": selected_index,
         }
-
-        create_task_directory_unified(
-            output_dir=temp_root,
-            task_id=produced,
-            instruction_content=instruction_content,
-            dataset_prefix=args.dataset_prefix,
-            metadata=metadata,
-            solution_content=solution_content,
-            test_sh_content=test_sh_content,
-            test_py_content=test_py_content,
-            dockerfile_content=BASE_DOCKERFILE,
+        task_dir = Path(
+            create_task_directory_unified(
+                output_dir=output,
+                task_id=selected_index,
+                instruction_content=render_instruction(row, task_id),
+                dataset_prefix=args.dataset_prefix,
+                metadata=metadata,
+                solution_content=render_solution(fixture),
+                test_sh_content=render_test_sh(),
+                test_py_content=render_check(),
+                task_toml_content=TASK_TOML,
+                dockerfile_content=DOCKERFILE,
+            )
         )
-        produced += 1
-
-    if produced == 0:
-        raise RuntimeError(
-            "No ToolScale tasks generated. Relax filters or check dataset."
+        (task_dir / "tests" / "test_state.py").rename(task_dir / "tests" / "check.py")
+        (task_dir / "environment" / "toolscale_runtime.py").write_text(
+            render_runtime(fixture, catalog[task_domain(row)]), encoding="utf-8"
         )
-
-    artifacts: Dict[str, object] = {
-        "dataset": DATASET_NAME,
-        "split": args.split,
-        "produced_tasks": produced,
-        "skipped": skipped,
+        (task_dir / "tests" / "expected.json").write_text(
+            json.dumps(fixture, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if not selected:
+        raise RuntimeError("No ToolScale tasks selected")
+    return output, {
+        "produced_tasks": len(selected),
+        "source": SOURCE_REPO,
+        "source_revision": SOURCE_REVISION,
     }
-    return temp_root, artifacts
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate ToolScale Harbor tasks.")
-    add_toolscale_args(parser)
+    parser = add_toolscale_args(argparse.ArgumentParser(description=__doc__))
     args = parser.parse_args()
-
-    dataset_dir, artifacts = generate_tasks(args)
-    final_path = finalize_dataset_output(dataset_dir, args.output_dir)
-
-    print(json.dumps({"output_dir": str(final_path), **artifacts}, indent=2))
-
+    generated, metadata = generate_tasks(args)
+    final_path = finalize_dataset_output(generated, args.output_dir)
+    print(json.dumps({"output_dir": str(final_path), **metadata}, indent=2))
     if args.target_repo and not args.no_upload:
         upload_tasks_to_hf(
             dataset_path=str(final_path),

--- a/tests/data/toolscale/test_deterministic_execution.py
+++ b/tests/data/toolscale/test_deterministic_execution.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+from data.toolscale.deterministic_execution import (
+    build_domain_catalog,
+    expected_fixture,
+    render_check,
+    render_runtime,
+)
+
+
+def _source_row() -> dict:
+    return {
+        "id": "calendar-1",
+        "user_scenario": {
+            "instructions": {
+                "domain": "calendar",
+                "task_instructions": "Find the design review.",
+                "known_info": "The attendee is user-7.",
+            }
+        },
+        "evaluation_criteria": {
+            "actions": [
+                {
+                    "name": "find_events",
+                    "arguments": {"attendee_id": "user-7", "day": "2026-09-01"},
+                }
+            ],
+            "nl_assertions": ["The design review starts at 10:00."],
+        },
+    }
+
+
+def _runtime(tmp_path):
+    row = _source_row()
+    fixture = expected_fixture(row, "toolscale-v4-0000")
+    catalog = build_domain_catalog([row])["calendar"]
+    runtime_path = tmp_path / "toolscale_runtime.py"
+    runtime_path.write_text(render_runtime(fixture, catalog))
+    return fixture, runtime_path
+
+
+def test_fixture_backed_runtime_and_verifier_accept_executed_call(tmp_path) -> None:
+    fixture, runtime_path = _runtime(tmp_path)
+    app_dir = tmp_path / "app"
+    tests_dir = tmp_path / "tests"
+    app_dir.mkdir()
+    tests_dir.mkdir()
+    log_path = app_dir / "toolscale_calls.jsonl"
+    arguments = json.dumps(fixture["calls"][0]["arguments"])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            runtime_path,
+            "call",
+            "--task-id",
+            fixture["task_id"],
+            "--tool",
+            fixture["calls"][0]["name"],
+            "--arguments",
+            arguments,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "TOOL_SCALE_LOG": str(log_path)},
+    )
+    call_result = json.loads(result.stdout)
+    assert call_result["evidence_id"] == fixture["calls"][0]["evidence_id"]
+    assert json.loads(log_path.read_text()) == call_result
+
+    (tests_dir / "expected.json").write_text(json.dumps(fixture))
+    check_path = tests_dir / "check.py"
+    check_path.write_text(render_check())
+    (app_dir / "response.md").write_text(
+        f"{fixture['assertions'][0]}\n{fixture['calls'][0]['evidence_id']}\n"
+    )
+    verifier = subprocess.run(
+        [sys.executable, check_path],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "APP_DIR": str(app_dir),
+            "TOOL_SCALE_TESTS_DIR": str(tests_dir),
+        },
+    )
+    assert verifier.returncode == 0, verifier.stderr
+
+
+def test_runtime_rejects_non_fixture_arguments_without_logging(tmp_path) -> None:
+    fixture, runtime_path = _runtime(tmp_path)
+    log_path = tmp_path / "toolscale_calls.jsonl"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            runtime_path,
+            "call",
+            "--task-id",
+            fixture["task_id"],
+            "--tool",
+            fixture["calls"][0]["name"],
+            "--arguments",
+            json.dumps({"attendee_id": "another-user", "day": "2026-09-01"}),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "TOOL_SCALE_LOG": str(log_path)},
+    )
+    assert result.returncode != 0
+    assert "no fixture-backed result" in result.stderr
+    assert not log_path.exists()


### PR DESCRIPTION
Replace ToolScale's synthetic result path with an offline fixture-backed runtime. The catalog remains domain-wide, inspection exposes ungrouped candidate argument values, and the verifier requires the exact calls and evidence IDs in the submitted response.

Preserve the newer TaskTrove and RewardKit implementations already on `main` instead of replaying their older branch variants. Behavior tests execute the generated runtime and verifier and reject non-fixture calls without recording them.
