### PR TITLE
[eval] Retry Daytona leaf infrastructure failures

### DIFF
--- a/database/unified_db/infra_errors.py
+++ b/database/unified_db/infra_errors.py
@@ -36,6 +36,7 @@ INFRA_ERROR_TYPES = {
     "DaytonaError",
     "DaytonaAuthenticationError",
     "DaytonaAuthorizationError",
+    "DaytonaConflictError",
     "DaytonaNotFoundError",
     "DaytonaSandboxStopError",
     "EnvironmentStartTimeoutError",

--- a/database/unified_db/infra_errors.py
+++ b/database/unified_db/infra_errors.py
@@ -37,6 +37,7 @@ INFRA_ERROR_TYPES = {
     "DaytonaAuthenticationError",
     "DaytonaAuthorizationError",
     "DaytonaNotFoundError",
+    "DaytonaSandboxStopError",
     "EnvironmentStartTimeoutError",
     "DaytonaRateLimitError",
     "ServiceUnavailableError",

--- a/tests/eval/test_service_unavailable_refire.py
+++ b/tests/eval/test_service_unavailable_refire.py
@@ -5,18 +5,23 @@ from database.unified_db.infra_errors import (
 from eval.cloud.launch_eval_iris import DEFAULT_REFIRE_ERROR_TYPES
 
 
-def test_api_and_signal_failures_are_refired() -> None:
-    for error_type in ("AgentKilledBySignalError", "ServiceUnavailableError"):
+def test_infrastructure_failures_are_refired() -> None:
+    for error_type in (
+        "AgentKilledBySignalError",
+        "DaytonaSandboxStopError",
+        "ServiceUnavailableError",
+    ):
         assert error_type in INFRA_ERROR_TYPES
         assert error_type in DEFAULT_REFIRE_ERROR_TYPES
 
 
-def test_service_unavailable_is_counted_as_infrastructure() -> None:
+def test_infrastructure_failures_are_counted_as_infrastructure() -> None:
     stats = {
         "evals": {
             "reward": {
                 "exception_stats": {
                     "AgentKilledBySignalError": ["trial-d"],
+                    "DaytonaSandboxStopError": ["trial-e", "trial-f"],
                     "ServiceUnavailableError": ["trial-a", "trial-b"],
                     "AgentTimeoutError": ["trial-c"],
                 }
@@ -25,6 +30,10 @@ def test_service_unavailable_is_counted_as_infrastructure() -> None:
     }
 
     assert compute_infra_error_stats(stats) == (
-        3,
-        {"AgentKilledBySignalError": 1, "ServiceUnavailableError": 2},
+        5,
+        {
+            "AgentKilledBySignalError": 1,
+            "DaytonaSandboxStopError": 2,
+            "ServiceUnavailableError": 2,
+        },
     )

--- a/tests/eval/test_service_unavailable_refire.py
+++ b/tests/eval/test_service_unavailable_refire.py
@@ -8,6 +8,7 @@ from eval.cloud.launch_eval_iris import DEFAULT_REFIRE_ERROR_TYPES
 def test_infrastructure_failures_are_refired() -> None:
     for error_type in (
         "AgentKilledBySignalError",
+        "DaytonaConflictError",
         "DaytonaSandboxStopError",
         "ServiceUnavailableError",
     ):
@@ -21,6 +22,7 @@ def test_infrastructure_failures_are_counted_as_infrastructure() -> None:
             "reward": {
                 "exception_stats": {
                     "AgentKilledBySignalError": ["trial-d"],
+                    "DaytonaConflictError": ["trial-g"],
                     "DaytonaSandboxStopError": ["trial-e", "trial-f"],
                     "ServiceUnavailableError": ["trial-a", "trial-b"],
                     "AgentTimeoutError": ["trial-c"],
@@ -30,9 +32,10 @@ def test_infrastructure_failures_are_counted_as_infrastructure() -> None:
     }
 
     assert compute_infra_error_stats(stats) == (
-        5,
+        6,
         {
             "AgentKilledBySignalError": 1,
+            "DaytonaConflictError": 1,
             "DaytonaSandboxStopError": 2,
             "ServiceUnavailableError": 2,
         },


### PR DESCRIPTION
Treat `DaytonaSandboxStopError` and `DaytonaConflictError` as retryable infrastructure. Harbor resume pruning compares exception-type strings exactly, so the existing `DaytonaError` entry did not match these leaf errors. In TaskTrove v4.8, 11 sandbox-stop trials survived repeated refire cycles and one session-creation conflict remained terminal.

The focused regressions fail without each classification and pass with them. Infrastructure counts and default Iris refire filters now use the same leaf types.
