### PR TITLE
[data] Preserve TaskTrove storage requirements

### DIFF
--- a/data/codeforces/generate.py
+++ b/data/codeforces/generate.py
@@ -32,6 +32,9 @@ timeout_sec = 300.0
 
 [agent]
 timeout_sec = 600.0
+
+[environment]
+storage_mb = 4096
 """
 
 DOCKERFILE = """FROM ubuntu:24.04

--- a/data/codeforces/generate_abstract.py
+++ b/data/codeforces/generate_abstract.py
@@ -38,6 +38,9 @@ timeout_sec = 300.0
 
 [agent]
 timeout_sec = 600.0
+
+[environment]
+storage_mb = 4096
 """
 
 DOCKERFILE = """FROM ubuntu:24.04

--- a/data/tasktrove/assemble_storage_release.py
+++ b/data/tasktrove/assemble_storage_release.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Assemble validated storage-repair outputs into one TaskTrove release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from data.tasktrove.build_storage_repair import file_sha256, validate_output
+
+
+def assemble(args: argparse.Namespace) -> None:
+    if args.stage.exists() and any(args.stage.iterdir()):
+        raise ValueError(f"release stage must be absent or empty: {args.stage}")
+    args.stage.mkdir(parents=True, exist_ok=True)
+    datasets = []
+    for manifest_path in args.manifests:
+        manifest = json.loads(manifest_path.read_text())
+        source = manifest_path.parent / manifest["output"]
+        if file_sha256(source) != manifest["output_sha256"]:
+            raise ValueError(f"output hash mismatch: {source}")
+        validate_output(
+            source, int(manifest["output_rows"]), int(manifest["storage_mb"])
+        )
+        relative = Path("datasets") / manifest["output_dataset"] / "tasks.parquet"
+        destination = args.stage / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.hardlink_to(source)
+        datasets.append({**manifest, "output": str(relative)})
+    source_names = [dataset["source_dataset"] for dataset in datasets]
+    output_names = [dataset["output_dataset"] for dataset in datasets]
+    if len(source_names) != len(set(source_names)):
+        raise ValueError("duplicate source dataset")
+    if len(output_names) != len(set(output_names)):
+        raise ValueError("duplicate output dataset")
+    source_revisions = {dataset["source_revision"] for dataset in datasets}
+    if source_revisions != {args.source_revision}:
+        raise ValueError(f"wrong source revisions: {sorted(source_revisions)}")
+    release = {
+        "source_repo": "open-thoughts/TaskTrove",
+        "source_revision": args.source_revision,
+        "source_version": args.source_version,
+        "target_version": args.target_version,
+        "datasets": datasets,
+    }
+    (args.stage / "manifest.json").write_text(json.dumps(release, indent=2) + "\n")
+    print(json.dumps(release, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", type=Path, required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--source-version", required=True)
+    parser.add_argument("--target-version", required=True)
+    parser.add_argument("--manifests", type=Path, nargs="+", required=True)
+    assemble(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/data/tasktrove/build_storage_repair.py
+++ b/data/tasktrove/build_storage_repair.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Build bounded-memory TaskTrove revisions with larger task storage."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import re
+import tarfile
+from pathlib import Path, PurePosixPath
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from harbor_config.models.task.config import TaskConfig
+from huggingface_hub import hf_hub_download
+
+TASKTROVE_REPO = "open-thoughts/TaskTrove"
+TASK_SCHEMA = pa.schema([("path", pa.string()), ("task_binary", pa.binary())])
+MAX_BATCH_ROWS = 32
+MIN_TASKS = 300
+REQUIRED_MEMBERS = frozenset(
+    {"environment/Dockerfile", "instruction.md", "task.toml", "tests/test.sh"}
+)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_task(task_binary: bytes) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    with tarfile.open(fileobj=io.BytesIO(task_binary), mode="r:gz") as archive:
+        for member in archive.getmembers():
+            path = PurePosixPath(member.name)
+            if (
+                not member.name
+                or path.is_absolute()
+                or ".." in path.parts
+                or path.as_posix() != member.name
+            ):
+                raise ValueError(f"unsafe archive member path: {member.name!r}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"archive links are forbidden: {member.name!r}")
+            if member.isdir():
+                continue
+            if not member.isfile():
+                raise ValueError(f"unsupported archive member: {member.name!r}")
+            if member.name in files:
+                raise ValueError(f"duplicate archive member: {member.name!r}")
+            extracted = archive.extractfile(member)
+            assert extracted is not None
+            files[member.name] = extracted.read()
+    return files
+
+
+def write_task(files: dict[str, bytes]) -> bytes:
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as archive:
+        for name, content in sorted(files.items()):
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            info.mtime = 0
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            info.mode = 0o755 if name.endswith(".sh") else 0o644
+            archive.addfile(info, io.BytesIO(content))
+    return gzip.compress(raw.getvalue(), compresslevel=6, mtime=0)
+
+
+def task_toml_with_storage(
+    task_toml: bytes, expected_storage_mb: int | None, storage_mb: int
+) -> bytes:
+    source = task_toml.decode("utf-8")
+    config = TaskConfig.model_validate_toml(source)
+    current = config.environment.storage_mb
+    if current != expected_storage_mb:
+        raise ValueError(
+            f"task declares storage_mb={current}, expected {expected_storage_mb}"
+        )
+    environment = re.search(r"(?m)^\[environment\][ \t]*(?:#.*)?$", source)
+    if environment is None:
+        suffix = "" if source.endswith("\n") else "\n"
+        transformed = f"{source}{suffix}\n[environment]\nstorage_mb = {storage_mb}\n"
+    else:
+        next_table = re.search(r"(?m)^\[", source[environment.end() :])
+        section_end = (
+            len(source)
+            if next_table is None
+            else environment.end() + next_table.start()
+        )
+        section = source[environment.end() : section_end]
+        declaration = re.search(
+            r"(?m)^(storage_mb[ \t]*=[ \t]*)\d+([ \t]*(?:#.*)?)$", section
+        )
+        if current is None:
+            transformed = (
+                source[: environment.end()]
+                + f"\nstorage_mb = {storage_mb}"
+                + source[environment.end() :]
+            )
+        else:
+            if declaration is None:
+                raise ValueError("parsed storage_mb has no replaceable declaration")
+            start = environment.end() + declaration.start()
+            end = environment.end() + declaration.end()
+            replacement = f"{declaration.group(1)}{storage_mb}{declaration.group(2)}"
+            transformed = source[:start] + replacement + source[end:]
+    parsed = TaskConfig.model_validate_toml(transformed)
+    if parsed.environment.storage_mb != storage_mb:
+        raise ValueError("transformed task has the wrong storage requirement")
+    return transformed.encode("utf-8")
+
+
+def source_parquet(args: argparse.Namespace) -> Path:
+    if args.source_parquet is not None:
+        return args.source_parquet.resolve()
+    return Path(
+        hf_hub_download(
+            TASKTROVE_REPO,
+            f"{args.source_dataset}/tasks.parquet",
+            repo_type="dataset",
+            revision=args.source_revision,
+            local_dir=args.stage / "source",
+        )
+    )
+
+
+def validate_output(path: Path, expected_rows: int, storage_mb: int) -> None:
+    parquet = pq.ParquetFile(path)
+    if parquet.schema_arrow != TASK_SCHEMA:
+        raise ValueError(f"unexpected output schema: {parquet.schema_arrow}")
+    if parquet.metadata.num_rows != expected_rows:
+        raise ValueError("output row count changed")
+    seen: set[str] = set()
+    for group in range(parquet.metadata.num_row_groups):
+        if parquet.metadata.row_group(group).num_rows > MAX_BATCH_ROWS:
+            raise ValueError("output row group exceeds bounded batch size")
+    for batch in parquet.iter_batches(batch_size=MAX_BATCH_ROWS):
+        for row in batch.to_pylist():
+            path_value = row["path"]
+            if path_value in seen:
+                raise ValueError(f"duplicate task path: {path_value}")
+            seen.add(path_value)
+            files = read_task(row["task_binary"])
+            if not REQUIRED_MEMBERS <= files.keys():
+                raise ValueError(f"incomplete task: {path_value}")
+            config = TaskConfig.model_validate_toml(files["task.toml"].decode())
+            if config.environment.storage_mb != storage_mb:
+                raise ValueError(f"wrong storage requirement: {path_value}")
+
+
+def build(args: argparse.Namespace) -> None:
+    if args.storage_mb <= 0 or args.storage_mb % 1024:
+        raise ValueError("storage_mb must be a positive whole number of GiB")
+    source = source_parquet(args)
+    if file_sha256(source) != args.source_sha256:
+        raise ValueError("source Parquet hash mismatch")
+    parquet = pq.ParquetFile(source)
+    if parquet.schema_arrow != TASK_SCHEMA:
+        raise ValueError(f"unexpected source schema: {parquet.schema_arrow}")
+    if parquet.metadata.num_rows < MIN_TASKS:
+        raise ValueError(f"source violates the {MIN_TASKS}-task floor")
+
+    output = args.stage / "datasets" / args.output_dataset / "tasks.parquet"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        raise FileExistsError(output)
+    writer = pq.ParquetWriter(
+        output,
+        TASK_SCHEMA,
+        compression="zstd",
+        use_dictionary=False,
+        write_statistics=True,
+    )
+    rows = 0
+    try:
+        for batch in parquet.iter_batches(batch_size=MAX_BATCH_ROWS):
+            transformed_rows = []
+            for row in batch.to_pylist():
+                original = read_task(row["task_binary"])
+                if not REQUIRED_MEMBERS <= original.keys():
+                    raise ValueError(f"incomplete task: {row['path']}")
+                transformed = dict(original)
+                transformed["task.toml"] = task_toml_with_storage(
+                    original["task.toml"],
+                    args.expected_current_storage_mb,
+                    args.storage_mb,
+                )
+                changed = {
+                    name
+                    for name in original.keys() | transformed.keys()
+                    if original.get(name) != transformed.get(name)
+                }
+                if changed != {"task.toml"}:
+                    raise ValueError(f"unexpected changed members: {sorted(changed)}")
+                transformed_rows.append(
+                    {"path": row["path"], "task_binary": write_task(transformed)}
+                )
+            writer.write_table(
+                pa.Table.from_pylist(transformed_rows, schema=TASK_SCHEMA)
+            )
+            rows += len(transformed_rows)
+    finally:
+        writer.close()
+
+    validate_output(output, rows, args.storage_mb)
+    report = {
+        "source_repo": TASKTROVE_REPO,
+        "source_revision": args.source_revision,
+        "source_dataset": args.source_dataset,
+        "source_rows": parquet.metadata.num_rows,
+        "source_sha256": args.source_sha256,
+        "output_dataset": args.output_dataset,
+        "output_rows": rows,
+        "output_sha256": file_sha256(output),
+        "storage_mb": args.storage_mb,
+        "output": str(output.relative_to(args.stage)),
+    }
+    (args.stage / "manifest.json").write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", type=Path, required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--source-dataset", required=True)
+    parser.add_argument("--source-sha256", required=True)
+    parser.add_argument("--output-dataset", required=True)
+    parser.add_argument("--storage-mb", type=int, required=True)
+    parser.add_argument("--expected-current-storage-mb", type=int)
+    parser.add_argument("--source-parquet", type=Path)
+    build(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/data/tasktrove/publish_storage_release.py
+++ b/data/tasktrove/publish_storage_release.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Publish, verify, tag, and retire standalones for a TaskTrove storage release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+from huggingface_hub import (
+    CommitOperationAdd,
+    CommitOperationDelete,
+    HfApi,
+    hf_hub_download,
+)
+
+REPO_ID = "open-thoughts/TaskTrove"
+UPLOAD_THREADS = 1
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def dataset_label(name: str) -> str:
+    return name.replace("__", "/", 1)
+
+
+def repo_files(api: HfApi, repo: str, revision: str) -> dict[str, object]:
+    return {
+        item.path: item
+        for item in api.list_repo_tree(
+            repo, repo_type="dataset", revision=revision, recursive=True, expand=True
+        )
+        if hasattr(item, "blob_id")
+    }
+
+
+def file_identity(item: object) -> tuple[str, int]:
+    lfs = getattr(item, "lfs", None)
+    digest = lfs.sha256 if lfs is not None else str(getattr(item, "blob_id"))
+    return digest, int(getattr(item, "size"))
+
+
+def updated_readme(source: str, manifest: dict[str, object]) -> str:
+    source_version = str(manifest["source_version"])
+    target_version = str(manifest["target_version"])
+    datasets = manifest["datasets"]
+    lines = "\n".join(
+        f"> - `{dataset_label(dataset['source_dataset'])}` → "
+        f"`{dataset_label(dataset['output_dataset'])}`: "
+        f"{int(dataset['storage_mb']) // 1024} GiB storage "
+        f"({int(dataset['output_rows']):,} tasks)"
+        for dataset in datasets
+    )
+    note = (
+        f"> **v{target_version} (current)** — task storage remediation — "
+        f"replaces {len(datasets)} source{'s' if len(datasets) != 1 else ''} with "
+        "explicit task-level storage requirements. All other packaged task files are "
+        "preserved byte-for-byte, every source remains above the 300-task floor, and "
+        "the new versions are hosted only inside TaskTrove. Historical rewards from "
+        "the superseded versions are excluded.\n>\n"
+        f"{lines}\n>\n"
+    )
+    marker = f"> **v{source_version} (current)**"
+    if marker not in source:
+        raise ValueError(f"README does not identify v{source_version} as current")
+    return source.replace(marker, note + f"> **v{source_version}**", 1)
+
+
+def prepare_standalones(
+    api: HfApi, stage: Path, manifest: dict[str, object]
+) -> tuple[dict[str, Path], list[str]]:
+    deprecated: dict[str, Path] = {}
+    existing = []
+    for dataset in manifest["datasets"]:
+        source_name = dataset["source_dataset"]
+        repo = dataset_label(source_name)
+        if not api.repo_exists(repo, repo_type="dataset"):
+            continue
+        existing.append(repo)
+        files = repo_files(api, repo, "main")
+        remote = files.get("tasks.parquet")
+        if remote is None:
+            raise ValueError(f"standalone lacks tasks.parquet: {repo}")
+        if file_identity(remote)[0] == dataset["source_sha256"]:
+            continue
+        downloaded = Path(
+            hf_hub_download(
+                repo,
+                "tasks.parquet",
+                repo_type="dataset",
+                token=api.token,
+                local_dir=stage / "standalone-provenance" / source_name,
+            )
+        )
+        if file_sha256(downloaded) == dataset["source_sha256"]:
+            raise ValueError(f"standalone metadata mismatch: {repo}")
+        deprecated[source_name] = downloaded
+    return deprecated, existing
+
+
+def publish(stage: Path) -> str:
+    manifest_path = stage / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    source_revision = manifest["source_revision"]
+    target_version = manifest["target_version"]
+    api = HfApi(token=os.environ["HF_TOKEN"])
+    if api.repo_info(REPO_ID, repo_type="dataset").sha != source_revision:
+        raise ValueError("TaskTrove changed after the release build")
+    tag = f"v{target_version}"
+    if any(
+        ref.name == tag for ref in api.list_repo_refs(REPO_ID, repo_type="dataset").tags
+    ):
+        raise ValueError(f"tag already exists: {tag}")
+    current = repo_files(api, REPO_ID, source_revision)
+    for dataset in manifest["datasets"]:
+        source_path = f"{dataset['source_dataset']}/tasks.parquet"
+        output_path = f"{dataset['output_dataset']}/tasks.parquet"
+        if source_path not in current:
+            raise ValueError(f"missing source: {source_path}")
+        if file_identity(current[source_path])[0] != dataset["source_sha256"]:
+            raise ValueError(f"source hash mismatch: {source_path}")
+        if output_path in current:
+            raise ValueError(f"target already exists: {output_path}")
+
+    readme_source = Path(
+        hf_hub_download(
+            REPO_ID, "README.md", repo_type="dataset", revision=source_revision
+        )
+    ).read_text()
+    readme = stage / f"README-v{target_version}.md"
+    readme.write_text(updated_readme(readme_source, manifest))
+    deprecated, standalone_repos = prepare_standalones(api, stage, manifest)
+    manifest["standalone_repositories"] = standalone_repos
+    manifest["deprecated_standalones"] = {
+        dataset: {
+            "output": f"deprecated/{dataset}/tasks.parquet",
+            "sha256": file_sha256(path),
+        }
+        for dataset, path in deprecated.items()
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    operations: list[CommitOperationAdd | CommitOperationDelete] = [
+        CommitOperationAdd("README.md", readme)
+    ]
+    for dataset in manifest["datasets"]:
+        operations.append(CommitOperationDelete(dataset["source_dataset"]))
+        operations.append(
+            CommitOperationAdd(
+                f"{dataset['output_dataset']}/tasks.parquet", stage / dataset["output"]
+            )
+        )
+    for dataset, path in deprecated.items():
+        operations.append(
+            CommitOperationAdd(f"deprecated/{dataset}/tasks.parquet", path)
+        )
+    commit = api.create_commit(
+        REPO_ID,
+        repo_type="dataset",
+        operations=operations,
+        commit_message=f"TaskTrove v{target_version}: increase task storage",
+        parent_commit=source_revision,
+        num_threads=UPLOAD_THREADS,
+    )
+    return commit.oid
+
+
+def verify_and_retire(stage: Path, commit: str) -> None:
+    manifest = json.loads((stage / "manifest.json").read_text())
+    source_revision = manifest["source_revision"]
+    target_version = manifest["target_version"]
+    api = HfApi(token=os.environ["HF_TOKEN"])
+    before = repo_files(api, REPO_ID, source_revision)
+    after = repo_files(api, REPO_ID, commit)
+    replaced = tuple(
+        f"{dataset['source_dataset']}/" for dataset in manifest["datasets"]
+    )
+    expected = {
+        path for path in before if path != "README.md" and not path.startswith(replaced)
+    }
+    expected.add("README.md")
+    expected.update(
+        f"{dataset['output_dataset']}/tasks.parquet" for dataset in manifest["datasets"]
+    )
+    expected.update(
+        item["output"] for item in manifest["deprecated_standalones"].values()
+    )
+    if set(after) != expected:
+        raise ValueError(
+            f"unexpected remote tree: missing={sorted(expected - set(after))}, "
+            f"extra={sorted(set(after) - expected)}"
+        )
+    for path, item in before.items():
+        if path == "README.md" or path.startswith(replaced):
+            continue
+        if file_identity(after[path]) != file_identity(item):
+            raise ValueError(f"untouched file changed: {path}")
+    for dataset in manifest["datasets"]:
+        output = f"{dataset['output_dataset']}/tasks.parquet"
+        if file_identity(after[output])[0] != dataset["output_sha256"]:
+            raise ValueError(f"remote output hash mismatch: {output}")
+    readme = Path(
+        hf_hub_download(REPO_ID, "README.md", repo_type="dataset", revision=commit)
+    ).read_text()
+    if not re.search(
+        rf"^> \*\*v{re.escape(target_version)} \(current\)\*\*", readme, re.MULTILINE
+    ):
+        raise ValueError("remote README has the wrong current version")
+    api.create_tag(
+        REPO_ID, tag=f"v{target_version}", repo_type="dataset", revision=commit
+    )
+    for repo in manifest["standalone_repositories"]:
+        if api.repo_exists(repo, repo_type="dataset"):
+            api.delete_repo(repo, repo_type="dataset")
+        if api.repo_exists(repo, repo_type="dataset"):
+            raise ValueError(f"standalone remains: {repo}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", type=Path, required=True)
+    parser.add_argument("--commit")
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--verify-and-retire", action="store_true")
+    args = parser.parse_args()
+    commit = args.commit
+    if args.publish:
+        commit = publish(args.stage)
+        print(commit)
+    if args.verify_and_retire:
+        if commit is None:
+            raise ValueError("--commit is required without --publish")
+        verify_and_retire(args.stage, commit)
+        print(f"verified {commit}, tagged, and retired standalones")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Declare 4 GiB in Codeforces generator task configs so future packages retain the TaskTrove v4.2 resource requirement.

Add the bounded deterministic release path used for TaskTrove v4.2 and v4.3. It rewrites only `task.toml`, checks archives, task configs, row counts, and hashes, caps Parquet batches at 32 rows and uploads at one thread, then verifies remote tree identity before tagging and retiring byte-identical standalone repositories.

The v4.2 and v4.3 releases are live at Hugging Face commits `74f0d6c6` and `4bb342e0`. V4.3 replaces 13 exact-current sources with ENOSPC evidence, covering 94,458 tasks: six move from the 2 GiB default to 4 GiB, and seven move from 10 GiB to 20 GiB. Two complete builds produced identical output hashes. The repository test suite passed 635 tests with 2 skips.
