### PR TITLE
Support TaskTrove selectors in RL launches

### DIFF
--- a/data/commons.py
+++ b/data/commons.py
@@ -364,35 +364,59 @@ def download_hf_dataset(
     """
     logger = setup_logging()
 
-    if not repo_id or not isinstance(repo_id, str):
-        raise ValueError("repo_id must be a non-empty string")
+    from hpc.hf_utils import parse_hf_dataset_selector
 
-    cache_path = os.environ.get(
-        "HF_CACHE_DIR", os.path.expanduser("~/.cache/huggingface/hub")
+    selector = parse_hf_dataset_selector(repo_id)
+    if selector is None:
+        raise ValueError(f"Invalid Hugging Face dataset selector: {repo_id!r}")
+    if (
+        revision is not None
+        and selector.revision is not None
+        and revision != selector.revision
+    ):
+        raise ValueError(
+            "revision conflicts with the revision embedded in the dataset selector"
+        )
+
+    cache_path = Path(
+        cache_dir
+        or os.environ.get(
+            "HF_CACHE_DIR", os.path.expanduser("~/.cache/huggingface/hub")
+        )
     )
-    logger.info(f"Downloading dataset: {repo_id}")
+    logger.info(f"Downloading dataset: {selector.canonical()}")
     logger.info(f"Cache directory: {cache_path}")
-    logger.info(f"Revision: {revision or 'latest'}")
+    resolved_revision = revision or selector.revision
+    logger.info(f"Revision: {resolved_revision or 'latest'}")
     logger.info(f"Use snapshot: {use_snapshot}")
 
     if use_snapshot:
         # Use snapshot_download for full repository download
         dataset_path = snapshot_download(
-            repo_id=repo_id,
+            repo_id=selector.repo_id,
             cache_dir=str(cache_path),
-            revision=revision,
+            revision=resolved_revision,
             local_files_only=local_files_only,
             repo_type="dataset",
+            allow_patterns=[f"{selector.subdir}/**"] if selector.subdir else None,
         )
+        if selector.subdir:
+            dataset_path = os.path.join(dataset_path, selector.subdir)
+            if not os.path.isdir(dataset_path):
+                raise FileNotFoundError(
+                    f"Dataset selector {repo_id!r} did not resolve a subdirectory"
+                )
         logger.info(f"Dataset downloaded via snapshot to: {dataset_path}")
 
     else:
+        if selector.subdir:
+            raise ValueError("dataset subdirectory selectors require use_snapshot=True")
         # Use load_dataset for dataset-specific download
         # Load the dataset to trigger download
         load_dataset(
-            repo_id,
+            selector.repo_id,
             cache_dir=str(cache_path),
-            revision=revision,
+            revision=resolved_revision,
             download_mode="reuse_dataset_if_exists"
             if local_files_only
             else "reuse_cache_if_exists",
@@ -400,11 +424,14 @@ def download_hf_dataset(
 
         # Find the actual dataset directory in the cache
         # The dataset is typically stored in a subdirectory of the cache
-        dataset_name = repo_id.replace("/", "___")
+        dataset_name = selector.repo_id.replace("/", "___")
         potential_paths = [
             cache_path / "downloads" / "extracted" / dataset_name,
-            cache_path / "downloads" / "extracted" / f"{dataset_name}-{revision}"
-            if revision
+            cache_path
+            / "downloads"
+            / "extracted"
+            / f"{dataset_name}-{resolved_revision}"
+            if resolved_revision
             else None,
             cache_path / "datasets" / dataset_name,
         ]

--- a/hpc/hf_utils.py
+++ b/hpc/hf_utils.py
@@ -13,10 +13,13 @@ import os
 import re
 from dataclasses import dataclass
 from typing import Optional
+from urllib.parse import quote
 
 # Default HuggingFace org for auto-derived repo IDs (override with env var)
 DEFAULT_HF_ORG = "DCAgent"
 HF_ORG_ENV_VAR = "DCAGENT_HF_ORG"
+HF_SELECTOR_REVISION_SEPARATOR = "@"
+HF_SELECTOR_SUBDIR_SEPARATOR = "::"
 
 
 @dataclass(frozen=True)
@@ -27,14 +30,37 @@ class HfDatasetSelector:
     revision: str | None = None
     subdir: str | None = None
 
+    def canonical(self) -> str:
+        revision = (
+            f"{HF_SELECTOR_REVISION_SEPARATOR}{self.revision}" if self.revision else ""
+        )
+        subdir = f"{HF_SELECTOR_SUBDIR_SEPARATOR}{self.subdir}" if self.subdir else ""
+        return f"{self.repo_id}{revision}{subdir}"
+
+    def cache_name(self) -> str:
+        """Return a reversible cache key containing repo, subdirectory, and revision."""
+        components = (
+            ("repo", self.repo_id),
+            ("subdir", self.subdir),
+            ("revision", self.revision),
+        )
+        encoded = (
+            (name, quote(value, safe="-._"))
+            for name, value in components
+            if value is not None
+        )
+        return "__".join(f"{name}-{len(value)}-{value}" for name, value in encoded)
+
 
 def parse_hf_dataset_selector(value: str) -> HfDatasetSelector | None:
     """Parse ``org/repo[@revision][::subdir]`` dataset selectors."""
     if not value or value.startswith(("./", "../", "/", "~")) or "\\" in value:
         return None
 
-    repo_revision, separator, subdir = value.partition("::")
-    repo_id, revision_separator, revision = repo_revision.partition("@")
+    repo_revision, separator, subdir = value.partition(HF_SELECTOR_SUBDIR_SEPARATOR)
+    repo_id, revision_separator, revision = repo_revision.partition(
+        HF_SELECTOR_REVISION_SEPARATOR
+    )
     if repo_id.count("/") != 1 or not all(part.strip() for part in repo_id.split("/")):
         return None
     if separator and (
@@ -64,6 +90,17 @@ def is_hf_dataset_path(path: str) -> bool:
         True if path appears to be an HF dataset identifier
     """
     return parse_hf_dataset_selector(path) is not None
+
+
+def resolve_hf_dataset_selector(value: str) -> HfDatasetSelector:
+    """Resolve a selector revision to an immutable Hub commit."""
+    selector = parse_hf_dataset_selector(value)
+    if selector is None:
+        raise ValueError(f"Invalid Hugging Face dataset selector: {value!r}")
+    from huggingface_hub import HfApi
+
+    info = HfApi().dataset_info(selector.repo_id, revision=selector.revision)
+    return HfDatasetSelector(selector.repo_id, info.sha, selector.subdir)
 
 
 def sanitize_hf_repo_id(repo_id: str, max_length: int = 96) -> str:

--- a/hpc/rl_launch_utils.py
+++ b/hpc/rl_launch_utils.py
@@ -33,7 +33,7 @@ from hpc.artifact_store import (
     write_authority_record,
 )
 from hpc.checkpoint_utils import is_huggingface_repo, pre_download_model
-from hpc.hf_utils import is_hf_dataset_path
+from hpc.hf_utils import is_hf_dataset_path, resolve_hf_dataset_selector
 from hpc.launch_utils import get_daytona_api_key_override
 from hpc.rl_config_utils import (
     expected_rl_world_sizes,
@@ -366,7 +366,35 @@ def resolve_rl_train_data(
     on_exist: str = "skip",
     verbose: bool = True,
 ) -> List[str]:
+    """Resolve data paths while preserving the historical list-only API."""
+    return list(
+        resolve_rl_train_data_with_sources(
+            train_data,
+            scratch_dir=scratch_dir,
+            on_exist=on_exist,
+            verbose=verbose,
+        ).paths
+    )
+
+
+@dataclass(frozen=True)
+class ResolvedRLData:
+    """Local data paths paired with their immutable or local source references."""
+
+    paths: tuple[str, ...]
+    sources: tuple[str, ...]
+
+
+def resolve_rl_train_data_with_sources(
+    train_data: List[str],
+    scratch_dir: Optional[str] = None,
+    on_exist: str = "skip",
+    verbose: bool = True,
+) -> ResolvedRLData:
     """Resolve train_data paths, extracting HF datasets to local task directories.
+
+    ``sources`` preserves local inputs and replaces Hub inputs with canonical
+    selectors pinned to their resolved commit.
 
     SkyRL's TerminalBenchTaskDataset expects local directory paths where each
     subdirectory is a task containing an instruction.md file. This function:
@@ -389,7 +417,7 @@ def resolve_rl_train_data(
         ['/scratch/tasks/my-dataset', '/local/path/tasks']
     """
     if not train_data:
-        return []
+        return ResolvedRLData((), ())
 
     # Determine scratch directory for extracted tasks
     # IMPORTANT: Must use a shared filesystem visible to all compute nodes.
@@ -415,16 +443,16 @@ def resolve_rl_train_data(
     tasks_base = Path(scratch_dir) / "tasks"
 
     resolved_paths = []
+    sources = []
 
     for data_path in train_data:
         if is_hf_dataset_path(data_path):
-            # It's a HuggingFace dataset - extract to local directory
-            # Extract repo name from "org/repo-name" -> "repo-name"
-            repo_name = data_path.split("/")[-1]
-            output_dir = tasks_base / repo_name
+            selector = resolve_hf_dataset_selector(data_path)
+            canonical_source = selector.canonical()
+            output_dir = tasks_base / selector.cache_name()
 
             if verbose:
-                print(f"[rl_launch_utils] Extracting HF dataset: {data_path}")
+                print(f"[rl_launch_utils] Extracting HF dataset: {canonical_source}")
                 print(f"[rl_launch_utils] Output directory: {output_dir}")
 
             # Check if already extracted (when on_exist="skip")
@@ -434,6 +462,7 @@ def resolve_rl_train_data(
                         f"[rl_launch_utils] Tasks already extracted, skipping: {output_dir}"
                     )
                 resolved_paths.append(str(output_dir))
+                sources.append(canonical_source)
                 continue
 
             # Run extract_tasks_from_parquet
@@ -442,7 +471,7 @@ def resolve_rl_train_data(
                 "-m",
                 "scripts.datagen.extract_tasks_from_parquet",
                 "--parquet",
-                data_path,
+                canonical_source,
                 "--output_dir",
                 str(output_dir),
                 "--on_exist",
@@ -500,14 +529,16 @@ def resolve_rl_train_data(
             _fix_task_permissions(output_dir, verbose=verbose)
 
             resolved_paths.append(str(output_dir))
+            sources.append(canonical_source)
         else:
             # It's a local path - fix permissions just in case
             local_path = Path(data_path)
             if local_path.exists():
                 _fix_task_permissions(local_path, verbose=verbose)
             resolved_paths.append(data_path)
+            sources.append(data_path)
 
-    return resolved_paths
+    return ResolvedRLData(tuple(resolved_paths), tuple(sources))
 
 
 def _fix_task_permissions(task_dir: Path, verbose: bool = True) -> None:
@@ -837,6 +868,8 @@ class RLJobConfig:
     model_path: str = ""
     train_data: List[str] = field(default_factory=list)
     val_data: List[str] = field(default_factory=list)
+    train_data_sources: List[str] = field(default_factory=list)
+    val_data_sources: List[str] = field(default_factory=list)
 
     # Resource allocation
     num_nodes: int = 1
@@ -1131,9 +1164,12 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         except (ValueError, SyntaxError):
             train_data_raw = [train_data_raw]
 
+    train_data_sources: list[str] = []
     if train_data_raw:
         print(f"Resolving train_data: {train_data_raw}")
-        resolved_train_data = resolve_rl_train_data(train_data_raw)
+        resolved_train = resolve_rl_train_data_with_sources(train_data_raw)
+        resolved_train_data = list(resolved_train.paths)
+        train_data_sources = list(resolved_train.sources)
         exp_args["train_data"] = resolved_train_data
         print(f"Resolved train_data: {resolved_train_data}")
 
@@ -1172,11 +1208,13 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         except (ValueError, SyntaxError):
             val_data_raw = [val_data_raw]
 
+    val_data_sources: list[str] = []
     if val_data_raw:
         print(f"Resolving val_data: {val_data_raw}")
-        resolved_val_data = resolve_rl_train_data(val_data_raw)
-        exp_args["val_data"] = resolved_val_data
-        print(f"Resolved val_data: {resolved_val_data}")
+        resolved_val = resolve_rl_train_data_with_sources(val_data_raw)
+        exp_args["val_data"] = list(resolved_val.paths)
+        val_data_sources = list(resolved_val.sources)
+        print(f"Resolved val_data: {exp_args['val_data']}")
 
     # Pre-download model for RL jobs
     # SkyRL's FSDP and DeepSpeed strategies don't have built-in pre-download logic
@@ -1263,6 +1301,8 @@ def construct_rl_sbatch_script(exp_args: dict, hpc) -> RLLaunchArtifacts:
         model_path=exp_args.get("model_path", ""),
         train_data=exp_args.get("train_data", []),
         val_data=exp_args.get("val_data", []),
+        train_data_sources=train_data_sources,
+        val_data_sources=val_data_sources,
         num_nodes=num_nodes,
         gpus_per_node=gpus_per_node,
         cpus_per_node=cpus_per_node,

--- a/scripts/datagen/extract_tasks_from_parquet.py
+++ b/scripts/datagen/extract_tasks_from_parquet.py
@@ -19,11 +19,8 @@ import argparse
 import shutil
 from pathlib import Path
 
-from hpc.hf_utils import is_raw_tasks_directory
+from hpc.hf_utils import is_raw_tasks_directory, resolve_dataset_path
 from scripts.harbor import tasks_parquet_converter as tpc
-
-# Lazy import to avoid requiring google.cloud unless needed.
-download_hf_dataset = None
 
 
 def copy_raw_tasks(source_dir: Path, output_dir: Path, on_exist: str = "skip") -> int:
@@ -137,24 +134,14 @@ def main() -> None:
         else:
             parquet_paths = [candidate_path.resolve()]
     else:
-        # Not a local path - treat as HuggingFace repo
-        global download_hf_dataset
-        if download_hf_dataset is None:
-            try:
-                from data.commons import download_hf_dataset as _download_hf_dataset  # type: ignore
-            except ModuleNotFoundError as exc:
-                raise RuntimeError(
-                    f"Cannot resolve '{parquet_input}' as a local file and failed to import data.commons "
-                    f"to download Hugging Face repos: {exc}"
-                ) from exc
-            download_hf_dataset = _download_hf_dataset
-
+        # Not a local path - treat as a Hugging Face dataset selector.
         print(
             f"[extract] Treating '{parquet_input}' as a Hugging Face dataset repo; downloading snapshot..."
         )
-        snapshot_dir = Path(
-            download_hf_dataset(parquet_input, revision=args.tasks_revision)
-        )
+        if args.tasks_revision and "@" not in parquet_input.partition("::")[0]:
+            repo, separator, subdir = parquet_input.partition("::")
+            parquet_input = f"{repo}@{args.tasks_revision}{separator}{subdir}"
+        snapshot_dir = Path(resolve_dataset_path(parquet_input))
 
         # Check if it's raw tasks or parquet with task_binary
         if is_raw_tasks_directory(snapshot_dir):

--- a/scripts/harbor/tasks_parquet_converter.py
+++ b/scripts/harbor/tasks_parquet_converter.py
@@ -34,7 +34,6 @@ from pathlib import Path, PurePosixPath
 from typing import Iterator, Sequence
 from tqdm import tqdm
 from datasets import load_dataset
-from data.gcs_cache import gcs_cache
 
 # Optional heavy imports; provide clear error if missing when used.
 try:
@@ -384,8 +383,24 @@ def from_hf_dataset(
         shutil.rmtree(temp_parquet_dir, ignore_errors=True)
 
 
-@gcs_cache()
 def from_hf_dataset_hdf5(
+    dataset_name: str,
+    output_path: str | None = None,
+    compression: str = "gzip",
+    compression_opts: int = 4,
+) -> str:
+    """Run the GCS-cached HDF5 conversion without importing GCS for other operations."""
+    from data.gcs_cache import gcs_cache
+
+    return gcs_cache()(_from_hf_dataset_hdf5)(
+        dataset_name,
+        output_path=output_path,
+        compression=compression,
+        compression_opts=compression_opts,
+    )
+
+
+def _from_hf_dataset_hdf5(
     dataset_name: str,
     output_path: str | None = None,
     compression: str = "gzip",

--- a/tests/hpc/test_rl_tasktrove_selectors.py
+++ b/tests/hpc/test_rl_tasktrove_selectors.py
@@ -1,0 +1,106 @@
+import importlib
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+
+from hpc import hf_utils, rl_launch_utils
+from hpc.hf_utils import HfDatasetSelector, parse_hf_dataset_selector
+from hpc.rl_launch_utils import RLJobConfig
+
+
+def test_cache_names_do_not_confuse_repo_suffixes_with_subdirectories():
+    repo_suffix = HfDatasetSelector("fixture-org/a__b", revision="commit").cache_name()
+    subdirectory = HfDatasetSelector(
+        "fixture-org/a", revision="commit", subdir="b"
+    ).cache_name()
+
+    assert repo_suffix != subdirectory
+
+
+def test_revision_resolution_honors_the_requested_revision(monkeypatch):
+    calls = []
+
+    class FakeApi:
+        def dataset_info(self, repo_id, revision):
+            calls.append((repo_id, revision))
+            return SimpleNamespace(sha="immutable-sha")
+
+    monkeypatch.setattr("huggingface_hub.HfApi", FakeApi)
+
+    selector = hf_utils.resolve_hf_dataset_selector(
+        "fixture-org/fixture-trove@rev-1::a"
+    )
+
+    assert selector.canonical() == "fixture-org/fixture-trove@immutable-sha::a"
+    assert calls == [("fixture-org/fixture-trove", "rev-1")]
+
+
+def test_task_selectors_use_distinct_revision_pinned_caches(monkeypatch, tmp_path):
+    commits = {"a": "commit-a", "b": "commit-b"}
+    commands = []
+
+    def resolve(value):
+        selector = parse_hf_dataset_selector(value)
+        assert selector is not None and selector.subdir is not None
+        return HfDatasetSelector(
+            selector.repo_id, commits[selector.subdir], selector.subdir
+        )
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        output = Path(command[command.index("--output_dir") + 1])
+        (output / "task-1").mkdir(parents=True)
+        (output / "task-1" / "instruction.md").write_text("task")
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(rl_launch_utils, "resolve_hf_dataset_selector", resolve)
+    monkeypatch.setattr(rl_launch_utils.subprocess, "run", run)
+    monkeypatch.setattr(
+        rl_launch_utils, "_fix_task_permissions", lambda *_args, **_kwargs: None
+    )
+
+    resolved = rl_launch_utils.resolve_rl_train_data_with_sources(
+        ["fixture-org/fixture-trove::a", "fixture-org/fixture-trove::b"],
+        scratch_dir=str(tmp_path),
+        verbose=False,
+    )
+
+    assert resolved.sources == (
+        "fixture-org/fixture-trove@commit-a::a",
+        "fixture-org/fixture-trove@commit-b::b",
+    )
+    assert resolved.paths[0] != resolved.paths[1]
+    assert all(
+        (Path(path) / "task-1" / "instruction.md").read_text() == "task"
+        for path in resolved.paths
+    )
+    assert [command[command.index("--parquet") + 1] for command in commands] == list(
+        resolved.sources
+    )
+
+
+def test_rendered_job_config_keeps_canonical_sources():
+    config = RLJobConfig(
+        job_name="job",
+        experiments_dir="experiments",
+        cluster_name="jupiter",
+        skyrl_entrypoint="fully_async",
+        trials_dir="trials",
+        train_data=["/tasks/a"],
+        train_data_sources=["fixture-org/fixture-trove@immutable-sha::a"],
+    )
+
+    assert asdict(config)["train_data_sources"] == [
+        "fixture-org/fixture-trove@immutable-sha::a"
+    ]
+
+
+def test_hf_extractor_import_does_not_load_google_cloud_storage():
+    for name in tuple(sys.modules):
+        if name == "google.cloud.storage" or name.startswith("google.cloud.storage."):
+            del sys.modules[name]
+
+    importlib.import_module("scripts.datagen.extract_tasks_from_parquet")
+
+    assert "google.cloud.storage" not in sys.modules


### PR DESCRIPTION
Accept `org/repo[@revision]::subdir` dataset selectors in Jupiter RL launches. Resolve every Hub source to an immutable commit before extraction, download only the selected subtree, and use a collision-free cache key containing the repository, subdirectory, and resolved revision.

Preserve the canonical source selector beside the extracted task path in the rendered job config. Route extraction through the existing selector-aware Hub resolver and make the HDF5 GCS cache import lazy, so Hugging Face and local-parquet extraction no longer load `google.cloud.storage` as collateral.

Regression coverage verifies revision pinning, subdirectory isolation, cache-key injectivity, rendered provenance, and the GCS-free extractor import boundary.
