### PR TITLE
Store Jupiter RL trials in a sparse image

### DIFF
--- a/.agents/ops/jupiter/ops.md
+++ b/.agents/ops/jupiter/ops.md
@@ -50,6 +50,24 @@ rsync -avz --progress -e "ssh -i ~/.ssh/id_ed25519_jsc -4" \
 - **Never `find` or `du` on Jupiter GPFS** (`/e/scratch`, `/e/data1`) — `stat`-walks stall the SSH session for minutes. Locate logs/dirs via canonical paths + depth-1 `ls -td <dir>/*JOBID*`, `ls | wc -l`, or `squeue -j JOBID -o '%Z'` (the `%Z` workdir). Same caution on Perlmutter/Leonardo parallel FS.
 - **Cleanup subagents must bake these rules into their prompt** (no inherited memory): never `du`/`find` to size or locate; **detach** long `rm -rf` (`nohup … &` or a tmux session logging `RM_DONE <dir> exit=$?`) and EXIT — do NOT poll a multi-hundred-thousand-file GPFS delete (idempotent/resumable).
 
+## Image-backed RL trial artifacts
+
+RL configs can set `container.artifact_store.enabled: true`. The launcher creates a sparse ext4 image under the durable inner run root, and each chain link mounts it on the Ray head before Apptainer and Ray start. The SkyRL entrypoint and Harbor coordinators are pinned to that node. Check `artifact_authority.json` for the active Slurm job, node, mount, and trial paths.
+
+Never mount `artifact_store.img` from a login node while its Slurm link is running. The image has one read-write authority, enforced by `artifact_store.img.lock`; a second mount can observe inconsistent ext4 metadata. Live inspection must run through the recorded node and mount:
+
+```bash
+srun --overlap --jobid <job_id> -w <node> -N1 -n1 ls <mount>/trace_jobs
+```
+
+After the link exits, repository readers mount the image read-only and release it automatically. For an ad-hoc inspection, use the same helper instead of a loop mount:
+
+```bash
+python -m hpc.artifact_store <run>/artifact_store.img
+```
+
+Every link requests `SIGTERM` 180 seconds before walltime. The batch shell forwards it to MarinSkyRL, waits for cooperative shutdown, then syncs and unmounts the image. A successor obtains the same writer lock, runs `e2fsck -p`, and remounts before resume.
+
 ## Inode quota (the binding constraint) — EDQUOT can masquerade as sig53
 `/e/scratch/jureap59` has a **project-shared inode quota** (~8.0M soft / 8.8M hard, shared across all jureap59 members, 2–4h lag). Datagen jobs create thousands of trial subdirs → inodes bind long before bytes.
 - **Inspect:** `jutil project dataquota -p jureap59 | grep exa_scratch` (project), `df -i /e/scratch` (live), `du -s --inodes <subdir>` (mine — avoid on huge trees).

--- a/.agents/skills/rl-agentic-job-cleanup/SKILL.md
+++ b/.agents/skills/rl-agentic-job-cleanup/SKILL.md
@@ -136,6 +136,7 @@ python -m scripts.harbor.make_and_upload_trace_dataset \
   --repo_id penfever/<job_name> --episodes last --skip_register
 ```
 **Never subsample or cap**: upload the full trial set. The script reads the inner `<job>/<job>` `trace_jobs/`.
+For image-backed Jupiter runs, pass the same inner run root. The exporter detects `artifact_store.img`, refuses an unsafe mount while a writer lock is active, mounts it read-only after the link exits, and unmounts it when export finishes. Legacy bare `trace_jobs/` runs keep the existing path.
 
 > `make_and_upload_trace_dataset` buffers the full dataset; `chunk_size` does not bound peak RAM. Large login-node
 > uploads can OOM; do not respond by sampling.
@@ -158,6 +159,7 @@ cp $EXPERIMENTS_DIR/<job_name>/logs/<job_name>_*.out $UPLOAD_DIR/training_logs/
 hf upload laion/<job_name>-<step>-<size> $UPLOAD_DIR . --repo-type=model   # additive
 ```
 Produces `metrics.csv`, `vllm_metrics.csv`, `trial_stats.csv`, `report.md`, `reward_plot.png`.
+The metrics reader also detects a missing `<run>/trace_jobs` beside `artifact_store.img` and mounts the inactive image read-only for trial statistics.
 **WARNING:** never use `huggingface_hub.upload_folder()` without `delete_patterns=[]` — it deletes files absent
 locally and clobbers the weights. `hf upload` is additive (safe).
 

--- a/hpc/artifact_store.py
+++ b/hpc/artifact_store.py
@@ -1,0 +1,218 @@
+"""Lifecycle and reader helpers for image-backed Harbor trial artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Literal
+
+
+ARTIFACT_STORE_IMAGE = "artifact_store.img"
+ARTIFACT_STORE_MOUNT = "artifact_mnt"
+ARTIFACT_STORE_LOCK_SUFFIX = ".lock"
+ARTIFACT_STORE_AUTHORITY = "artifact_authority.json"
+TRACE_JOBS_SUBDIR = "trace_jobs"
+DEFAULT_IMAGE_SIZE = "1T"
+DEFAULT_INODE_COUNT = 50_000_000
+
+
+class ArtifactStoreBusyError(RuntimeError):
+    """The image has an active writer and cannot be mounted on this host."""
+
+
+@dataclass(frozen=True)
+class ArtifactStorePaths:
+    """Stable files and directories for one image-backed run."""
+
+    image: Path
+    mount: Path
+
+    @property
+    def lock(self) -> Path:
+        return Path(f"{self.image}{ARTIFACT_STORE_LOCK_SUFFIX}")
+
+    @property
+    def trials(self) -> Path:
+        return self.mount / TRACE_JOBS_SUBDIR
+
+
+def paths_for_run(run_dir: Path) -> ArtifactStorePaths:
+    """Return the canonical artifact-store paths below one durable run root."""
+    run_dir = Path(run_dir)
+    return ArtifactStorePaths(
+        image=run_dir / ARTIFACT_STORE_IMAGE,
+        mount=run_dir / ARTIFACT_STORE_MOUNT,
+    )
+
+
+def ensure_image(
+    image_path: Path,
+    *,
+    size: str = DEFAULT_IMAGE_SIZE,
+    inode_count: int = DEFAULT_INODE_COUNT,
+) -> None:
+    """Create a sparse ext4 image atomically, or retain the existing image."""
+    image_path = Path(image_path)
+    if image_path.exists():
+        return
+    if not size or inode_count <= 0:
+        raise ValueError("artifact-store size and inode_count must be positive")
+
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = Path(f"{image_path}{ARTIFACT_STORE_LOCK_SUFFIX}")
+    with lock_path.open("a+b") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        if image_path.exists():
+            return
+        temporary = image_path.with_name(f".{image_path.name}.creating-{os.getpid()}")
+        try:
+            subprocess.run(["truncate", "-s", size, str(temporary)], check=True)
+            subprocess.run(
+                ["mkfs.ext4", "-F", "-N", str(inode_count), str(temporary)],
+                check=True,
+            )
+            os.replace(temporary, image_path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+def write_authority_record(
+    image_path: Path,
+    *,
+    job_id: str,
+    node: str,
+    node_ip: str,
+    mount_path: Path,
+) -> Path:
+    """Publish the live writer location for node-routed readers."""
+    image_path = Path(image_path)
+    record_path = image_path.parent / ARTIFACT_STORE_AUTHORITY
+    temporary = record_path.with_name(f".{record_path.name}.tmp-{os.getpid()}")
+    payload = {
+        "job_id": job_id,
+        "node": node,
+        "node_ip": node_ip,
+        "image": str(image_path),
+        "mount": str(mount_path),
+        "trials": str(Path(mount_path) / TRACE_JOBS_SUBDIR),
+    }
+    temporary.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+    os.replace(temporary, record_path)
+    return record_path
+
+
+def resolve_trials_root(run_dir: Path) -> tuple[Literal["bare", "image"], Path]:
+    """Resolve a legacy trial tree or the image that contains the new tree."""
+    run_dir = Path(run_dir)
+    image_path = run_dir / ARTIFACT_STORE_IMAGE
+    if image_path.is_file():
+        return "image", image_path
+    return "bare", run_dir / TRACE_JOBS_SUBDIR
+
+
+@contextmanager
+def mounted(
+    image_path: Path,
+    mode: Literal["ro", "rw"] = "ro",
+    *,
+    mount_path: Path | None = None,
+) -> Iterator[Path]:
+    """Mount an inactive ext4 image with fuse2fs and unmount it on exit.
+
+    A shared sidecar lock protects read-only mounts and an exclusive lock protects
+    read-write mounts. Both fail while a batch link holds the writer lock.
+    """
+    if mode not in {"ro", "rw"}:
+        raise ValueError(f"unsupported artifact-store mount mode: {mode}")
+
+    image_path = Path(image_path)
+    if not image_path.is_file():
+        raise FileNotFoundError(image_path)
+    lock_path = Path(f"{image_path}{ARTIFACT_STORE_LOCK_SUFFIX}")
+    requested_lock = fcntl.LOCK_SH if mode == "ro" else fcntl.LOCK_EX
+
+    with lock_path.open("a+b") as lock_file:
+        try:
+            fcntl.flock(lock_file, requested_lock | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise ArtifactStoreBusyError(
+                f"artifact store is mounted by an active writer: {image_path}"
+            ) from error
+
+        temporary_mount = None
+        if mount_path is None:
+            temporary_mount = tempfile.TemporaryDirectory(prefix="otagent-artifacts-")
+            resolved_mount = Path(temporary_mount.name)
+        else:
+            resolved_mount = Path(mount_path)
+            resolved_mount.mkdir(parents=True, exist_ok=True)
+
+        mounted_ok = False
+        try:
+            if mode == "rw":
+                check = subprocess.run(["e2fsck", "-p", str(image_path)], check=False)
+                if check.returncode not in {0, 1}:
+                    raise subprocess.CalledProcessError(check.returncode, check.args)
+            subprocess.run(
+                ["fuse2fs", "-o", mode, str(image_path), str(resolved_mount)],
+                check=True,
+            )
+            mounted_ok = True
+            yield resolved_mount
+        finally:
+            if mounted_ok:
+                subprocess.run(["fusermount3", "-u", str(resolved_mount)], check=True)
+            if temporary_mount is not None:
+                temporary_mount.cleanup()
+
+
+@contextmanager
+def open_trials_root(run_dir: Path) -> Iterator[Path]:
+    """Yield the readable trial tree for legacy and image-backed runs."""
+    kind, path = resolve_trials_root(run_dir)
+    if kind == "bare":
+        yield path
+        return
+    with mounted(path, mode="ro") as root:
+        yield root / TRACE_JOBS_SUBDIR
+
+
+@contextmanager
+def open_trials_path(path: Path) -> Iterator[Path]:
+    """Yield a requested trial path, mounting its parent run image if needed."""
+    path = Path(path)
+    if path.is_dir():
+        yield path
+        return
+    if path.name != TRACE_JOBS_SUBDIR:
+        yield path
+        return
+    kind, source = resolve_trials_root(path.parent)
+    if kind == "bare":
+        yield source
+        return
+    with mounted(source, mode="ro") as root:
+        yield root / TRACE_JOBS_SUBDIR
+
+
+def main() -> None:
+    """Mount an inactive image read-only for an interactive inspection."""
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument("image", type=Path)
+    parser.add_argument("--mount-path", type=Path)
+    args = parser.parse_args()
+
+    with mounted(args.image, mode="ro", mount_path=args.mount_path) as root:
+        print(root, flush=True)
+        input("Press Enter to unmount: ")
+
+
+if __name__ == "__main__":
+    main()

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import shlex
 import stat
 import subprocess
@@ -25,6 +26,12 @@ from dataclasses import dataclass, asdict, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
+from hpc.artifact_store import (
+    DEFAULT_IMAGE_SIZE,
+    DEFAULT_INODE_COUNT,
+    ensure_image,
+    write_authority_record,
+)
 from hpc.checkpoint_utils import is_huggingface_repo, pre_download_model
 from hpc.hf_utils import is_hf_dataset_path
 from hpc.launch_utils import get_daytona_api_key_override
@@ -878,6 +885,12 @@ class RLJobConfig:
     # Ray object store size in GB (default: 40)
     ray_object_store_gb: float = 40.0
 
+    # Optional image-backed Harbor trial tree. The sbatch shell mounts the image
+    # before Ray/Apptainer starts and holds its writer lock for the whole link.
+    artifact_store_enabled: bool = False
+    artifact_store_image: Optional[str] = None
+    artifact_store_mount: Optional[str] = None
+
     # Post-training trace upload settings
     trace_upload_enabled: bool = False
     trace_upload_repo_org: str = "DCAgent"
@@ -999,6 +1012,29 @@ def validate_trace_upload_environment(
         )
 
 
+def _parse_artifact_store(container: Mapping[str, Any]) -> tuple[bool, str, int]:
+    """Validate the optional ``container.artifact_store`` launcher contract."""
+    raw = container.get("artifact_store") or {}
+    if not isinstance(raw, Mapping):
+        raise ValueError("container.artifact_store must be a mapping")
+    unknown = set(raw) - {"enabled", "size", "inodes"}
+    if unknown:
+        raise ValueError(
+            "unknown container.artifact_store fields: " + ", ".join(sorted(unknown))
+        )
+    enabled_value = raw.get("enabled", False)
+    if not isinstance(enabled_value, bool):
+        raise ValueError("container.artifact_store.enabled must be a boolean")
+    enabled = enabled_value
+    size = str(raw.get("size", DEFAULT_IMAGE_SIZE))
+    inodes = raw.get("inodes", DEFAULT_INODE_COUNT)
+    if isinstance(inodes, bool) or not isinstance(inodes, int) or inodes <= 0:
+        raise ValueError("container.artifact_store.inodes must be a positive integer")
+    if not size:
+        raise ValueError("container.artifact_store.size must be non-empty")
+    return enabled, size, inodes
+
+
 def prefetch_rl_model(model_path: str) -> str:
     """Populate the model cache while preserving a replayable SkyRL reference.
 
@@ -1051,6 +1087,9 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
     print(f"Loaded RL config from: {parsed.config_path}")
     container = parsed.raw.get("container") or {}
     validate_trace_upload_environment(parsed.terminal_bench or {}, container)
+    artifact_store_enabled, artifact_store_size, artifact_store_inodes = (
+        _parse_artifact_store(container)
+    )
 
     # --- RL container section (Apptainer SIF + overlays + pydeps + extra env) ---
     # Optional top-level `container:` block in the RL yaml. When present it lets a
@@ -1179,6 +1218,7 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         job_name,
         exp_paths.canonical_root or exp_paths.root,
         exp_paths.root,
+        artifact_store_enabled=artifact_store_enabled,
     ).resolve(
         trainer_config=parsed.trainer,
         terminal_bench_config=parsed.terminal_bench or {},
@@ -1191,6 +1231,16 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         expected_world_sizes=expected_world_sizes,
     )
     print(run_paths.describe())
+    if run_paths.artifact_store is not None:
+        ensure_image(
+            run_paths.artifact_store.image,
+            size=artifact_store_size,
+            inode_count=artifact_store_inodes,
+        )
+        print(
+            f"[artifact_store] image={run_paths.artifact_store.image}; "
+            f"mount={run_paths.artifact_store.mount}; trials={run_paths.trials_dir}"
+        )
 
     hydra_args = build_skyrl_hydra_args(parsed, exp_args, hpc, run_paths=run_paths)
     if passthrough_overrides:
@@ -1238,6 +1288,13 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         if exp_args.get("rl_container_sif")
         else [],
         ray_object_store_gb=float(exp_args.get("ray_object_store_gb", 40.0)),
+        artifact_store_enabled=run_paths.artifact_store is not None,
+        artifact_store_image=(
+            str(run_paths.artifact_store.image) if run_paths.artifact_store else None
+        ),
+        artifact_store_mount=(
+            str(run_paths.artifact_store.mount) if run_paths.artifact_store else None
+        ),
     )
 
     # Populate trace upload settings from parsed terminal_bench config
@@ -1323,6 +1380,9 @@ fi"""
         "email_address": os.environ.get("EMAIL_ADDRESS", ""),
         "harbor_env": job_config.harbor_env,
         "daytona_api_key_override": get_daytona_api_key_override(exp_args),
+        "artifact_store_enabled": "1" if job_config.artifact_store_enabled else "0",
+        "artifact_store_image": job_config.artifact_store_image or "",
+        "artifact_store_mount": job_config.artifact_store_mount or "",
     }
 
     sbatch_text = substitute_template(template_text, substitutions)
@@ -1459,8 +1519,28 @@ class RLJobRunner:
     """
 
     def __init__(self, config: RLJobConfig):
+        if config.artifact_store_enabled and (
+            not config.artifact_store_image or not config.artifact_store_mount
+        ):
+            raise ValueError(
+                "artifact_store_enabled requires artifact_store_image and artifact_store_mount"
+            )
         self.config = config
         self._hpc = None
+        self._active_process: subprocess.Popen | None = None
+        self._termination_requested = False
+
+    def handle_termination(self, signum: int, _frame: object) -> None:
+        """Forward scheduler termination to the active trainer or uploader."""
+        process = self._active_process
+        if process is None or process.poll() is not None:
+            raise SystemExit(128 + signum)
+        self._termination_requested = True
+        print(
+            f"[RLJobRunner] Forwarding signal {signum} to child pid {process.pid}",
+            flush=True,
+        )
+        process.send_signal(signum)
 
     def _get_hpc(self):
         """Lazy-load HPC configuration."""
@@ -1560,6 +1640,14 @@ class RLJobRunner:
 
             traceback.print_exc()
 
+        if getattr(self, "_termination_requested", False):
+            print(
+                "[RLJobRunner] Trainer stopped for scheduler termination; "
+                "skipping post-run upload so the batch trap can flush artifacts.",
+                flush=True,
+            )
+            return 128 + signal.SIGTERM
+
         # On a crash, preserve Ray logs BEFORE the (potentially slow) trace
         # upload. The sbatch EXIT-trap also preserves them, but it only runs
         # after this Python process returns — and this process then blocks on
@@ -1574,7 +1662,11 @@ class RLJobRunner:
         upload_proc = self._launch_trace_upload(training_exit_code)
         if upload_proc is not None:
             print("[RLJobRunner] Waiting for trace upload to complete...", flush=True)
-            upload_exit_code = upload_proc.wait()
+            self._active_process = upload_proc
+            try:
+                upload_exit_code = upload_proc.wait()
+            finally:
+                self._active_process = None
             if upload_exit_code == 0:
                 print("[RLJobRunner] Trace upload completed successfully.", flush=True)
                 if self.config.trace_upload_cleanup:
@@ -1902,6 +1994,22 @@ class RLJobRunner:
             os.environ["RAY_ADDRESS"] = ray_cluster.address
             print(f"Ray cluster ready at {ray_cluster.address}", flush=True)
             print(f"Total GPUs available: {ray_cluster.total_gpus}", flush=True)
+            if self.config.artifact_store_enabled:
+                self._set_hydra_override(
+                    "trainer.entrypoint_node_ip", ray_cluster.head_ip, optional=True
+                )
+                record = write_authority_record(
+                    Path(self.config.artifact_store_image),
+                    job_id=os.environ.get("SLURM_JOB_ID", ""),
+                    node=ray_cluster.node_list[0],
+                    node_ip=ray_cluster.head_ip,
+                    mount_path=Path(self.config.artifact_store_mount),
+                )
+                print(
+                    "[artifact_store] Pinned the SkyRL entrypoint and Harbor coordinators "
+                    f"to the artifact authority node at {ray_cluster.head_ip}; record={record}",
+                    flush=True,
+                )
 
             # Enable distributed containers for multi-node local backend jobs
             # This allows Harbor to spread container workload across all Ray nodes
@@ -2146,8 +2254,22 @@ class RLJobRunner:
 
         print(f"\nExecuting command with srun: {' '.join(srun_cmd)}", flush=True)
 
-        result = subprocess.run(srun_cmd, cwd=cwd)
-        return result.returncode
+        process = subprocess.Popen(srun_cmd, cwd=cwd)
+        self._active_process = process
+        try:
+            return process.wait()
+        finally:
+            self._active_process = None
+
+    def _set_hydra_override(self, key: str, value: object, *, optional: bool) -> None:
+        """Replace one Hydra value while preserving all unrelated arguments."""
+        retained = [
+            argument
+            for argument in self.config.skyrl_hydra_args
+            if argument.lstrip("+").partition("=")[0] != key
+        ]
+        prefix = "++" if optional else ""
+        self.config.skyrl_hydra_args = [*retained, f"{prefix}{key}={value}"]
 
 
 def run_rl_job_main():
@@ -2167,6 +2289,7 @@ def run_rl_job_main():
 
     config = RLJobConfig(**config_dict)
     runner = RLJobRunner(config)
+    signal.signal(signal.SIGTERM, runner.handle_termination)
     sys.exit(runner.run())
 
 

--- a/hpc/rl_paths.py
+++ b/hpc/rl_paths.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from hpc.artifact_store import ArtifactStorePaths, paths_for_run
 from hpc.experiment_path_names import numbered_experiment_fork_pattern
 
 
@@ -97,6 +98,7 @@ class RLRunPaths:
     resume_mode: RLResumeMode
     resume_path: Path | None
     resume_policy: RLResumePolicy
+    artifact_store: ArtifactStorePaths | None = None
 
     def describe(self) -> str:
         if self.resume_path is not None:
@@ -181,10 +183,18 @@ def _validate_checkpoint_world_size(
 class RLPathManager:
     """Own checkpoint discovery and all durable RL path resolution."""
 
-    def __init__(self, job_name: str, canonical_root: Path, launch_root: Path):
+    def __init__(
+        self,
+        job_name: str,
+        canonical_root: Path,
+        launch_root: Path,
+        *,
+        artifact_store_enabled: bool = False,
+    ):
         self.job_name = job_name
         self.canonical_root = canonical_root.expanduser().resolve()
         self.launch_root = launch_root.expanduser().resolve()
+        self.artifact_store_enabled = artifact_store_enabled
 
     def resolve(
         self,
@@ -493,11 +503,21 @@ class RLPathManager:
             if EXPORT_PATH_KEY in overrides
             else trainer_root / EXPORTS_SUBDIR
         )
-        trials_dir = (
-            _absolute_path(overrides[TRIALS_DIR_KEY])
-            if TRIALS_DIR_KEY in overrides
-            else trainer_root / TRACE_JOBS_SUBDIR
-        )
+        artifact_store = None
+        if self.artifact_store_enabled:
+            if TRIALS_DIR_KEY in overrides:
+                raise CheckpointLayoutError(
+                    "container.artifact_store.enabled=true owns terminal_bench_config.trials_dir; "
+                    "remove the explicit trials_dir override"
+                )
+            artifact_store = paths_for_run(trainer_root)
+            trials_dir = artifact_store.trials
+        else:
+            trials_dir = (
+                _absolute_path(overrides[TRIALS_DIR_KEY])
+                if TRIALS_DIR_KEY in overrides
+                else trainer_root / TRACE_JOBS_SUBDIR
+            )
         return RLRunPaths(
             job_name=self.job_name,
             checkpoint_dir=checkpoint_dir,
@@ -506,4 +526,5 @@ class RLPathManager:
             resume_mode=resume_mode,
             resume_path=resume_path,
             resume_policy=resume_policy,
+            artifact_store=artifact_store,
         )

--- a/hpc/sbatch_rl/universal_rl.sbatch
+++ b/hpc/sbatch_rl/universal_rl.sbatch
@@ -7,6 +7,7 @@
 #SBATCH --job-name={job_name}
 #SBATCH --mail-type=END,TIME_LIMIT,FAIL
 #SBATCH --mail-user={email_address}
+#SBATCH --signal=B:TERM@180
 {sbatch_extra_directives}
 
 # ==============================================================================
@@ -232,7 +233,81 @@ cleanup_ray_logs() {
 
   echo "Ray log preservation complete"
 }
-trap cleanup_ray_logs EXIT
+
+ARTIFACT_STORE_ENABLED="{artifact_store_enabled}"
+ARTIFACT_STORE_IMAGE="{artifact_store_image}"
+ARTIFACT_STORE_MOUNT="{artifact_store_mount}"
+ARTIFACT_STORE_MOUNTED=0
+RL_RUNNER_PID=""
+
+cleanup_artifact_store() {
+  if [[ "$ARTIFACT_STORE_MOUNTED" != "1" ]]; then
+    return
+  fi
+  echo "Flushing artifact store: $ARTIFACT_STORE_IMAGE"
+  if ! sync; then
+    echo "FATAL: sync failed for artifact store $ARTIFACT_STORE_IMAGE" >&2
+    return 1
+  fi
+  if ! fusermount3 -u "$ARTIFACT_STORE_MOUNT"; then
+    echo "FATAL: could not unmount artifact store $ARTIFACT_STORE_MOUNT" >&2
+    return 1
+  fi
+  ARTIFACT_STORE_MOUNTED=0
+  flock -u 9 || true
+  exec 9>&-
+  echo "Artifact store unmounted"
+}
+
+cleanup_job() {
+  local status=$?
+  local cleanup_status=0
+  trap - EXIT TERM
+  set +e
+  cleanup_ray_logs || cleanup_status=1
+  cleanup_artifact_store || cleanup_status=1
+  if [[ "$status" == "0" ]] && [[ "$cleanup_status" != "0" ]]; then
+    status=$cleanup_status
+  fi
+  exit "$status"
+}
+
+forward_termination() {
+  echo "Received SIGTERM; forwarding it to the RL runner"
+  if [[ -n "$RL_RUNNER_PID" ]] && kill -0 "$RL_RUNNER_PID" 2>/dev/null; then
+    kill -TERM "$RL_RUNNER_PID"
+  else
+    exit 143
+  fi
+}
+
+trap cleanup_job EXIT
+trap forward_termination TERM
+
+if [[ "$ARTIFACT_STORE_ENABLED" == "1" ]]; then
+  if [[ ! -f "$ARTIFACT_STORE_IMAGE" ]]; then
+    echo "FATAL: artifact-store image is missing: $ARTIFACT_STORE_IMAGE" >&2
+    exit 1
+  fi
+  mkdir -p "$ARTIFACT_STORE_MOUNT"
+  exec 9>"${ARTIFACT_STORE_IMAGE}.lock"
+  if ! flock -n 9; then
+    echo "FATAL: artifact store already has an active writer: $ARTIFACT_STORE_IMAGE" >&2
+    exit 1
+  fi
+  set +e
+  e2fsck -p "$ARTIFACT_STORE_IMAGE"
+  E2FSCK_STATUS=$?
+  set -e
+  if [[ "$E2FSCK_STATUS" -gt 1 ]]; then
+    echo "FATAL: e2fsck failed for $ARTIFACT_STORE_IMAGE (status $E2FSCK_STATUS)" >&2
+    exit "$E2FSCK_STATUS"
+  fi
+  fuse2fs -o rw,allow_other "$ARTIFACT_STORE_IMAGE" "$ARTIFACT_STORE_MOUNT"
+  ARTIFACT_STORE_MOUNTED=1
+  mkdir -p "$ARTIFACT_STORE_MOUNT/trace_jobs"
+  echo "Artifact store mounted at $ARTIFACT_STORE_MOUNT"
+fi
 
 # --- SSH Tunneling (JSC clusters only) ---
 {ssh_tunnel_setup}
@@ -268,4 +343,17 @@ else
 fi
 echo "========================================"
 
-python -m hpc.rl_launch_utils --config "{config_path}"
+python -m hpc.rl_launch_utils --config "{config_path}" &
+RL_RUNNER_PID=$!
+set +e
+while true; do
+  wait "$RL_RUNNER_PID"
+  RL_STATUS=$?
+  if ! kill -0 "$RL_RUNNER_PID" 2>/dev/null; then
+    break
+  fi
+  echo "RL runner is still shutting down; continuing to wait"
+done
+set -e
+RL_RUNNER_PID=""
+exit "$RL_STATUS"

--- a/hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml
+++ b/hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml
@@ -226,6 +226,10 @@ rollout:
     cpus_per_coordinator: 8
 
 container:
+  artifact_store:
+    enabled: true
+    size: 1T
+    inodes: 50000000
   sif: /e/scratch/jureap59/feuer1/containers/skyrl_megatron_vllm0202rc0_r3.sif
   overlays:
     - /e/scratch/jureap59/feuer1/containers/skyrl_titan_overlay.img

--- a/scripts/analysis/parse_skyrl_metrics.py
+++ b/scripts/analysis/parse_skyrl_metrics.py
@@ -39,6 +39,8 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import pandas as pd
 
+from hpc.artifact_store import open_trials_path
+
 
 def strip_ansi(text: str) -> str:
     """Remove ANSI escape codes from text."""
@@ -1825,20 +1827,26 @@ def main():
         else:
             trace_jobs_dir = find_trace_jobs_dir(log_folder)
 
-        if trace_jobs_dir and trace_jobs_dir.is_dir():
-            print(f"\nParsing result.json files from: {trace_jobs_dir}")
-            trial_data = parse_result_files(trace_jobs_dir)
-            if trial_data:
-                print(f"  Parsed {len(trial_data)} trial results")
-                trial_stats_result = compute_trial_stats(trial_data)
+        if trace_jobs_dir:
+            with open_trials_path(trace_jobs_dir) as readable_trials_dir:
+                if readable_trials_dir.is_dir():
+                    print(f"\nParsing result.json files from: {readable_trials_dir}")
+                    trial_data = parse_result_files(readable_trials_dir)
+                    if trial_data:
+                        print(f"  Parsed {len(trial_data)} trial results")
+                        trial_stats_result = compute_trial_stats(trial_data)
 
-                # Save trial data CSV
-                trial_df = pd.DataFrame(trial_data)
-                trial_csv_path = output_folder / f"{ts}_trial_results.csv"
-                trial_df.to_csv(trial_csv_path, index=False)
-                print(f"Saved trial results to: {trial_csv_path}")
-            else:
-                print("  No trial results found")
+                        # Save trial data CSV
+                        trial_df = pd.DataFrame(trial_data)
+                        trial_csv_path = output_folder / f"{ts}_trial_results.csv"
+                        trial_df.to_csv(trial_csv_path, index=False)
+                        print(f"Saved trial results to: {trial_csv_path}")
+                    else:
+                        print("  No trial results found")
+                else:
+                    print(
+                        "\nNo trace_jobs directory found; skipping per-trial analysis"
+                    )
         else:
             print("\nNo trace_jobs directory found; skipping per-trial analysis")
 

--- a/scripts/harbor/make_and_upload_trace_dataset.py
+++ b/scripts/harbor/make_and_upload_trace_dataset.py
@@ -48,6 +48,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence
 
+from hpc.artifact_store import mounted, resolve_trials_root
+
 
 # ---------------------------------------------------------------------------
 # Harbor monkeypatches (preserved from the previous implementation). These make
@@ -1110,9 +1112,7 @@ def resolve_literal_inclusion(
     return (False, [])
 
 
-def main() -> None:
-    args = _parse_args()
-
+def _run_export(args: argparse.Namespace) -> None:
     job_dir = Path(args.job_dir).expanduser().resolve()
     if not job_dir.exists() or not job_dir.is_dir():
         raise SystemExit(f"job_dir does not exist or is not a directory: {job_dir}")
@@ -1125,7 +1125,7 @@ def main() -> None:
     # BEFORE export. Verify-or-skip: only steps whose token COUNTS match a
     # correlated record are enriched. No-op for non-literal jobs.
     include_literal_tokens, literal_logs = resolve_literal_inclusion(
-        str(job_dir),
+        getattr(args, "literal_discovery_root", str(job_dir)),
         literal_log=args.literal_log,
         include_literal_tokens=bool(args.include_literal_tokens),
         no_literal_tokens=bool(args.no_literal_tokens),
@@ -1245,6 +1245,26 @@ def main() -> None:
         )
         register_trace_dataset_in_supabase(args.repo_id, dataset_type=args.dataset_type)
         print(f"[trace-export] Supabase registration complete for {args.repo_id}.")
+
+
+def main() -> None:
+    """Export a legacy tree directly or mount an inactive image for the read."""
+    args = _parse_args()
+    requested_root = Path(args.job_dir).expanduser().resolve()
+    if not requested_root.is_dir():
+        raise SystemExit(
+            f"job_dir does not exist or is not a directory: {requested_root}"
+        )
+
+    kind, source = resolve_trials_root(requested_root)
+    if kind == "bare":
+        _run_export(args)
+        return
+
+    args.literal_discovery_root = str(requested_root)
+    with mounted(source, mode="ro") as image_root:
+        args.job_dir = str(image_root)
+        _run_export(args)
 
 
 if __name__ == "__main__":

--- a/tests/hpc/test_artifact_store.py
+++ b/tests/hpc/test_artifact_store.py
@@ -1,0 +1,158 @@
+from pathlib import Path
+from types import SimpleNamespace
+from contextlib import contextmanager
+import json
+
+import pytest
+
+from hpc.artifact_store import (
+    ArtifactStoreBusyError,
+    ensure_image,
+    mounted,
+    resolve_trials_root,
+    write_authority_record,
+)
+
+
+def test_resolve_trials_root_supports_legacy_and_image_runs(tmp_path: Path) -> None:
+    legacy = tmp_path / "legacy"
+    (legacy / "trace_jobs").mkdir(parents=True)
+    assert resolve_trials_root(legacy) == ("bare", legacy / "trace_jobs")
+
+    image_run = tmp_path / "image-run"
+    image_run.mkdir()
+    image = image_run / "artifact_store.img"
+    image.touch()
+    assert resolve_trials_root(image_run) == ("image", image)
+
+
+def test_ensure_image_formats_a_sparse_temporary_then_publishes_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool):
+        calls.append(command)
+        if command[0] == "truncate":
+            Path(command[-1]).touch()
+        return SimpleNamespace(returncode=0, args=command)
+
+    monkeypatch.setattr("hpc.artifact_store.subprocess.run", fake_run)
+    image = tmp_path / "run" / "artifact_store.img"
+
+    ensure_image(image, size="2T", inode_count=123)
+
+    assert image.is_file()
+    assert calls[0][:3] == ["truncate", "-s", "2T"]
+    assert calls[1][:4] == ["mkfs.ext4", "-F", "-N", "123"]
+
+
+def test_mounted_read_only_unmounts_after_the_reader(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image = tmp_path / "artifact_store.img"
+    image.touch()
+    mount_path = tmp_path / "mount"
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool):
+        calls.append(command)
+        return SimpleNamespace(returncode=0, args=command)
+
+    monkeypatch.setattr("hpc.artifact_store.subprocess.run", fake_run)
+
+    with mounted(image, mount_path=mount_path) as root:
+        assert root == mount_path
+
+    assert calls == [
+        ["fuse2fs", "-o", "ro", str(image), str(mount_path)],
+        ["fusermount3", "-u", str(mount_path)],
+    ]
+
+
+def test_mounted_refuses_an_image_with_an_active_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image = tmp_path / "artifact_store.img"
+    image.touch()
+
+    def busy_lock(_file, operation: int):
+        if operation & 4:
+            raise BlockingIOError
+
+    monkeypatch.setattr("hpc.artifact_store.fcntl.flock", busy_lock)
+
+    with pytest.raises(ArtifactStoreBusyError, match="active writer"):
+        with mounted(image):
+            pass
+
+
+def test_authority_record_names_the_live_node_and_mount(tmp_path: Path) -> None:
+    image = tmp_path / "artifact_store.img"
+    mount_path = tmp_path / "artifact_mnt"
+
+    record = write_authority_record(
+        image,
+        job_id="123",
+        node="jwb0123",
+        node_ip="10.0.0.2",
+        mount_path=mount_path,
+    )
+
+    assert json.loads(record.read_text()) == {
+        "image": str(image),
+        "job_id": "123",
+        "mount": str(mount_path),
+        "node": "jwb0123",
+        "node_ip": "10.0.0.2",
+        "trials": str(mount_path / "trace_jobs"),
+    }
+
+
+def test_rl_template_mounts_before_container_setup_and_forwards_term() -> None:
+    template = Path("hpc/sbatch_rl/universal_rl.sbatch").read_text()
+
+    assert "#SBATCH --signal=B:TERM@180" in template
+    assert template.index("fuse2fs -o rw,allow_other") < template.index(
+        "setup_container_runtime"
+    )
+    assert 'kill -TERM "$RL_RUNNER_PID"' in template
+    assert template.index("sync") < template.index(
+        'fusermount3 -u "$ARTIFACT_STORE_MOUNT"'
+    )
+
+
+def test_trace_exporter_mounts_an_image_backed_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts.harbor import make_and_upload_trace_dataset as exporter
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    image = run_dir / "artifact_store.img"
+    image.touch()
+    mounted_root = tmp_path / "mounted"
+    mounted_root.mkdir()
+    args = SimpleNamespace(job_dir=str(run_dir))
+    observed = {}
+
+    @contextmanager
+    def fake_mounted(image_path, mode):
+        observed["mount"] = (image_path, mode)
+        yield mounted_root
+
+    def fake_run_export(actual_args):
+        observed["job_dir"] = actual_args.job_dir
+        observed["literal_root"] = actual_args.literal_discovery_root
+
+    monkeypatch.setattr(exporter, "_parse_args", lambda: args)
+    monkeypatch.setattr(exporter, "mounted", fake_mounted)
+    monkeypatch.setattr(exporter, "_run_export", fake_run_export)
+
+    exporter.main()
+
+    assert observed == {
+        "mount": (image, "ro"),
+        "job_dir": str(mounted_root),
+        "literal_root": str(run_dir),
+    }

--- a/tests/hpc/test_jupiter_rl_configs.py
+++ b/tests/hpc/test_jupiter_rl_configs.py
@@ -14,3 +14,16 @@ def test_30b_kl_reference_does_not_share_policy_host_memory() -> None:
 
     assert config["trainer"]["placement"]["colocate_policy_ref"] is True
     assert config["trainer"]["ref"]["fsdp_config"]["cpu_offload"] is False
+
+
+def test_30b_tasktrove_config_uses_the_image_backed_trial_store() -> None:
+    config_path = (
+        REPOSITORY_ROOT / "hpc/skyrl_yaml/jupiter/24GPU_qwen3_30b_a3b_thinking.yaml"
+    )
+    config = yaml.safe_load(config_path.read_text())
+
+    assert config["container"]["artifact_store"] == {
+        "enabled": True,
+        "size": "1T",
+        "inodes": 50_000_000,
+    }

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -74,6 +74,35 @@ def test_new_run_uses_canonical_state_root_after_artifact_collision(
     assert resolved.checkpoint_dir == canonical_root / JOB_NAME / "checkpoints"
 
 
+def test_artifact_store_moves_only_the_trial_tree_under_the_image_mount(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / JOB_NAME
+
+    resolved = RLPathManager(
+        JOB_NAME, root, root, artifact_store_enabled=True
+    ).resolve()
+
+    run_root = root / JOB_NAME
+    assert resolved.checkpoint_dir == run_root / "checkpoints"
+    assert resolved.export_dir == run_root / "exports"
+    assert resolved.artifact_store is not None
+    assert resolved.artifact_store.image == run_root / "artifact_store.img"
+    assert resolved.artifact_store.mount == run_root / "artifact_mnt"
+    assert resolved.trials_dir == run_root / "artifact_mnt" / "trace_jobs"
+
+
+def test_artifact_store_rejects_an_independent_trials_override(tmp_path: Path) -> None:
+    root = tmp_path / JOB_NAME
+
+    with pytest.raises(
+        CheckpointLayoutError, match="owns terminal_bench_config.trials_dir"
+    ):
+        RLPathManager(JOB_NAME, root, root, artifact_store_enabled=True).resolve(
+            terminal_bench_config={"trials_dir": str(tmp_path / "other")}
+        )
+
+
 def test_explicit_fresh_launch_uses_the_launch_root(tmp_path: Path) -> None:
     canonical_root = tmp_path / JOB_NAME
     launch_root = tmp_path / f"{JOB_NAME}_2"

--- a/tests/hpc/test_rl_trace_upload.py
+++ b/tests/hpc/test_rl_trace_upload.py
@@ -1,6 +1,11 @@
 import pytest
 
-from hpc.rl_launch_utils import validate_trace_upload_environment
+from hpc.rl_launch_utils import (
+    RLJobConfig,
+    RLJobRunner,
+    _parse_artifact_store,
+    validate_trace_upload_environment,
+)
 
 
 def test_trace_upload_rejects_offline_hub_environment() -> None:
@@ -24,3 +29,68 @@ def test_disabled_trace_upload_allows_offline_hub_environment() -> None:
     container = {"extra_env": {"HF_HUB_OFFLINE": 1}}
 
     validate_trace_upload_environment(terminal_bench, container)
+
+
+def test_artifact_store_config_defaults_to_the_large_sparse_geometry() -> None:
+    assert _parse_artifact_store({"artifact_store": {"enabled": True}}) == (
+        True,
+        "1T",
+        50_000_000,
+    )
+
+
+def test_artifact_store_config_rejects_unknown_fields() -> None:
+    with pytest.raises(ValueError, match="unknown container.artifact_store fields"):
+        _parse_artifact_store(
+            {"artifact_store": {"enabled": True, "surprise": "value"}}
+        )
+
+
+def test_artifact_authority_override_replaces_a_stale_value() -> None:
+    config = RLJobConfig(
+        job_name="run",
+        experiments_dir="/tmp",
+        cluster_name="test",
+        skyrl_entrypoint="skyrl_train.entrypoints.main_base",
+        trials_dir="/tmp/trials",
+        skyrl_hydra_args=[
+            "trainer.max_steps=10",
+            "++trainer.entrypoint_node_ip=10.0.0.1",
+        ],
+    )
+    runner = RLJobRunner(config)
+
+    runner._set_hydra_override("trainer.entrypoint_node_ip", "10.0.0.2", optional=True)
+
+    assert config.skyrl_hydra_args == [
+        "trainer.max_steps=10",
+        "++trainer.entrypoint_node_ip=10.0.0.2",
+    ]
+
+
+def test_runner_forwards_term_to_the_active_trainer() -> None:
+    class Process:
+        pid = 42
+        signal = None
+
+        def poll(self):
+            return None
+
+        def send_signal(self, signum):
+            self.signal = signum
+
+    config = RLJobConfig(
+        job_name="run",
+        experiments_dir="/tmp",
+        cluster_name="test",
+        skyrl_entrypoint="skyrl_train.entrypoints.main_base",
+        trials_dir="/tmp/trials",
+    )
+    runner = RLJobRunner(config)
+    process = Process()
+    runner._active_process = process
+
+    runner.handle_termination(15, None)
+
+    assert process.signal == 15
+    assert runner._termination_requested is True


### PR DESCRIPTION
Store Jupiter RL trial artifacts in a sparse ext4 image while keeping checkpoints and exports on GPFS. The launcher creates and mounts the image on the authority node before the container runtime starts, pins the trainer entrypoint there, and drains SIGTERM cooperatively before unmounting.

Add shared read-only and read-write mounting helpers for post-run trace and metrics readers, with locking, filesystem checks, authority metadata, and legacy bare-directory compatibility. Document the safe live-reader and post-run-reader paths.

Tests: `uv run pytest` (649 passed, 2 skipped); scoped marin-style lint; `bash -n hpc/sbatch_rl/universal_rl.sbatch`; `git diff main...HEAD --check`. The required advisory review was attempted twice, but every review lane was rejected by the review-agent session quota before producing findings; logs are preserved under `/tmp/marin-style-lint/benjaminfeuer-sif-artifact-store/`.