### PR TITLE
Fix Jupiter artifact store mount authority

### DIFF
--- a/.agents/ops/jupiter/ops.md
+++ b/.agents/ops/jupiter/ops.md
@@ -52,12 +52,12 @@ rsync -avz --progress -e "ssh -i ~/.ssh/id_ed25519_jsc -4" \
 
 ## Image-backed RL trial artifacts
 
-RL configs can set `container.artifact_store.enabled: true`. The launcher creates a sparse ext4 image under the durable inner run root, and each chain link mounts it on the Ray head before Apptainer and Ray start. The SkyRL entrypoint and Harbor coordinators are pinned to that node. Check `artifact_authority.json` for the active Slurm job, node, mount, and trial paths.
+RL configs can set `container.artifact_store.enabled: true`. The launcher creates a sparse ext4 image under the durable inner run root, and each chain link mounts it below node-local `/tmp/otagent-artifact-stores` on the Ray head before Apptainer and Ray start. The live mount cannot reside below GPFS: Jupiter's `fusermount` refuses that filesystem even when `fuse2fs` reports success. The SkyRL entrypoint and Harbor coordinators are pinned to the mount node. Check `artifact_authority.json` for the active Slurm job, node, mount, and trial paths.
 
-Never mount `artifact_store.img` from a login node while its Slurm link is running. The image has one read-write authority, enforced by `artifact_store.img.lock`; a second mount can observe inconsistent ext4 metadata. Live inspection must run through the recorded node and mount:
+Never mount `artifact_store.img` from a login node while its Slurm link is running. The image has one read-write authority, enforced across hosts by `artifact_store.img.mount-lease` and on one host by `artifact_store.img.lock`; a second mount can observe inconsistent ext4 metadata. Live inspection must run through the recorded node and mount:
 
 ```bash
-srun --overlap --jobid <job_id> -w <node> -N1 -n1 ls <mount>/trace_jobs
+srun --mpi=none --overlap --jobid <job_id> -w <node> -N1 -n1 ls <mount>/trace_jobs
 ```
 
 After the link exits, repository readers mount the image read-only and release it automatically. For an ad-hoc inspection, use the same helper instead of a loop mount:

--- a/hpc/artifact_store.py
+++ b/hpc/artifact_store.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import json
 import os
+import socket
 import subprocess
 import tempfile
 from contextlib import contextmanager
@@ -17,10 +19,12 @@ from typing import Iterator, Literal
 ARTIFACT_STORE_IMAGE = "artifact_store.img"
 ARTIFACT_STORE_MOUNT = "artifact_mnt"
 ARTIFACT_STORE_LOCK_SUFFIX = ".lock"
+ARTIFACT_STORE_MOUNT_LEASE_SUFFIX = ".mount-lease"
 ARTIFACT_STORE_AUTHORITY = "artifact_authority.json"
 TRACE_JOBS_SUBDIR = "trace_jobs"
 DEFAULT_IMAGE_SIZE = "1T"
 DEFAULT_INODE_COUNT = 50_000_000
+DEFAULT_MOUNT_ROOT = Path("/tmp/otagent-artifact-stores")
 
 
 class ArtifactStoreBusyError(RuntimeError):
@@ -43,13 +47,25 @@ class ArtifactStorePaths:
         return self.mount / TRACE_JOBS_SUBDIR
 
 
+def mount_path_for_image(
+    image_path: Path, *, mount_root: Path = DEFAULT_MOUNT_ROOT
+) -> Path:
+    """Return a stable node-local mount path for an artifact image."""
+    image_path = Path(image_path).absolute()
+    identity = hashlib.sha256(str(image_path).encode()).hexdigest()[:12]
+    return Path(mount_root) / f"{image_path.parent.name}-{identity}"
+
+
+def mount_lease_path(image_path: Path) -> Path:
+    """Return the cross-host lease directory for an image mount."""
+    return Path(f"{Path(image_path)}{ARTIFACT_STORE_MOUNT_LEASE_SUFFIX}")
+
+
 def paths_for_run(run_dir: Path) -> ArtifactStorePaths:
-    """Return the canonical artifact-store paths below one durable run root."""
+    """Return the durable image and its deterministic node-local mount path."""
     run_dir = Path(run_dir)
-    return ArtifactStorePaths(
-        image=run_dir / ARTIFACT_STORE_IMAGE,
-        mount=run_dir / ARTIFACT_STORE_MOUNT,
-    )
+    image = run_dir / ARTIFACT_STORE_IMAGE
+    return ArtifactStorePaths(image=image, mount=mount_path_for_image(image))
 
 
 def ensure_image(
@@ -135,42 +151,74 @@ def mounted(
     image_path = Path(image_path)
     if not image_path.is_file():
         raise FileNotFoundError(image_path)
-    lock_path = Path(f"{image_path}{ARTIFACT_STORE_LOCK_SUFFIX}")
-    requested_lock = fcntl.LOCK_SH if mode == "ro" else fcntl.LOCK_EX
+    lease_path = mount_lease_path(image_path)
+    try:
+        lease_path.mkdir()
+    except FileExistsError as error:
+        raise ArtifactStoreBusyError(
+            f"artifact store has an active mount lease: {image_path}"
+        ) from error
+    lease_owner = lease_path / "owner"
+    try:
+        lease_owner.write_text(
+            f"kind=reader\nhost={socket.gethostname()}\npid={os.getpid()}\n"
+        )
+        lock_path = Path(f"{image_path}{ARTIFACT_STORE_LOCK_SUFFIX}")
+        requested_lock = fcntl.LOCK_SH if mode == "ro" else fcntl.LOCK_EX
+        with lock_path.open("a+b") as lock_file:
+            try:
+                fcntl.flock(lock_file, requested_lock | fcntl.LOCK_NB)
+            except BlockingIOError as error:
+                raise ArtifactStoreBusyError(
+                    f"artifact store is mounted by an active writer: {image_path}"
+                ) from error
 
-    with lock_path.open("a+b") as lock_file:
-        try:
-            fcntl.flock(lock_file, requested_lock | fcntl.LOCK_NB)
-        except BlockingIOError as error:
-            raise ArtifactStoreBusyError(
-                f"artifact store is mounted by an active writer: {image_path}"
-            ) from error
+            temporary_mount = None
+            if mount_path is None:
+                temporary_mount = tempfile.TemporaryDirectory(
+                    prefix="otagent-artifacts-"
+                )
+                resolved_mount = Path(temporary_mount.name)
+            else:
+                resolved_mount = Path(mount_path)
+                resolved_mount.mkdir(parents=True, exist_ok=True)
 
-        temporary_mount = None
-        if mount_path is None:
-            temporary_mount = tempfile.TemporaryDirectory(prefix="otagent-artifacts-")
-            resolved_mount = Path(temporary_mount.name)
-        else:
-            resolved_mount = Path(mount_path)
-            resolved_mount.mkdir(parents=True, exist_ok=True)
-
-        mounted_ok = False
-        try:
-            if mode == "rw":
-                check = subprocess.run(["e2fsck", "-p", str(image_path)], check=False)
-                if check.returncode not in {0, 1}:
-                    raise subprocess.CalledProcessError(check.returncode, check.args)
-            subprocess.run(
-                ["fuse2fs", "-o", mode, str(image_path), str(resolved_mount)],
-                check=True,
-            )
-            mounted_ok = True
-            yield resolved_mount
-        finally:
-            if mounted_ok:
-                subprocess.run(["fusermount3", "-u", str(resolved_mount)], check=True)
-            if temporary_mount is not None:
-                temporary_mount.cleanup()
+            mounted_ok = False
+            try:
+                if mode == "rw":
+                    check = subprocess.run(
+                        ["e2fsck", "-p", str(image_path)], check=False
+                    )
+                    if check.returncode not in {0, 1}:
+                        raise subprocess.CalledProcessError(
+                            check.returncode, check.args
+                        )
+                subprocess.run(
+                    ["fuse2fs", "-o", mode, str(image_path), str(resolved_mount)],
+                    check=True,
+                )
+                mount_check = subprocess.run(
+                    ["mountpoint", "-q", str(resolved_mount)], check=False
+                )
+                if mount_check.returncode != 0:
+                    subprocess.run(
+                        ["fusermount3", "-u", str(resolved_mount)], check=False
+                    )
+                    raise subprocess.CalledProcessError(
+                        mount_check.returncode, mount_check.args
+                    )
+                mounted_ok = True
+                yield resolved_mount
+            finally:
+                if mounted_ok:
+                    subprocess.run(
+                        ["fusermount3", "-u", str(resolved_mount)], check=True
+                    )
+                if temporary_mount is not None:
+                    temporary_mount.cleanup()
+    finally:
+        lease_owner.unlink(missing_ok=True)
+        lease_path.rmdir()
 
 
 @contextmanager

--- a/hpc/sbatch_rl/universal_rl.sbatch
+++ b/hpc/sbatch_rl/universal_rl.sbatch
@@ -237,17 +237,58 @@ cleanup_ray_logs() {
 ARTIFACT_STORE_ENABLED="{artifact_store_enabled}"
 ARTIFACT_STORE_IMAGE="{artifact_store_image}"
 ARTIFACT_STORE_MOUNT="{artifact_store_mount}"
+ARTIFACT_STORE_LEASE="${ARTIFACT_STORE_IMAGE}.mount-lease"
 ARTIFACT_STORE_MOUNTED=0
+ARTIFACT_STORE_LEASE_HELD=0
 RL_RUNNER_PID=""
 
+release_artifact_store_lease() {
+  if [[ "$ARTIFACT_STORE_LEASE_HELD" != "1" ]]; then
+    return
+  fi
+  rm -f "$ARTIFACT_STORE_LEASE/owner"
+  rmdir "$ARTIFACT_STORE_LEASE"
+  ARTIFACT_STORE_LEASE_HELD=0
+}
+
+acquire_artifact_store_lease() {
+  if ! mkdir "$ARTIFACT_STORE_LEASE" 2>/dev/null; then
+    local previous_job=""
+    local previous_state=""
+    if [[ -f "$ARTIFACT_STORE_LEASE/owner" ]]; then
+      previous_job=$(sed -n 's/^job_id=//p' "$ARTIFACT_STORE_LEASE/owner" | head -1)
+    fi
+    if [[ -z "$previous_job" ]]; then
+      echo "FATAL: artifact store has an active non-Slurm mount lease: $ARTIFACT_STORE_LEASE" >&2
+      return 1
+    fi
+    if ! previous_state=$(squeue -h -j "$previous_job" -o '%T'); then
+      echo "FATAL: could not validate artifact-store lease owner job $previous_job" >&2
+      return 1
+    fi
+    if [[ -n "$previous_state" ]]; then
+      echo "FATAL: artifact store is owned by active job $previous_job ($previous_state)" >&2
+      return 1
+    fi
+    echo "Recovering stale artifact-store lease from completed job $previous_job"
+    rm -f "$ARTIFACT_STORE_LEASE/owner"
+    rmdir "$ARTIFACT_STORE_LEASE"
+    mkdir "$ARTIFACT_STORE_LEASE"
+  fi
+  printf 'kind=writer\njob_id=%s\nnode=%s\n' "$SLURM_JOB_ID" "$(hostname)" > "$ARTIFACT_STORE_LEASE/owner"
+  ARTIFACT_STORE_LEASE_HELD=1
+}
+
 cleanup_artifact_store() {
+  local status=0
   if [[ "$ARTIFACT_STORE_MOUNTED" != "1" ]]; then
+    release_artifact_store_lease
     return
   fi
   echo "Flushing artifact store: $ARTIFACT_STORE_IMAGE"
   if ! sync; then
     echo "FATAL: sync failed for artifact store $ARTIFACT_STORE_IMAGE" >&2
-    return 1
+    status=1
   fi
   if ! fusermount3 -u "$ARTIFACT_STORE_MOUNT"; then
     echo "FATAL: could not unmount artifact store $ARTIFACT_STORE_MOUNT" >&2
@@ -256,7 +297,10 @@ cleanup_artifact_store() {
   ARTIFACT_STORE_MOUNTED=0
   flock -u 9 || true
   exec 9>&-
+  rmdir "$ARTIFACT_STORE_MOUNT" 2>/dev/null || true
+  release_artifact_store_lease
   echo "Artifact store unmounted"
+  return "$status"
 }
 
 cleanup_job() {
@@ -264,8 +308,8 @@ cleanup_job() {
   local cleanup_status=0
   trap - EXIT TERM
   set +e
-  cleanup_ray_logs || cleanup_status=1
   cleanup_artifact_store || cleanup_status=1
+  cleanup_ray_logs || cleanup_status=1
   if [[ "$status" == "0" ]] && [[ "$cleanup_status" != "0" ]]; then
     status=$cleanup_status
   fi
@@ -290,6 +334,7 @@ if [[ "$ARTIFACT_STORE_ENABLED" == "1" ]]; then
     exit 1
   fi
   mkdir -p "$ARTIFACT_STORE_MOUNT"
+  acquire_artifact_store_lease
   exec 9>"${ARTIFACT_STORE_IMAGE}.lock"
   if ! flock -n 9; then
     echo "FATAL: artifact store already has an active writer: $ARTIFACT_STORE_IMAGE" >&2
@@ -304,6 +349,10 @@ if [[ "$ARTIFACT_STORE_ENABLED" == "1" ]]; then
     exit "$E2FSCK_STATUS"
   fi
   fuse2fs -o rw,allow_other "$ARTIFACT_STORE_IMAGE" "$ARTIFACT_STORE_MOUNT"
+  if ! mountpoint -q "$ARTIFACT_STORE_MOUNT"; then
+    echo "FATAL: fuse2fs returned without mounting $ARTIFACT_STORE_MOUNT" >&2
+    exit 1
+  fi
   ARTIFACT_STORE_MOUNTED=1
   mkdir -p "$ARTIFACT_STORE_MOUNT/trace_jobs"
   echo "Artifact store mounted at $ARTIFACT_STORE_MOUNT"

--- a/tests/hpc/test_artifact_store.py
+++ b/tests/hpc/test_artifact_store.py
@@ -2,12 +2,15 @@ from pathlib import Path
 from types import SimpleNamespace
 from contextlib import contextmanager
 import json
+import subprocess
 
 import pytest
 
 from hpc.artifact_store import (
     ArtifactStoreBusyError,
     ensure_image,
+    mount_lease_path,
+    mount_path_for_image,
     mounted,
     resolve_trials_root,
     write_authority_record,
@@ -66,8 +69,10 @@ def test_mounted_read_only_unmounts_after_the_reader(
 
     assert calls == [
         ["fuse2fs", "-o", "ro", str(image), str(mount_path)],
+        ["mountpoint", "-q", str(mount_path)],
         ["fusermount3", "-u", str(mount_path)],
     ]
+    assert not mount_lease_path(image).exists()
 
 
 def test_mounted_refuses_an_image_with_an_active_writer(
@@ -76,15 +81,44 @@ def test_mounted_refuses_an_image_with_an_active_writer(
     image = tmp_path / "artifact_store.img"
     image.touch()
 
-    def busy_lock(_file, operation: int):
-        if operation & 4:
-            raise BlockingIOError
+    mount_lease_path(image).mkdir()
 
-    monkeypatch.setattr("hpc.artifact_store.fcntl.flock", busy_lock)
-
-    with pytest.raises(ArtifactStoreBusyError, match="active writer"):
+    with pytest.raises(ArtifactStoreBusyError, match="active mount lease"):
         with mounted(image):
             pass
+
+
+def test_mount_path_is_stable_and_node_local(tmp_path: Path) -> None:
+    image = tmp_path / "run" / "artifact_store.img"
+
+    first = mount_path_for_image(image)
+    second = mount_path_for_image(image)
+
+    assert first == second
+    assert first.parent == Path("/tmp/otagent-artifact-stores")
+
+
+def test_mounted_fails_closed_when_fuse2fs_did_not_mount(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image = tmp_path / "artifact_store.img"
+    image.touch()
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool):
+        calls.append(command)
+        return SimpleNamespace(
+            returncode=1 if command[0] == "mountpoint" else 0, args=command
+        )
+
+    monkeypatch.setattr("hpc.artifact_store.subprocess.run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        with mounted(image, mount_path=tmp_path / "mount"):
+            pass
+
+    assert ["fusermount3", "-u", str(tmp_path / "mount")] in calls
+    assert not mount_lease_path(image).exists()
 
 
 def test_authority_record_names_the_live_node_and_mount(tmp_path: Path) -> None:
@@ -116,6 +150,8 @@ def test_rl_template_mounts_before_container_setup_and_forwards_term() -> None:
     assert template.index("fuse2fs -o rw,allow_other") < template.index(
         "setup_container_runtime"
     )
+    assert 'mountpoint -q "$ARTIFACT_STORE_MOUNT"' in template
+    assert 'mkdir "$ARTIFACT_STORE_LEASE"' in template
     assert 'kill -TERM "$RL_RUNNER_PID"' in template
     assert template.index("sync") < template.index(
         'fusermount3 -u "$ARTIFACT_STORE_MOUNT"'

--- a/tests/hpc/test_rl_paths.py
+++ b/tests/hpc/test_rl_paths.py
@@ -88,8 +88,8 @@ def test_artifact_store_moves_only_the_trial_tree_under_the_image_mount(
     assert resolved.export_dir == run_root / "exports"
     assert resolved.artifact_store is not None
     assert resolved.artifact_store.image == run_root / "artifact_store.img"
-    assert resolved.artifact_store.mount == run_root / "artifact_mnt"
-    assert resolved.trials_dir == run_root / "artifact_mnt" / "trace_jobs"
+    assert resolved.artifact_store.mount.parent == Path("/tmp/otagent-artifact-stores")
+    assert resolved.trials_dir == resolved.artifact_store.mount / "trace_jobs"
 
 
 def test_artifact_store_rejects_an_independent_trials_override(tmp_path: Path) -> None:


### PR DESCRIPTION
The first Jupiter lifecycle smoke exposed that `fusermount` refuses a FUSE mountpoint on GPFS while `fuse2fs` still exits successfully. The trial path therefore remained a bare GPFS directory. The same smoke also showed that the sidecar `flock` is not sufficient for cross-host reader exclusion.

Move the live mount to a stable node-local path below `/tmp`, while retaining the image on durable GPFS. Fail closed unless `mountpoint` confirms the mount, add an atomic cross-host mount lease with stale Slurm-writer recovery, and flush/unmount before Ray-log preservation. Update the live-inspection command to use `--mpi=none`.

Tests: `uv run pytest` (651 passed, 2 skipped); marin-style lint; `bash -n hpc/sbatch_rl/universal_rl.sbatch`; `git diff --check`. The advisory review was attempted, but all lanes were rejected by the review-agent session quota before producing findings; logs are under `/tmp/marin-style-lint/benjaminfeuer-sif-artifact-store-jupiter-fix/`.