### PR TITLE
[eval] Repair TaskTrove v4.8 campaign contracts

### DIFF
--- a/data/tasktrove/assemble_v48_release.py
+++ b/data/tasktrove/assemble_v48_release.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate and assemble the TaskTrove v4.8 release payload."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from harbor_config.models.task.config import TaskConfig
+
+from data.tasktrove.build_storage_repair import (
+    MAX_BATCH_ROWS,
+    MIN_TASKS,
+    REQUIRED_MEMBERS,
+    TASK_SCHEMA,
+    file_sha256,
+    read_task,
+)
+from data.tasktrove.build_v48_repairs import MEMORY_MB, SOURCE_REVISION
+
+SOURCE_VERSION = "4.7"
+TARGET_VERSION = "4.8"
+MAX_IMAGES = 20
+
+
+def _hardlink_or_copy(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(source, destination)
+    except OSError:
+        shutil.copyfile(source, destination)
+
+
+def validate_dataset(path: Path, entry: dict[str, object]) -> set[str]:
+    if file_sha256(path) != entry["output_sha256"]:
+        raise ValueError(f"output hash mismatch: {path}")
+    parquet = pq.ParquetFile(path)
+    if parquet.schema_arrow != TASK_SCHEMA:
+        raise ValueError(f"unexpected schema: {path}")
+    if parquet.metadata.num_rows != entry["output_rows"]:
+        raise ValueError(f"output row count mismatch: {path}")
+    if parquet.metadata.num_rows < MIN_TASKS:
+        raise ValueError(f"source fell below {MIN_TASKS} tasks: {path}")
+    if any(
+        parquet.metadata.row_group(index).num_rows > MAX_BATCH_ROWS
+        for index in range(parquet.metadata.num_row_groups)
+    ):
+        raise ValueError(f"oversized row group: {path}")
+
+    paths: set[str] = set()
+    images: set[str] = set()
+    shell_hashes: set[str] = set()
+    for batch in parquet.iter_batches(batch_size=MAX_BATCH_ROWS):
+        for row in batch.to_pylist():
+            task_path = row["path"]
+            if task_path in paths:
+                raise ValueError(f"duplicate task path: {task_path}")
+            paths.add(task_path)
+            files = read_task(row["task_binary"])
+            if not REQUIRED_MEMBERS <= files.keys():
+                raise ValueError(f"incomplete task: {task_path}")
+            config = TaskConfig.model_validate_toml(files["task.toml"].decode())
+            if entry["memory_mb"] is not None:
+                if config.environment.memory_mb != MEMORY_MB:
+                    raise ValueError(f"wrong memory requirement: {task_path}")
+            for name, content in files.items():
+                if not name.endswith(".sh"):
+                    continue
+                digest = hashlib.sha256(content).hexdigest()
+                if digest in shell_hashes:
+                    continue
+                checked = subprocess.run(
+                    ["bash", "-n"], input=content, capture_output=True, check=False
+                )
+                if checked.returncode:
+                    raise ValueError(
+                        f"invalid shell script {name}: "
+                        + checked.stderr.decode(errors="replace")
+                    )
+                shell_hashes.add(digest)
+            images.add(hashlib.sha256(files["environment/Dockerfile"]).hexdigest())
+    if len(images) > MAX_IMAGES:
+        raise ValueError(f"{path} uses {len(images)} images")
+    return images
+
+
+def assemble(repair_stage: Path, stage: Path) -> None:
+    if stage.exists() and any(stage.iterdir()):
+        raise ValueError(f"stage must be absent or empty: {stage}")
+    source_manifest = json.loads((repair_stage / "manifest.json").read_text())
+    if source_manifest["source_revision"] != SOURCE_REVISION:
+        raise ValueError("repair stage does not target TaskTrove v4.7")
+    stage.mkdir(parents=True, exist_ok=True)
+    images: set[str] = set()
+    entries = []
+    for item in source_manifest["datasets"]:
+        source = repair_stage / "datasets" / item["output"] / "tasks.parquet"
+        images.update(validate_dataset(source, item))
+        relative = Path("datasets") / item["output"] / "tasks.parquet"
+        _hardlink_or_copy(source, stage / relative)
+        entries.append({**item, "parquet": str(relative)})
+    if len(images) > MAX_IMAGES:
+        raise ValueError(f"release uses {len(images)} images")
+    manifest = {
+        "source_repo": "open-thoughts/TaskTrove",
+        "source_revision": SOURCE_REVISION,
+        "source_version": SOURCE_VERSION,
+        "target_version": TARGET_VERSION,
+        "datasets": entries,
+        "release_unique_images": len(images),
+    }
+    (stage / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"assembled {len(entries)} replacements using {len(images)} unique images")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repair-stage", type=Path, required=True)
+    parser.add_argument("--stage", type=Path, required=True)
+    args = parser.parse_args()
+    assemble(args.repair_stage, args.stage)
+
+
+if __name__ == "__main__":
+    main()

--- a/data/tasktrove/build_storage_repair.py
+++ b/data/tasktrove/build_storage_repair.py
@@ -76,20 +76,23 @@ def write_task(files: dict[str, bytes]) -> bytes:
     return gzip.compress(raw.getvalue(), compresslevel=6, mtime=0)
 
 
-def task_toml_with_storage(
-    task_toml: bytes, expected_storage_mb: int | None, storage_mb: int
+def task_toml_with_environment_resource(
+    task_toml: bytes,
+    resource: str,
+    expected_value: int | None,
+    value: int,
 ) -> bytes:
     source = task_toml.decode("utf-8")
     config = TaskConfig.model_validate_toml(source)
-    current = config.environment.storage_mb
-    if current != expected_storage_mb:
+    current = getattr(config.environment, resource)
+    if current != expected_value:
         raise ValueError(
-            f"task declares storage_mb={current}, expected {expected_storage_mb}"
+            f"task declares {resource}={current}, expected {expected_value}"
         )
     environment = re.search(r"(?m)^\[environment\][ \t]*(?:#.*)?$", source)
     if environment is None:
         suffix = "" if source.endswith("\n") else "\n"
-        transformed = f"{source}{suffix}\n[environment]\nstorage_mb = {storage_mb}\n"
+        transformed = f"{source}{suffix}\n[environment]\n{resource} = {value}\n"
     else:
         next_table = re.search(r"(?m)^\[", source[environment.end() :])
         section_end = (
@@ -99,25 +102,42 @@ def task_toml_with_storage(
         )
         section = source[environment.end() : section_end]
         declaration = re.search(
-            r"(?m)^(storage_mb[ \t]*=[ \t]*)\d+([ \t]*(?:#.*)?)$", section
+            rf"(?m)^({re.escape(resource)}[ \t]*=[ \t]*)\d+([ \t]*(?:#.*)?)$",
+            section,
         )
         if current is None:
             transformed = (
                 source[: environment.end()]
-                + f"\nstorage_mb = {storage_mb}"
+                + f"\n{resource} = {value}"
                 + source[environment.end() :]
             )
         else:
             if declaration is None:
-                raise ValueError("parsed storage_mb has no replaceable declaration")
+                raise ValueError(f"parsed {resource} has no replaceable declaration")
             start = environment.end() + declaration.start()
             end = environment.end() + declaration.end()
-            replacement = f"{declaration.group(1)}{storage_mb}{declaration.group(2)}"
+            replacement = f"{declaration.group(1)}{value}{declaration.group(2)}"
             transformed = source[:start] + replacement + source[end:]
     parsed = TaskConfig.model_validate_toml(transformed)
-    if parsed.environment.storage_mb != storage_mb:
-        raise ValueError("transformed task has the wrong storage requirement")
+    if getattr(parsed.environment, resource) != value:
+        raise ValueError(f"transformed task has the wrong {resource} requirement")
     return transformed.encode("utf-8")
+
+
+def task_toml_with_storage(
+    task_toml: bytes, expected_storage_mb: int | None, storage_mb: int
+) -> bytes:
+    return task_toml_with_environment_resource(
+        task_toml, "storage_mb", expected_storage_mb, storage_mb
+    )
+
+
+def task_toml_with_memory(
+    task_toml: bytes, expected_memory_mb: int | None, memory_mb: int
+) -> bytes:
+    return task_toml_with_environment_resource(
+        task_toml, "memory_mb", expected_memory_mb, memory_mb
+    )
 
 
 def source_parquet(args: argparse.Namespace) -> Path:

--- a/data/tasktrove/build_v48_repairs.py
+++ b/data/tasktrove/build_v48_repairs.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Build TaskTrove v4.8 verifier and memory revisions from v4.7."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from harbor_config.models.task.config import TaskConfig
+from huggingface_hub import hf_hub_download
+
+from data.tasktrove.build_storage_repair import (
+    MAX_BATCH_ROWS,
+    MIN_TASKS,
+    REQUIRED_MEMBERS,
+    TASK_SCHEMA,
+    file_sha256,
+    read_task,
+    task_toml_with_memory,
+    write_task,
+)
+
+TASKTROVE_REPO = "open-thoughts/TaskTrove"
+SOURCE_REVISION = "697a123d73f39114471468536c8c65da29ea9edc"
+MEMORY_MB = 4096
+ADVERSARIAL_STATIC_VERIFIER_DEFECTS = frozenset({"5k-adversarial-0174"})
+
+ADVERSARIAL_VERIFIER = r"""#!/bin/bash
+set -uo pipefail
+
+LOG_DIR=/logs/verifier
+REPORT="$LOG_DIR/junit.xml"
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR/reward.txt" "$REPORT"
+cd /app
+export PYTHONPATH="/app:${PYTHONPATH:-}"
+
+if grep -qE '(^|[[:space:]])(from|import)[[:space:]]+django' /tests/test_adversarial.py; then
+    settings_file=$(find /app -type f -name settings.py -not -path '*/.venv/*' -print -quit)
+    if [[ -n "$settings_file" ]]; then
+        settings_module=${settings_file#/app/}
+        settings_module=${settings_module%.py}
+        export DJANGO_SETTINGS_MODULE=${settings_module//\//.}
+    fi
+fi
+
+set +e
+timeout --signal=TERM --kill-after=15s 690s \
+    python3 -m pytest /tests/test_adversarial.py -v --tb=short --junitxml="$REPORT" \
+    -p pytester -p aiohttp.pytest_plugin \
+    > >(tee "$LOG_DIR/pytest_output.txt") 2>&1
+pytest_status=$?
+set -e
+
+if [[ $pytest_status -eq 124 || $pytest_status -eq 137 ]]; then
+    echo "verifier process-group deadline exceeded" >&2
+    exit 124
+fi
+
+case "$pytest_status" in
+    0)
+        if [[ ! -s "$REPORT" ]]; then
+            echo "pytest passed without producing a JUnit report" >&2
+            exit 42
+        fi
+        python3 - "$REPORT" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+executed = [
+    case for case in root.findall(".//testcase") if case.find("skipped") is None
+]
+if not executed:
+    raise SystemExit("zero non-skipped tests executed")
+with open("/logs/verifier/reward.txt", "w", encoding="utf-8") as output:
+    output.write("1\n")
+PY
+        ;;
+    1|2)
+        # Test failures, target exceptions, and target import/collection failures
+        # are consequences of the submitted workspace and are scoreable zeros.
+        echo 0 > "$LOG_DIR/reward.txt"
+        ;;
+    *)
+        # Pytest usage/internal/no-test failures do not establish task quality.
+        exit "$pytest_status"
+        ;;
+esac
+""".encode()
+
+PHP_EXECUTION_PATTERN = "(Tests: [1-9][0-9]*|OK \\([1-9][0-9]* tests?,)"
+PHP_OLD_EXECUTION_GATE = (
+    b"if ! grep -Eq 'Tests: [1-9][0-9]*' /logs/verifier/test-stdout.txt; then"
+)
+PHP_NEW_EXECUTION_GATE = (
+    f"if ! grep -Eq '{PHP_EXECUTION_PATTERN}' /logs/verifier/test-stdout.txt; then"
+).encode()
+
+
+@dataclass(frozen=True)
+class Revision:
+    source: str
+    source_sha256: str
+    output: str
+    memory_mb: int | None = None
+    verifier: str | None = None
+
+
+REVISIONS = (
+    Revision(
+        "DCAgent__exp_rle_adversarial-v5",
+        "da1dc8bbde9d415c39461fdb5558b2d0b6e0927b327381ac1306d580a577f9af",
+        "DCAgent__exp_rle_adversarial-v6",
+        verifier="adversarial",
+    ),
+    Revision(
+        "laion__exp_rpt_stack-cpp-v3",
+        "2f76e1dac738c15553ed51d7dbe59024c3e5885e3a9690ec1a57863eb8ab0ebb",
+        "laion__exp_rpt_stack-cpp-v4",
+        memory_mb=MEMORY_MB,
+    ),
+    Revision(
+        "laion__exp_rpt_stack-php-large-v8",
+        "4469a4eac31ed091d635d6cd0aed4e8c4022dd3a3907a30502b8cc35d25d5219",
+        "laion__exp_rpt_stack-php-large-v9",
+        memory_mb=MEMORY_MB,
+        verifier="php",
+    ),
+    Revision(
+        "laion__exp_rpt_stack-php-v2-v7",
+        "45a30e52e868fb2ae8ff630a01de86d9204be1cb65e0eef6cca299ec3703c57f",
+        "laion__exp_rpt_stack-php-v2-v8",
+        memory_mb=MEMORY_MB,
+    ),
+)
+
+
+def patch_php_verifier(test_sh: bytes) -> bytes:
+    if test_sh.count(PHP_OLD_EXECUTION_GATE) != 1:
+        raise ValueError("PHP verifier execution gate does not match v8")
+    return test_sh.replace(PHP_OLD_EXECUTION_GATE, PHP_NEW_EXECUTION_GATE)
+
+
+def transform_files(files: dict[str, bytes], revision: Revision) -> dict[str, bytes]:
+    transformed = dict(files)
+    if revision.memory_mb is not None:
+        transformed["task.toml"] = task_toml_with_memory(
+            files["task.toml"], None, revision.memory_mb
+        )
+    if revision.verifier == "adversarial":
+        transformed["tests/test.sh"] = ADVERSARIAL_VERIFIER
+    elif revision.verifier == "php":
+        transformed["tests/test.sh"] = patch_php_verifier(files["tests/test.sh"])
+    return transformed
+
+
+def source_path(args: argparse.Namespace, revision: Revision) -> Path:
+    if args.source_root is not None:
+        return args.source_root / revision.source / "tasks.parquet"
+    return Path(
+        hf_hub_download(
+            TASKTROVE_REPO,
+            f"{revision.source}/tasks.parquet",
+            repo_type="dataset",
+            revision=SOURCE_REVISION,
+        )
+    )
+
+
+def should_retain(path: str, revision: Revision) -> bool:
+    return not (
+        revision.verifier == "adversarial"
+        and path in ADVERSARIAL_STATIC_VERIFIER_DEFECTS
+    )
+
+
+def validate_output(path: Path, revision: Revision, expected_rows: int) -> None:
+    parquet = pq.ParquetFile(path)
+    if parquet.schema_arrow != TASK_SCHEMA:
+        raise ValueError(f"unexpected output schema: {parquet.schema_arrow}")
+    if parquet.metadata.num_rows != expected_rows or expected_rows < MIN_TASKS:
+        raise ValueError("output row count is invalid")
+    seen: set[str] = set()
+    for batch in parquet.iter_batches(batch_size=MAX_BATCH_ROWS):
+        for row in batch.to_pylist():
+            task_path = row["path"]
+            if task_path in seen:
+                raise ValueError(f"duplicate task path: {task_path}")
+            seen.add(task_path)
+            files = read_task(row["task_binary"])
+            if not REQUIRED_MEMBERS <= files.keys():
+                raise ValueError(f"incomplete task: {task_path}")
+            config = TaskConfig.model_validate_toml(files["task.toml"].decode())
+            if revision.memory_mb is not None:
+                if config.environment.memory_mb != revision.memory_mb:
+                    raise ValueError(f"wrong memory requirement: {task_path}")
+            if revision.verifier == "adversarial":
+                if files["tests/test.sh"] != ADVERSARIAL_VERIFIER:
+                    raise ValueError(f"wrong adversarial verifier: {task_path}")
+            elif revision.verifier == "php":
+                test_sh = files["tests/test.sh"]
+                if (
+                    PHP_NEW_EXECUTION_GATE not in test_sh
+                    or PHP_OLD_EXECUTION_GATE in test_sh
+                ):
+                    raise ValueError(f"wrong PHP execution gate: {task_path}")
+
+
+def build_revision(args: argparse.Namespace, revision: Revision) -> dict[str, object]:
+    source = source_path(args, revision)
+    if file_sha256(source) != revision.source_sha256:
+        raise ValueError(f"source hash mismatch: {revision.source}")
+    parquet = pq.ParquetFile(source)
+    if parquet.schema_arrow != TASK_SCHEMA:
+        raise ValueError(f"unexpected source schema: {parquet.schema_arrow}")
+    output = args.stage / "datasets" / revision.output / "tasks.parquet"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        raise FileExistsError(output)
+    writer = pq.ParquetWriter(
+        output, TASK_SCHEMA, compression="zstd", use_dictionary=False
+    )
+    rows = 0
+    try:
+        for batch in parquet.iter_batches(batch_size=MAX_BATCH_ROWS):
+            transformed_rows = []
+            for row in batch.to_pylist():
+                if not should_retain(row["path"], revision):
+                    continue
+                files = read_task(row["task_binary"])
+                if not REQUIRED_MEMBERS <= files.keys():
+                    raise ValueError(f"incomplete task: {row['path']}")
+                transformed = transform_files(files, revision)
+                transformed_rows.append(
+                    {"path": row["path"], "task_binary": write_task(transformed)}
+                )
+            if transformed_rows:
+                writer.write_table(
+                    pa.Table.from_pylist(transformed_rows, schema=TASK_SCHEMA)
+                )
+                rows += len(transformed_rows)
+    finally:
+        writer.close()
+    validate_output(output, revision, rows)
+    return {
+        "source": revision.source,
+        "source_sha256": revision.source_sha256,
+        "source_rows": parquet.metadata.num_rows,
+        "output": revision.output,
+        "output_rows": rows,
+        "output_sha256": file_sha256(output),
+        "memory_mb": revision.memory_mb,
+        "verifier": revision.verifier,
+        "removed_paths": sorted(
+            ADVERSARIAL_STATIC_VERIFIER_DEFECTS
+            if revision.verifier == "adversarial"
+            else ()
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", type=Path, required=True)
+    parser.add_argument("--source-root", type=Path)
+    args = parser.parse_args()
+    reports = [build_revision(args, revision) for revision in REVISIONS]
+    manifest = {
+        "source_repo": TASKTROVE_REPO,
+        "source_revision": SOURCE_REVISION,
+        "datasets": reports,
+    }
+    (args.stage / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    print(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/data/tasktrove/publish_v48_release.py
+++ b/data/tasktrove/publish_v48_release.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Publish, verify, tag, and retire standalones for TaskTrove v4.8."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+from huggingface_hub import (
+    CommitOperationAdd,
+    CommitOperationDelete,
+    HfApi,
+    hf_hub_download,
+)
+
+REPO_ID = "open-thoughts/TaskTrove"
+VERSION = "4.8"
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def repo_files(api: HfApi, repo: str, revision: str) -> dict[str, object]:
+    return {
+        item.path: item
+        for item in api.list_repo_tree(
+            repo, repo_type="dataset", revision=revision, recursive=True, expand=True
+        )
+        if hasattr(item, "blob_id")
+    }
+
+
+def identity(item: object) -> tuple[str, int]:
+    lfs = getattr(item, "lfs", None)
+    digest = lfs.sha256 if lfs is not None else str(getattr(item, "blob_id"))
+    return digest, int(getattr(item, "size"))
+
+
+def release_note(manifest: dict[str, object]) -> str:
+    rows = {item["output"]: item for item in manifest["datasets"]}
+    adversarial = rows["DCAgent__exp_rle_adversarial-v6"]
+    return (
+        "> **v4.8 (current)** — verifier and sandbox-memory remediation — "
+        "replaces four sources. `DCAgent/exp_rle_adversarial-v6` records target "
+        "exceptions and target import failures as scoreable zeros and removes the "
+        "one statically invalid verifier task "
+        f"({int(adversarial['source_rows']):,} → {int(adversarial['output_rows']):,}). "
+        "`laion/exp_rpt_stack-php-large-v9` recognizes PHPUnit 10 successful-test "
+        "output instead of treating it as a verifier crash. The C++, PHP-large, "
+        "and PHP-v2 sources now explicitly request 4 GiB RAM, double the previous "
+        "2 GiB default. Every active source retains at least 300 tasks, the release "
+        f"uses {int(manifest['release_unique_images'])} unique images, and versioned "
+        "sources are hosted only inside TaskTrove. Superseded source versions remain "
+        "available through earlier TaskTrove tags.\n>\n"
+        "> - `DCAgent/exp_rle_adversarial-v5` → "
+        "`DCAgent/exp_rle_adversarial-v6`\n"
+        "> - `laion/exp_rpt_stack-cpp-v3` → `laion/exp_rpt_stack-cpp-v4`\n"
+        "> - `laion/exp_rpt_stack-php-large-v8` → "
+        "`laion/exp_rpt_stack-php-large-v9`\n"
+        "> - `laion/exp_rpt_stack-php-v2-v7` → "
+        "`laion/exp_rpt_stack-php-v2-v8`\n>\n"
+    )
+
+
+def updated_readme(source: str, manifest: dict[str, object]) -> str:
+    marker = "> **v4.7 (current)**"
+    if marker not in source:
+        raise ValueError("README does not identify v4.7 as current")
+    return source.replace(marker, release_note(manifest) + "> **v4.7**", 1)
+
+
+def publish(stage: Path) -> str:
+    manifest = json.loads((stage / "manifest.json").read_text())
+    source_revision = str(manifest["source_revision"])
+    api = HfApi(token=os.environ["HF_TOKEN"])
+    if api.repo_info(REPO_ID, repo_type="dataset").sha != source_revision:
+        raise ValueError("TaskTrove changed after the v4.8 build")
+    if any(
+        ref.name == f"v{VERSION}"
+        for ref in api.list_repo_refs(REPO_ID, repo_type="dataset").tags
+    ):
+        raise ValueError(f"v{VERSION} already exists")
+    current = repo_files(api, REPO_ID, source_revision)
+    for item in manifest["datasets"]:
+        source = f"{item['source']}/tasks.parquet"
+        target = f"{item['output']}/tasks.parquet"
+        if source not in current:
+            raise ValueError(f"missing source: {source}")
+        if identity(current[source])[0] != item["source_sha256"]:
+            raise ValueError(f"source hash mismatch: {source}")
+        if target in current:
+            raise ValueError(f"target already exists: {target}")
+
+    readme_source = Path(
+        hf_hub_download(
+            REPO_ID,
+            "README.md",
+            repo_type="dataset",
+            revision=source_revision,
+            token=api.token,
+        )
+    ).read_text()
+    readme = stage / "README-v4.8.md"
+    readme.write_text(updated_readme(readme_source, manifest))
+    operations: list[CommitOperationAdd | CommitOperationDelete] = [
+        CommitOperationAdd("README.md", readme)
+    ]
+    for item in manifest["datasets"]:
+        operations.extend(
+            (
+                CommitOperationDelete(str(item["source"])),
+                CommitOperationAdd(
+                    f"{item['output']}/tasks.parquet", stage / str(item["parquet"])
+                ),
+            )
+        )
+    commit = api.create_commit(
+        REPO_ID,
+        repo_type="dataset",
+        operations=operations,
+        commit_message="TaskTrove v4.8: repair verifiers and memory limits",
+        parent_commit=source_revision,
+        num_threads=1,
+    )
+    return commit.oid
+
+
+def verify_and_retire(stage: Path, commit: str) -> None:
+    manifest = json.loads((stage / "manifest.json").read_text())
+    source_revision = str(manifest["source_revision"])
+    api = HfApi(token=os.environ["HF_TOKEN"])
+    before = repo_files(api, REPO_ID, source_revision)
+    after = repo_files(api, REPO_ID, commit)
+    removed = tuple(f"{item['source']}/" for item in manifest["datasets"])
+    expected = {
+        path for path in before if path != "README.md" and not path.startswith(removed)
+    }
+    expected.add("README.md")
+    expected.update(f"{item['output']}/tasks.parquet" for item in manifest["datasets"])
+    if set(after) != expected:
+        raise ValueError(
+            f"unexpected tree: missing={sorted(expected - set(after))}, "
+            f"extra={sorted(set(after) - expected)}"
+        )
+    for path, item in before.items():
+        if path == "README.md" or path.startswith(removed):
+            continue
+        if identity(after[path]) != identity(item):
+            raise ValueError(f"untouched file changed: {path}")
+    for item in manifest["datasets"]:
+        target = f"{item['output']}/tasks.parquet"
+        if identity(after[target])[0] != item["output_sha256"]:
+            raise ValueError(f"output hash mismatch: {target}")
+    readme = Path(
+        hf_hub_download(
+            REPO_ID, "README.md", repo_type="dataset", revision=commit, token=api.token
+        )
+    ).read_text()
+    if not re.search(r"^> \*\*v4\.8 \(current\)\*\*", readme, re.MULTILINE):
+        raise ValueError("README does not identify v4.8 as current")
+    api.create_tag(REPO_ID, tag="v4.8", repo_type="dataset", revision=commit)
+    repositories = {
+        str(item[field]).replace("__", "/", 1)
+        for item in manifest["datasets"]
+        for field in ("source", "output")
+    }
+    for repo in sorted(repositories):
+        if api.repo_exists(repo, repo_type="dataset"):
+            api.delete_repo(repo, repo_type="dataset")
+        if api.repo_exists(repo, repo_type="dataset"):
+            raise ValueError(f"standalone remains: {repo}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", type=Path, required=True)
+    parser.add_argument("--commit")
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--verify-and-retire", action="store_true")
+    args = parser.parse_args()
+    commit = args.commit
+    if args.publish:
+        commit = publish(args.stage)
+        print(commit)
+    if args.verify_and_retire:
+        if commit is None:
+            raise ValueError("--commit is required")
+        verify_and_retire(args.stage, commit)
+        print(f"verified {commit}, tagged v4.8, and retired standalones")
+
+
+if __name__ == "__main__":
+    main()

--- a/database/unified_db/infra_errors.py
+++ b/database/unified_db/infra_errors.py
@@ -39,6 +39,7 @@ INFRA_ERROR_TYPES = {
     "DaytonaNotFoundError",
     "EnvironmentStartTimeoutError",
     "DaytonaRateLimitError",
+    "ServiceUnavailableError",
     "CancelledError",
     "SandboxBuildFailedError",
     "AgentEnvironmentTimeoutError",

--- a/database/unified_db/infra_errors.py
+++ b/database/unified_db/infra_errors.py
@@ -42,6 +42,7 @@ INFRA_ERROR_TYPES = {
     "ServiceUnavailableError",
     "CancelledError",
     "SandboxBuildFailedError",
+    "AgentKilledBySignalError",
     "AgentEnvironmentTimeoutError",
     "VerificationNotCompletedError",
     "TrialNotScoredError",

--- a/eval/configs/baseline_model_configs_minimal.yaml
+++ b/eval/configs/baseline_model_configs_minimal.yaml
@@ -68,7 +68,6 @@ models:
   "Qwen/Qwen3-Coder-30B-A3B-Instruct":
     tensor_parallel_size: 2
     max_model_len: 32768
-    swap_space: 32
     trust_remote_code: true
     tool_call_parser: qwen3_coder
     extra_args: '--enable-prefix-caching --override-generation-config {"temperature":0.7,"top_p":0.8,"top_k":20,"repetition_penalty":1.05}'

--- a/eval/configs/model_configs.yaml
+++ b/eval/configs/model_configs.yaml
@@ -117,7 +117,6 @@ models:
     trust_remote_code: true
     tool_call_parser: qwen3_coder
     tensor_parallel_size: 2
-    swap_space: 32
     extra_args: --enable-prefix-caching --override-generation-config {"temperature":0.7,"top_p":0.8,"top_k":20,"repetition_penalty":1.05}
   Qwen/Qwen3.5-35B-A3B:
     max_model_len: 32768

--- a/hpc/datagen_yaml/extra/qwen35_tasktrove_v44_external.yaml
+++ b/hpc/datagen_yaml/extra/qwen35_tasktrove_v44_external.yaml
@@ -1,0 +1,13 @@
+engine:
+  type: openai
+  model: vllm/Qwen/Qwen3.5-122B-A10B-FP8@a099dee70ccfcd8d5dda56aaa0b60cb8ecadabc9
+  max_output_tokens: 16384
+  healthcheck_interval: 300
+  openai:
+    api_key_env: EXTERNAL_AGENT_API_KEY
+backend:
+  type: none
+vllm_server: null
+extra_agent_kwargs:
+  api_base: ${oc.env:EXTERNAL_AGENT_API_BASE}
+  api_key: capability-url-no-auth-header

--- a/hpc/datagen_yaml/together_glm52_tasktrove_v44.yaml
+++ b/hpc/datagen_yaml/together_glm52_tasktrove_v44.yaml
@@ -1,0 +1,10 @@
+engine:
+  type: openai
+  model: together_ai/zai-org/GLM-5.2
+  max_output_tokens: 8192
+  healthcheck_interval: 300
+  openai:
+    api_key_env: TOGETHER_API_KEY
+backend:
+  type: none
+vllm_server: null

--- a/hpc/harbor_yaml/eval/tasktrove_v44_glm52_terminus2_ctx32k.yaml
+++ b/hpc/harbor_yaml/eval/tasktrove_v44_glm52_terminus2_ctx32k.yaml
@@ -1,0 +1,58 @@
+n_attempts: 1
+timeout_multiplier: 1.0
+trial_attempt_timeout_sec: 23400
+trial_cleanup_grace_sec: 30
+orchestrator:
+  type: local
+  n_concurrent_trials: 32
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    include_exceptions:
+      - DaytonaRateLimitError
+      - ContextManagementInfrastructureError
+    exclude_exceptions:
+      - AgentTimeoutError
+      - ContextLengthExceededError
+      - TrialTimeoutError
+    wait_multiplier: 2.0
+    min_wait_sec: 1.0
+    max_wait_sec: 90.0
+environment:
+  type: daytona
+  force_build: true
+  delete: true
+  kwargs:
+    auto_snapshot: true
+verifier:
+  override_timeout_sec: 14400
+  max_timeout_sec: 14400
+agents:
+  - name: terminus-2
+    model_name: placeholder/override-at-runtime
+    override_timeout_sec: 7200
+    max_timeout_sec: 7200
+    kwargs:
+      temperature: 0.6
+      record_terminal_session: false
+      enable_episode_logging: false
+      enable_pane_logging: false
+      collect_rollout_details: false
+      collect_engine_metrics: false
+      trajectory_config:
+        raw_content: true
+        linear_history: true
+      model_info:
+        max_input_tokens: 24576
+        max_output_tokens: 8192
+        input_cost_per_token: 0.0
+        output_cost_per_token: 0.0
+      max_tokens: 8192
+      extra_body:
+        skip_special_tokens: false
+        repetition_penalty: 1.1
+      enable_summarize: true
+      proactive_summarization_threshold: 2048
+datasets: []
+tasks: []

--- a/hpc/harbor_yaml/eval/tasktrove_v44_qwen35_opencode_ctx131k.yaml
+++ b/hpc/harbor_yaml/eval/tasktrove_v44_qwen35_opencode_ctx131k.yaml
@@ -1,0 +1,45 @@
+n_attempts: 1
+timeout_multiplier: 1.0
+trial_attempt_timeout_sec: 23400
+trial_cleanup_grace_sec: 30
+orchestrator:
+  type: local
+  n_concurrent_trials: 32
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    include_exceptions:
+      - DaytonaRateLimitError
+      - ContextManagementInfrastructureError
+    exclude_exceptions:
+      - AgentTimeoutError
+      - ContextLengthExceededError
+      - TrialTimeoutError
+    wait_multiplier: 2.0
+    min_wait_sec: 1.0
+    max_wait_sec: 90.0
+environment:
+  type: daytona
+  force_build: true
+  delete: true
+  kwargs:
+    auto_snapshot: true
+verifier:
+  override_timeout_sec: 14400
+  max_timeout_sec: 14400
+agents:
+  - name: opencode
+    model_name: openai/override-at-runtime
+    override_timeout_sec: 7200
+    max_timeout_sec: 7200
+    override_setup_timeout_sec: 600
+    kwargs:
+      model_info:
+        max_input_tokens: 114688
+        max_output_tokens: 16384
+        input_cost_per_token: 0.0
+        output_cost_per_token: 0.0
+      opencode_config: {}
+datasets: []
+tasks: []

--- a/hpc/harbor_yaml/eval/tasktrove_v46_qwen3_coder_terminus2_ctx32k.yaml
+++ b/hpc/harbor_yaml/eval/tasktrove_v46_qwen3_coder_terminus2_ctx32k.yaml
@@ -1,0 +1,55 @@
+n_attempts: 1
+timeout_multiplier: 1.0
+trial_attempt_timeout_sec: 23400
+trial_cleanup_grace_sec: 30
+orchestrator:
+  type: local
+  n_concurrent_trials: 32
+  quiet: false
+  plain_output: true
+  retry:
+    max_retries: 10
+    include_exceptions:
+      - DaytonaRateLimitError
+      - ContextManagementInfrastructureError
+      - VerifierRuntimeError
+    exclude_exceptions:
+      - AgentTimeoutError
+      - ContextLengthExceededError
+      - TrialTimeoutError
+    wait_multiplier: 2.0
+    min_wait_sec: 1.0
+    max_wait_sec: 90.0
+environment:
+  type: daytona
+  force_build: true
+  delete: true
+  kwargs:
+    auto_snapshot: true
+verifier:
+  override_timeout_sec: 14400
+  max_timeout_sec: 14400
+agents:
+  - name: terminus-2
+    model_name: placeholder/override-at-runtime
+    override_timeout_sec: 7200
+    max_timeout_sec: 7200
+    kwargs:
+      record_terminal_session: false
+      enable_episode_logging: false
+      enable_pane_logging: false
+      collect_rollout_details: false
+      collect_engine_metrics: false
+      trajectory_config:
+        raw_content: true
+        linear_history: true
+      model_info:
+        max_input_tokens: 32768
+        max_output_tokens: 16384
+        input_cost_per_token: 0.0
+        output_cost_per_token: 0.0
+      max_tokens: 16384
+      enable_summarize: true
+      proactive_summarization_threshold: 2048
+datasets: []
+tasks: []

--- a/model_config/Qwen/Qwen3-Coder-30B-A3B-Instruct.yaml
+++ b/model_config/Qwen/Qwen3-Coder-30B-A3B-Instruct.yaml
@@ -5,5 +5,4 @@ model: Qwen/Qwen3-Coder-30B-A3B-Instruct
 subsystems:
   eval:
     tensor_parallel_size: 2
-    swap_space: 32
     extra_args: --enable-prefix-caching --override-generation-config {"temperature":0.7,"top_p":0.8,"top_k":20,"repetition_penalty":1.05}

--- a/tests/data/tasktrove/test_build_v48_repairs.py
+++ b/tests/data/tasktrove/test_build_v48_repairs.py
@@ -1,0 +1,50 @@
+import tomllib
+
+from data.tasktrove.build_storage_repair import task_toml_with_memory
+from data.tasktrove.build_v48_repairs import (
+    PHP_NEW_EXECUTION_GATE,
+    PHP_OLD_EXECUTION_GATE,
+    patch_php_verifier,
+)
+from data.tasktrove.publish_v48_release import updated_readme
+
+
+def test_memory_requirement_is_added_to_existing_environment() -> None:
+    source = b'version = "1.0"\n\n[environment]\nstorage_mb = 4096\n'
+    transformed = task_toml_with_memory(source, None, 4096)
+    parsed = tomllib.loads(transformed.decode())
+
+    assert parsed["environment"] == {"memory_mb": 4096, "storage_mb": 4096}
+
+
+def test_memory_requirement_is_added_with_environment_table() -> None:
+    source = b'version = "1.0"\n'
+    transformed = task_toml_with_memory(source, None, 4096)
+    parsed = tomllib.loads(transformed.decode())
+
+    assert parsed["environment"]["memory_mb"] == 4096
+
+
+def test_php_success_output_counts_as_executed_tests() -> None:
+    source = b"header\n" + PHP_OLD_EXECUTION_GATE + b"\nfooter\n"
+    transformed = patch_php_verifier(source)
+
+    assert PHP_OLD_EXECUTION_GATE not in transformed
+    assert PHP_NEW_EXECUTION_GATE in transformed
+
+
+def test_v48_readme_replaces_current_marker() -> None:
+    manifest = {
+        "release_unique_images": 6,
+        "datasets": [
+            {
+                "output": "DCAgent__exp_rle_adversarial-v6",
+                "source_rows": 2731,
+                "output_rows": 2730,
+            }
+        ],
+    }
+    result = updated_readme("> **v4.7 (current)** — previous\n", manifest)
+
+    assert result.startswith("> **v4.8 (current)**")
+    assert "> **v4.7** — previous" in result

--- a/tests/eval/test_service_unavailable_refire.py
+++ b/tests/eval/test_service_unavailable_refire.py
@@ -5,9 +5,10 @@ from database.unified_db.infra_errors import (
 from eval.cloud.launch_eval_iris import DEFAULT_REFIRE_ERROR_TYPES
 
 
-def test_service_unavailable_is_refired() -> None:
-    assert "ServiceUnavailableError" in INFRA_ERROR_TYPES
-    assert "ServiceUnavailableError" in DEFAULT_REFIRE_ERROR_TYPES
+def test_api_and_signal_failures_are_refired() -> None:
+    for error_type in ("AgentKilledBySignalError", "ServiceUnavailableError"):
+        assert error_type in INFRA_ERROR_TYPES
+        assert error_type in DEFAULT_REFIRE_ERROR_TYPES
 
 
 def test_service_unavailable_is_counted_as_infrastructure() -> None:
@@ -15,6 +16,7 @@ def test_service_unavailable_is_counted_as_infrastructure() -> None:
         "evals": {
             "reward": {
                 "exception_stats": {
+                    "AgentKilledBySignalError": ["trial-d"],
                     "ServiceUnavailableError": ["trial-a", "trial-b"],
                     "AgentTimeoutError": ["trial-c"],
                 }
@@ -23,6 +25,6 @@ def test_service_unavailable_is_counted_as_infrastructure() -> None:
     }
 
     assert compute_infra_error_stats(stats) == (
-        2,
-        {"ServiceUnavailableError": 2},
+        3,
+        {"AgentKilledBySignalError": 1, "ServiceUnavailableError": 2},
     )

--- a/tests/eval/test_service_unavailable_refire.py
+++ b/tests/eval/test_service_unavailable_refire.py
@@ -1,0 +1,28 @@
+from database.unified_db.infra_errors import (
+    INFRA_ERROR_TYPES,
+    compute_infra_error_stats,
+)
+from eval.cloud.launch_eval_iris import DEFAULT_REFIRE_ERROR_TYPES
+
+
+def test_service_unavailable_is_refired() -> None:
+    assert "ServiceUnavailableError" in INFRA_ERROR_TYPES
+    assert "ServiceUnavailableError" in DEFAULT_REFIRE_ERROR_TYPES
+
+
+def test_service_unavailable_is_counted_as_infrastructure() -> None:
+    stats = {
+        "evals": {
+            "reward": {
+                "exception_stats": {
+                    "ServiceUnavailableError": ["trial-a", "trial-b"],
+                    "AgentTimeoutError": ["trial-c"],
+                }
+            }
+        }
+    }
+
+    assert compute_infra_error_stats(stats) == (
+        2,
+        {"ServiceUnavailableError": 2},
+    )


### PR DESCRIPTION
Repair the adversarial verifier so malformed reward output fails closed, and
raise the C++, PHP-large, and PHP-v2 task memory limits to 4096 MB. Add the
reproducible TaskTrove v4.8 assembly and publication paths used for the repaired
sources.

Track the GLM 5.2, Qwen3.5-122B, and Qwen3-Coder campaign configurations needed
to reproduce the v4.8 evaluations. Remove the unsupported Qwen3-Coder vLLM swap
argument. Warm resumes now delete and refire trials terminated by Together
service unavailability or agent SIGKILL instead of preserving them as completed
infrastructure failures.
