### PR TITLE
Mount writable artifact stores with fakeroot

### DIFF
--- a/.agents/ops/jupiter/ops.md
+++ b/.agents/ops/jupiter/ops.md
@@ -54,7 +54,7 @@ rsync -avz --progress -e "ssh -i ~/.ssh/id_ed25519_jsc -4" \
 
 RL configs can set `container.artifact_store.enabled: true`. The launcher creates a sparse ext4 image under the durable inner run root, and each chain link mounts it below node-local `/tmp/otagent-artifact-stores` on the Ray head before Apptainer and Ray start. The live mount cannot reside below GPFS: Jupiter's `fusermount` refuses that filesystem even when `fuse2fs` reports success. The SkyRL entrypoint and Harbor coordinators are pinned to the mount node. Check `artifact_authority.json` for the active Slurm job, node, mount, and trial paths.
 
-Do not add `allow_other` to the FUSE options. Jupiter does not enable `user_allow_other` in `/etc/fuse.conf`, and every process that needs the mount already runs as the submitting user.
+Use `rw,fakeroot`, not `allow_other`, for the writer mount. A new ext4 root is owned by UID 0, so `fakeroot` is required for the submitting user to create `trace_jobs`. Jupiter does not enable `user_allow_other` in `/etc/fuse.conf`, and every process that needs the mount already runs as the submitting user.
 
 Never mount `artifact_store.img` from a login node while its Slurm link is running. The image has one read-write authority, enforced across hosts by `artifact_store.img.mount-lease` and on one host by `artifact_store.img.lock`; a second mount can observe inconsistent ext4 metadata. Live inspection must run through the recorded node and mount:
 

--- a/hpc/artifact_store.py
+++ b/hpc/artifact_store.py
@@ -193,8 +193,15 @@ def mounted(
                         raise subprocess.CalledProcessError(
                             check.returncode, check.args
                         )
+                mount_options = "rw,fakeroot" if mode == "rw" else "ro"
                 subprocess.run(
-                    ["fuse2fs", "-o", mode, str(image_path), str(resolved_mount)],
+                    [
+                        "fuse2fs",
+                        "-o",
+                        mount_options,
+                        str(image_path),
+                        str(resolved_mount),
+                    ],
                     check=True,
                 )
                 mount_check = subprocess.run(

--- a/hpc/sbatch_rl/universal_rl.sbatch
+++ b/hpc/sbatch_rl/universal_rl.sbatch
@@ -348,7 +348,7 @@ if [[ "$ARTIFACT_STORE_ENABLED" == "1" ]]; then
     echo "FATAL: e2fsck failed for $ARTIFACT_STORE_IMAGE (status $E2FSCK_STATUS)" >&2
     exit "$E2FSCK_STATUS"
   fi
-  fuse2fs -o rw "$ARTIFACT_STORE_IMAGE" "$ARTIFACT_STORE_MOUNT"
+  fuse2fs -o rw,fakeroot "$ARTIFACT_STORE_IMAGE" "$ARTIFACT_STORE_MOUNT"
   if ! mountpoint -q "$ARTIFACT_STORE_MOUNT"; then
     echo "FATAL: fuse2fs returned without mounting $ARTIFACT_STORE_MOUNT" >&2
     exit 1

--- a/tests/hpc/test_artifact_store.py
+++ b/tests/hpc/test_artifact_store.py
@@ -75,6 +75,26 @@ def test_mounted_read_only_unmounts_after_the_reader(
     assert not mount_lease_path(image).exists()
 
 
+def test_mounted_read_write_uses_fakeroot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    image = tmp_path / "artifact_store.img"
+    image.touch()
+    mount_path = tmp_path / "mount"
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool):
+        calls.append(command)
+        return SimpleNamespace(returncode=0, args=command)
+
+    monkeypatch.setattr("hpc.artifact_store.subprocess.run", fake_run)
+
+    with mounted(image, mode="rw", mount_path=mount_path):
+        pass
+
+    assert ["fuse2fs", "-o", "rw,fakeroot", str(image), str(mount_path)] in calls
+
+
 def test_mounted_refuses_an_image_with_an_active_writer(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -147,7 +167,9 @@ def test_rl_template_mounts_before_container_setup_and_forwards_term() -> None:
     template = Path("hpc/sbatch_rl/universal_rl.sbatch").read_text()
 
     assert "#SBATCH --signal=B:TERM@180" in template
-    assert template.index("fuse2fs -o rw") < template.index("setup_container_runtime")
+    assert template.index("fuse2fs -o rw,fakeroot") < template.index(
+        "setup_container_runtime"
+    )
     assert "allow_other" not in template
     assert 'mountpoint -q "$ARTIFACT_STORE_MOUNT"' in template
     assert 'mkdir "$ARTIFACT_STORE_LEASE"' in template


### PR DESCRIPTION
The Jupiter lifecycle smoke proved that a node-local FUSE mount succeeds without `allow_other`, but a newly formatted ext4 root remains owned by UID 0 and rejects creation of `trace_jobs`. Jupiter `fuse2fs` supports `fakeroot`, and the full mount/cancel/remount/post-run-reader smoke passed with that option.

Use `rw,fakeroot` for batch writer mounts and shared-helper read-write mounts. Read-only mounts remain unchanged. Document the ownership requirement and add direct regression coverage.

Tests: `uv run pytest tests/hpc/test_artifact_store.py` (10 passed); marin-style lint; `bash -n hpc/sbatch_rl/universal_rl.sbatch`; `git diff --check`. The advisory review was attempted, but its review-agent lanes remain unavailable because of the session quota and produced no findings.