### PR TITLE
[rl] Flush generation buffers before Slurm walltime

### DIFF
--- a/hpc/sbatch_rl/universal_rl.sbatch
+++ b/hpc/sbatch_rl/universal_rl.sbatch
@@ -7,7 +7,11 @@
 #SBATCH --job-name={job_name}
 #SBATCH --mail-type=END,TIME_LIMIT,FAIL
 #SBATCH --mail-user={email_address}
-#SBATCH --signal=B:TERM@180
+# Send a batch-shell-only warning while the Ray job steps are still alive. The
+# USR1 trap below translates this into a cooperative TERM for the RL runner.
+# Five minutes covers MarinSkyRL's 120-second entrypoint shutdown deadline and
+# leaves time for artifact-store and Ray-log cleanup before the hard time limit.
+#SBATCH --signal=B:USR1@300
 {sbatch_extra_directives}
 
 # ==============================================================================
@@ -306,7 +310,7 @@ cleanup_artifact_store() {
 cleanup_job() {
   local status=$?
   local cleanup_status=0
-  trap - EXIT TERM
+  trap - EXIT TERM USR1
   set +e
   cleanup_artifact_store || cleanup_status=1
   cleanup_ray_logs || cleanup_status=1
@@ -317,7 +321,7 @@ cleanup_job() {
 }
 
 forward_termination() {
-  echo "Received SIGTERM; forwarding it to the RL runner"
+  echo "Received Slurm shutdown signal; forwarding SIGTERM to the RL runner"
   if [[ -n "$RL_RUNNER_PID" ]] && kill -0 "$RL_RUNNER_PID" 2>/dev/null; then
     kill -TERM "$RL_RUNNER_PID"
   else
@@ -326,7 +330,7 @@ forward_termination() {
 }
 
 trap cleanup_job EXIT
-trap forward_termination TERM
+trap forward_termination TERM USR1
 
 if [[ "$ARTIFACT_STORE_ENABLED" == "1" ]]; then
   if [[ ! -f "$ARTIFACT_STORE_IMAGE" ]]; then

--- a/hpc/sbatch_rl/universal_rl.sbatch
+++ b/hpc/sbatch_rl/universal_rl.sbatch
@@ -320,11 +320,11 @@ cleanup_job() {
   exit "$status"
 }
 
+source "$WORKDIR/hpc/shell_utils/rl_shutdown.sh"
+
 forward_termination() {
   echo "Received Slurm shutdown signal; forwarding SIGTERM to the RL runner"
-  if [[ -n "$RL_RUNNER_PID" ]] && kill -0 "$RL_RUNNER_PID" 2>/dev/null; then
-    kill -TERM "$RL_RUNNER_PID"
-  else
+  if ! forward_termination_to_rl_runner "$RL_RUNNER_PID"; then
     exit 143
   fi
 }

--- a/hpc/shell_utils/rl_shutdown.sh
+++ b/hpc/shell_utils/rl_shutdown.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+forward_termination_to_rl_runner() {
+  local runner_pid="${1:-}"
+  if [[ -z "$runner_pid" ]] || ! kill -0 "$runner_pid" 2>/dev/null; then
+    return 1
+  fi
+  kill -TERM "$runner_pid"
+}

--- a/tests/hpc/test_artifact_store.py
+++ b/tests/hpc/test_artifact_store.py
@@ -173,11 +173,44 @@ def test_rl_template_mounts_before_container_setup_and_forwards_term() -> None:
     assert "allow_other" not in template
     assert 'mountpoint -q "$ARTIFACT_STORE_MOUNT"' in template
     assert 'mkdir "$ARTIFACT_STORE_LEASE"' in template
-    assert "trap forward_termination TERM USR1" in template
-    assert 'kill -TERM "$RL_RUNNER_PID"' in template
     assert template.index("sync") < template.index(
         'fusermount3 -u "$ARTIFACT_STORE_MOUNT"'
     )
+
+
+def test_rl_shutdown_forwards_term_to_live_runner(tmp_path: Path) -> None:
+    marker = tmp_path / "terminated"
+    runner = subprocess.Popen(
+        [
+            "bash",
+            "-c",
+            'trap \'printf terminated > "$1"; exit 0\' TERM; printf "ready\\n"; while true; do sleep 1; done',
+            "runner",
+            str(marker),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert runner.stdout is not None
+        assert runner.stdout.readline() == "ready\n"
+        subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; forward_termination_to_rl_runner "$2"',
+                "forwarder",
+                str(Path("hpc/shell_utils/rl_shutdown.sh").resolve()),
+                str(runner.pid),
+            ],
+            check=True,
+        )
+        assert runner.wait(timeout=5) == 0
+        assert marker.read_text() == "terminated"
+    finally:
+        if runner.poll() is None:
+            runner.kill()
+            runner.wait(timeout=5)
 
 
 def test_trace_exporter_mounts_an_image_backed_run(

--- a/tests/hpc/test_artifact_store.py
+++ b/tests/hpc/test_artifact_store.py
@@ -166,13 +166,14 @@ def test_authority_record_names_the_live_node_and_mount(tmp_path: Path) -> None:
 def test_rl_template_mounts_before_container_setup_and_forwards_term() -> None:
     template = Path("hpc/sbatch_rl/universal_rl.sbatch").read_text()
 
-    assert "#SBATCH --signal=B:TERM@180" in template
+    assert "#SBATCH --signal=B:USR1@300" in template
     assert template.index("fuse2fs -o rw,fakeroot") < template.index(
         "setup_container_runtime"
     )
     assert "allow_other" not in template
     assert 'mountpoint -q "$ARTIFACT_STORE_MOUNT"' in template
     assert 'mkdir "$ARTIFACT_STORE_LEASE"' in template
+    assert "trap forward_termination TERM USR1" in template
     assert 'kill -TERM "$RL_RUNNER_PID"' in template
     assert template.index("sync") < template.index(
         'fusermount3 -u "$ARTIFACT_STORE_MOUNT"'


### PR DESCRIPTION
Send a batch-shell-only `USR1` five minutes before Slurm walltime and translate it into `SIGTERM` for the RL runner. Ray job steps remain alive while MarinSkyRL uses its 120-second cooperative shutdown to flush the generation buffer preserved by [MarinSkyRL #474](https://github.com/marin-community/MarinSkyRL/pull/474); the remaining window is reserved for artifact-store and Ray-log cleanup.

This replaces the early `TERM` warning that produced no runner acknowledgement on the observed jtd-d2 and jtd-d4 terminations. The production forwarding boundary is exercised against a real child process so regressions cannot silently bypass the runner again.
