### PR TITLE
Use supported Jupiter FUSE options

### DIFF
--- a/.agents/ops/jupiter/ops.md
+++ b/.agents/ops/jupiter/ops.md
@@ -54,6 +54,8 @@ rsync -avz --progress -e "ssh -i ~/.ssh/id_ed25519_jsc -4" \
 
 RL configs can set `container.artifact_store.enabled: true`. The launcher creates a sparse ext4 image under the durable inner run root, and each chain link mounts it below node-local `/tmp/otagent-artifact-stores` on the Ray head before Apptainer and Ray start. The live mount cannot reside below GPFS: Jupiter's `fusermount` refuses that filesystem even when `fuse2fs` reports success. The SkyRL entrypoint and Harbor coordinators are pinned to the mount node. Check `artifact_authority.json` for the active Slurm job, node, mount, and trial paths.
 
+Do not add `allow_other` to the FUSE options. Jupiter does not enable `user_allow_other` in `/etc/fuse.conf`, and every process that needs the mount already runs as the submitting user.
+
 Never mount `artifact_store.img` from a login node while its Slurm link is running. The image has one read-write authority, enforced across hosts by `artifact_store.img.mount-lease` and on one host by `artifact_store.img.lock`; a second mount can observe inconsistent ext4 metadata. Live inspection must run through the recorded node and mount:
 
 ```bash

--- a/hpc/sbatch_rl/universal_rl.sbatch
+++ b/hpc/sbatch_rl/universal_rl.sbatch
@@ -348,7 +348,7 @@ if [[ "$ARTIFACT_STORE_ENABLED" == "1" ]]; then
     echo "FATAL: e2fsck failed for $ARTIFACT_STORE_IMAGE (status $E2FSCK_STATUS)" >&2
     exit "$E2FSCK_STATUS"
   fi
-  fuse2fs -o rw,allow_other "$ARTIFACT_STORE_IMAGE" "$ARTIFACT_STORE_MOUNT"
+  fuse2fs -o rw "$ARTIFACT_STORE_IMAGE" "$ARTIFACT_STORE_MOUNT"
   if ! mountpoint -q "$ARTIFACT_STORE_MOUNT"; then
     echo "FATAL: fuse2fs returned without mounting $ARTIFACT_STORE_MOUNT" >&2
     exit 1

--- a/tests/hpc/test_artifact_store.py
+++ b/tests/hpc/test_artifact_store.py
@@ -147,9 +147,8 @@ def test_rl_template_mounts_before_container_setup_and_forwards_term() -> None:
     template = Path("hpc/sbatch_rl/universal_rl.sbatch").read_text()
 
     assert "#SBATCH --signal=B:TERM@180" in template
-    assert template.index("fuse2fs -o rw,allow_other") < template.index(
-        "setup_container_runtime"
-    )
+    assert template.index("fuse2fs -o rw") < template.index("setup_container_runtime")
+    assert "allow_other" not in template
     assert 'mountpoint -q "$ARTIFACT_STORE_MOUNT"' in template
     assert 'mkdir "$ARTIFACT_STORE_LEASE"' in template
     assert 'kill -TERM "$RL_RUNNER_PID"' in template


### PR DESCRIPTION
The corrected node-local mount smoke reached Jupiter but failed before mounting because `/etc/fuse.conf` does not enable `user_allow_other`. All trainer and coordinator processes use the submitting Unix identity, so that option is unnecessary.

Remove `allow_other`, add a regression assertion, and document the cluster constraint.

Tests: `uv run pytest tests/hpc/test_artifact_store.py` (9 passed); marin-style lint; `bash -n hpc/sbatch_rl/universal_rl.sbatch`; `git diff --check`. The advisory review was attempted, but its review-agent lanes remain unavailable because of the session quota and produced no findings.